### PR TITLE
fix: add quarto package to pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, any::quarto, local::.
           needs: website
 
       - name: Build site


### PR DESCRIPTION
## Summary
Fixes pkgdown build failure on main branch.

## Problem
The pkgdown workflow was failing with:
```
Error in loadNamespace(): there is no package called 'quarto'
```

This occurred when pkgdown tried to process the Quarto vignettes (`.qmd` files):
- `vignettes/ratio-estimators-guide.qmd`
- `vignettes/ratio-estimators-guide_full_with_hybrid.qmd`

## Solution
Added `any::quarto` to the `extra-packages` list in the pkgdown workflow's `setup-r-dependencies` step.

## Testing
After merge, the pkgdown workflow should successfully:
1. Install the quarto R package
2. Process .qmd vignettes
3. Build and deploy the package website to GitHub Pages

## Related
This fix addresses the workflow failure introduced after merging PR #8.