### PR TITLE
fix: standardize NEWS.md heading levels for pkgdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-tidycreel 0.0.0.9000 (development)
+# tidycreel 0.0.0.9000 (development)
 
 - Survey-first refactor: Estimation relies on day-PSU designs from
   `as_day_svydesign()` and interview-level `svydesign`; legacy constructors
@@ -19,7 +19,7 @@ tidycreel 0.0.0.9000 (development)
 - Docs/DevEx: Updated README, pkgdown navbar, and AGENTS.md conventions;
   modernized CI workflows (R CMD check, lintr, pkgdown).
 
-2025-08-22
+# tidycreel 0.0.0.9000 (2025-08-22)
 - Added survey-first CPUE and Catch estimators: `est_cpue()` (ratio-of-means
   default; mean-of-ratios option) and `est_catch()` (totals via
   svytotal/svyby).


### PR DESCRIPTION
## Summary
Fixes pkgdown NEWS.md parsing error.

## Problem
The pkgdown workflow was failing with:
```
Error in build_news_single():
! In NEWS.md, inconsistent use of section headings.
ℹ Top-level headings must be either all <h1> or all <h2>.
```

## Root Cause
NEWS.md had inconsistent heading formats:
- Line 1: `tidycreel 0.0.0.9000 (development)` - no # marker
- Line 22: `2025-08-22` - no # marker

pkgdown requires all version headings to use consistent markdown heading levels.

## Solution
- Added `#` prefix to both version headings
- Formatted date heading as: `# tidycreel 0.0.0.9000 (2025-08-22)`

## Testing
After merge, the pkgdown workflow should successfully:
1. Parse NEWS.md without errors
2. Build the changelog page
3. Deploy to GitHub Pages

## Related
- Follow-up to PR #10 which fixed the quarto dependency issue