### PR TITLE
fix: disable Roo TODO Sync workflow

### DIFF
--- a/.github/workflows/roo-todo-sync.yml
+++ b/.github/workflows/roo-todo-sync.yml
@@ -1,10 +1,12 @@
 # .github/workflows/roo-todo-sync.yml
+# DISABLED: This workflow requires .roo/scripts/update_todo_from_status.py which is not present
+# Re-enable by uncommenting the push trigger below
 name: Roo TODO Sync
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
+  # push:
+  #   branches: [ main ]
 
 jobs:
   sync-todo:


### PR DESCRIPTION
## Summary
Prevents Roo TODO Sync workflow failures by disabling automatic runs.

## Problem
The Roo TODO Sync workflow was failing on every push to main with:
```
python3: can't open file '.roo/scripts/update_todo_from_status.py': [Errno 2] No such file or directory
```

## Root Cause
This workflow appears to be from a template/framework that requires:
- `.roo/scripts/update_todo_from_status.py` (Python script)
- `.roo/status/` directory structure
- Additional Roo framework files

These files are not present in the repository and the workflow has no practical use without them.

## Solution
- Disabled automatic push trigger by commenting out `push:` event
- Kept `workflow_dispatch` trigger for manual runs if needed in the future
- Added clear comments explaining why it's disabled and how to re-enable

## Impact
- ✅ No more failed workflow runs on every push to main
- ✅ Clean CI/CD status (only failures will be real issues)
- ✅ Can still be manually triggered if Roo framework is implemented later

## Future Work
If Roo TODO tracking is desired, would need to:
1. Create `.roo/scripts/update_todo_from_status.py`
2. Set up `.roo/status/` directory structure  
3. Uncomment the push trigger in the workflow