### PR TITLE
fix: correct markdown syntax for README badges

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,15 +21,9 @@ knitr::opts_chunk$set(
 </p>
 
 <!-- badges: start -->
-[![Lifecycle: experimental]
-(https://img.shields.io/badge/lifecycle-experimental-orange.svg)]
-(https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R CMD Check]
-(https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml/badge.svg)]
-(https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml)
-[![lintr]
-(https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml/badge.svg)]
-(https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![R CMD Check](https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml)
+[![lintr](https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml)
 <!-- badges: end -->
 
 The goal of tidycreel is to provide a survey-first, tidy interface for creel

--- a/README.md
+++ b/README.md
@@ -10,15 +10,11 @@
 
 <!-- badges: start -->
 
-\[\![Lifecycle: experimental\]
-(<https://img.shields.io/badge/lifecycle-experimental-orange.svg>)\]
-(<https://lifecycle.r-lib.org/articles/stages.html#experimental>) \[\![R
-CMD Check\]
-(<https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml/badge.svg>)\]
-(<https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml>)
-\[\![lintr\]
-(<https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml/badge.svg>)\]
-(<https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml>)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![R CMD
+Check](https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/r-check.yml)
+[![lintr](https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/lintr.yaml)
 <!-- badges: end -->
 
 The goal of tidycreel is to provide a survey-first, tidy interface for


### PR DESCRIPTION
## Summary
Fixes broken badge rendering in README on GitHub.

## Problem
The badges and hex sticker were displaying as plain text instead of rendering properly:
```
tidycreel hex sticker

[![Lifecycle: experimental] (https://img.shields.io/badge/lifecycle-experimental-orange.svg)] (https://lifecycle.r-lib.org/articles/stages.html#experimental)
```

## Root Cause
The markdown syntax in README.Rmd had line breaks between `]` and `(`, which breaks the link/image syntax:
```markdown
[![Lifecycle: experimental]
(https://img.shields.io/badge/lifecycle-experimental-orange.svg)]
(https://lifecycle.r-lib.org/articles/stages.html#experimental)
```

Markdown requires no space or line break between `](` for proper rendering.

## Solution
- Removed line breaks from badge markdown in README.Rmd
- Rebuilt README.md using `devtools::build_readme()`
- Changed from multi-line format to single-line format:
```markdown
[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
```

## Result
After merge, the README on GitHub will properly display:
- ✅ Hex sticker image
- ✅ Lifecycle badge (clickable)
- ✅ R CMD Check badge (clickable)
- ✅ lintr badge (clickable)

## Files Changed
- `README.Rmd` - Fixed badge markdown syntax (source file)
- `README.md` - Regenerated from README.Rmd (output file)