### PR TITLE
fix: use full GitHub URL for hex sticker image

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 # tidycreel
 
 <p align="center">
-  <img src="man/figures/tidycreel-hex.svg" alt="tidycreel hex sticker" width="250"/>
+  <img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.svg" alt="tidycreel hex sticker" width="250"/>
 </p>
 
 <!-- badges: start -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
 
-<img src="man/figures/tidycreel-hex.svg" alt="tidycreel hex sticker" width="250"/>
+<img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.svg" alt="tidycreel hex sticker" width="250"/>
 </p>
 
 <!-- badges: start -->


### PR DESCRIPTION
## Summary
Fixes hex sticker image not displaying on GitHub README.

## Problem
The hex sticker image is not showing on the GitHub repository README page, even though the file exists and the badges display correctly.

## Root Cause
The relative path `man/figures/tidycreel-hex.svg` doesn't reliably render on GitHub's README display. GitHub needs the full raw content URL for SVG files to display properly.

## Solution
Changed the image source from relative path to full GitHub raw URL:
```html
<!-- Before -->
<img src="man/figures/tidycreel-hex.svg" alt="tidycreel hex sticker" width="250"/>

<!-- After -->
<img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.svg" alt="tidycreel hex sticker" width="250"/>
```

## Testing
The SVG file is confirmed valid and accessible at:
https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.svg

After merge, the hex sticker should display properly at the top of the README.

## Files Changed
- `README.Rmd` - Updated image src to full GitHub URL
- `README.md` - Regenerated from README.Rmd