### PR TITLE
fix: correct XML parsing error in hex sticker SVG

### DIFF
--- a/man/figures/tidycreel-hex.svg
+++ b/man/figures/tidycreel-hex.svg
@@ -3,7 +3,7 @@
     <style>
       :root{
         --bg:#0F7C90;        /* teal fill inside hex */
-        --border:#2D1B46;    /* dark border & strokes */
+        --border:#2D1B46;    /* dark border and strokes */
         --cream:#F4F1E8;     /* cream for text */
         --basket:#F4A259;    /* basket base */
         --basket-shade:#D97A2B; /* basket shading stripes */


### PR DESCRIPTION
## Summary
Fixes XML parsing error preventing hex sticker SVG from rendering.

## Problem
When clicking on the hex sticker image, GitHub displays:
```
This page contains the following errors:
error on line 6 at column 46: xmlParseEntityRef: no name
```

The SVG file cannot be properly rendered or displayed.

## Root Cause
Line 6 of the SVG file contained an unescaped ampersand (`&`) in a CSS comment:
```css
--border:#2D1B46;    /* dark border & strokes */
```

In XML/SVG, the `&` character must be escaped as `&amp;` because it's a special character. Raw `&` characters cause XML parsing errors.

## Solution
Changed the comment to avoid the ampersand:
```css
/* Before */
--border:#2D1B46;    /* dark border & strokes */

/* After */
--border:#2D1B46;    /* dark border and strokes */
```

## Testing
After this fix, the SVG should:
- ✅ Render correctly in browsers
- ✅ Display properly on GitHub
- ✅ Show no XML parsing errors when accessed directly

## Files Changed
- `man/figures/tidycreel-hex.svg` - Fixed unescaped ampersand in CSS comment

## Related
- Follow-up to PR #14 which added the full GitHub URL for the hex sticker