### PR TITLE
docs: update README with badges and current v0.4.0 feature coverage

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -5,28 +5,111 @@ output: github_document
 # tidycreel
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.png" alt="tidycreel hex sticker" width="250"/>
+  <img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.png" alt="tidycreel hex sticker" width="200"/>
 </p>
 
-Tidy Interface for Creel Survey Design and Analysis
+<p align="center">
+[![R-CMD-check](https://github.com/chrischizinski/tidycreel/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/R-CMD-check.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+</p>
+
+**Tidy Interface for Creel Survey Design and Analysis**
+
+tidycreel provides a pipe-friendly interface for creel survey design, data management, estimation, and reporting. Built on the [`survey`](https://cran.r-project.org/package=survey) package for robust design-based inference, it lets fisheries biologists work in domain vocabulary — dates, strata, counts, effort — without managing survey design internals directly.
 
 ## Installation
 
-You can install the development version of tidycreel from GitHub:
+Install the development version from GitHub:
 
 ```r
-# install.packages("devtools")
+# install.packages("pak")
+pak::pak("chrischizinski/tidycreel")
+
+# or with devtools
 devtools::install_github("chrischizinski/tidycreel")
 ```
 
-## Overview
+## Quick Start
 
-tidycreel provides a tidy, pipe-friendly interface for creel survey design, data management, estimation, and reporting. Built on the 'survey' package for robust design-based inference.
+### Instantaneous Count Survey
 
-## Usage
+```r
+library(tidycreel)
 
-Documentation and examples coming soon as features are implemented.
+# 1. Define survey structure with tidy selectors
+design <- creel_design(example_calendar, date = date, strata = day_type)
+
+# 2. Attach count observations
+design <- add_counts(design, example_counts)
+
+# 3. Estimate effort with design-based variance
+estimate_effort(design)
+```
+
+### Bus-Route Survey
+
+```r
+# Probability-proportional-to-size site selection
+design <- creel_design(
+  example_calendar,
+  date = date,
+  strata = day_type,
+  survey_type = "bus_route",
+  sampling_frame = my_site_frame,
+  site = site_id
+)
+
+design <- add_interviews(design, interview_data,
+  catch = catch_total,
+  effort = hours_fished,
+  harvest = catch_kept
+)
+
+estimate_cpue(design)
+```
+
+## Features
+
+### Survey Design
+
+- **`creel_design()`** — single entry point with tidy selectors; supports instantaneous count and bus-route survey types
+- **`add_counts()`** — attach instantaneous count observations with data validation against the design
+- **`add_interviews()`** — attach angler interview data with tidy selectors for catch, effort, harvest, and trip metadata
+
+### Estimation
+
+- **`estimate_effort()`** — total and grouped effort with Taylor linearization, bootstrap, or jackknife variance
+- **`estimate_cpue()`** — CPUE via ratio-of-means (default) or mean-of-ratios (for incomplete trips)
+- **`estimate_harvest()`** — harvest rate estimation from interview data
+- **`estimate_total_catch()`** / **`estimate_total_harvest()`** — expansion to totals with delta method variance propagation
+
+### Bus-Route Surveys
+
+- Horvitz-Thompson estimators following Malvestuto et al. (1978) and Jones & Pollock (2012, Ch. 19)
+- Enumeration expansion that scales interviewed catch/effort to all anglers at each site
+- Helpers: `get_enumeration_counts()`, `get_inclusion_probs()`, `get_sampling_frame()`, `get_site_contributions()`
+
+### Incomplete Trips & Validation
+
+- **`summarize_trips()`** — summarize trip status, duration, and completeness across interviews
+- **`validate_incomplete_trips()`** — TOST equivalence testing to validate incomplete vs. complete trip comparability
+- Sample size warnings when < 10% of interviews are complete trips, following Colorado C-SAP best practices
+
+### Survey Package Integration
+
+- **`as_survey_design()`** — extract the underlying `survey` design object for advanced use
+
+## Vignettes
+
+| Vignette | Description |
+|---|---|
+| [Getting Started](https://chrischizinski.github.io/tidycreel/articles/tidycreel.html) | Core workflow: design → counts → effort estimation |
+| [Bus-Route Surveys](https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html) | PPS site selection, enumeration expansion, HT estimators |
+| [Bus-Route Equations](https://chrischizinski.github.io/tidycreel/articles/bus-route-equations.html) | Statistical derivations and formulas |
+| [Interview Estimation](https://chrischizinski.github.io/tidycreel/articles/interview-estimation.html) | CPUE, catch, and harvest from interview data |
+| [Incomplete Trips](https://chrischizinski.github.io/tidycreel/articles/incomplete-trips.html) | When and how to use mean-of-ratios; TOST validation |
 
 ## License
 
-MIT License - see LICENSE.md for details.
+MIT License — see [LICENSE.md](LICENSE.md) for details.

--- a/README.md
+++ b/README.md
@@ -5,56 +5,111 @@ output: github_document
 # tidycreel
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.png" alt="tidycreel hex sticker" width="250"/>
+  <img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/tidycreel-hex.png" alt="tidycreel hex sticker" width="200"/>
 </p>
 
-Tidy Interface for Creel Survey Design and Analysis
+<p align="center">
+[![R-CMD-check](https://github.com/chrischizinski/tidycreel/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/R-CMD-check.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+</p>
+
+**Tidy Interface for Creel Survey Design and Analysis**
+
+tidycreel provides a pipe-friendly interface for creel survey design, data management, estimation, and reporting. Built on the [`survey`](https://cran.r-project.org/package=survey) package for robust design-based inference, it lets fisheries biologists work in domain vocabulary — dates, strata, counts, effort — without managing survey design internals directly.
 
 ## Installation
 
-You can install the development version of tidycreel from GitHub:
+Install the development version from GitHub:
 
-```r
-# install.packages("devtools")
+``` r
+# install.packages("pak")
+pak::pak("chrischizinski/tidycreel")
+
+# or with devtools
 devtools::install_github("chrischizinski/tidycreel")
 ```
 
-## Overview
+## Quick Start
 
-tidycreel provides a tidy, pipe-friendly interface for creel survey design, data management, estimation, and reporting. Built on the 'survey' package for robust design-based inference.
+### Instantaneous Count Survey
+
+``` r
+library(tidycreel)
+
+# 1. Define survey structure with tidy selectors
+design <- creel_design(example_calendar, date = date, strata = day_type)
+
+# 2. Attach count observations
+design <- add_counts(design, example_counts)
+
+# 3. Estimate effort with design-based variance
+estimate_effort(design)
+```
+
+### Bus-Route Survey
+
+``` r
+# Probability-proportional-to-size site selection
+design <- creel_design(
+  example_calendar,
+  date = date,
+  strata = day_type,
+  survey_type = "bus_route",
+  sampling_frame = my_site_frame,
+  site = site_id
+)
+
+design <- add_interviews(design, interview_data,
+  catch = catch_total,
+  effort = hours_fished,
+  harvest = catch_kept
+)
+
+estimate_cpue(design)
+```
 
 ## Features
 
-### v0.3.0 (Current Development)
+### Survey Design
 
-- **Incomplete Trip Support**: Mean-of-ratios estimator for incomplete trip CPUE
-  - Trip status tracking (complete vs. incomplete trips)
-  - Trip duration calculation (including overnight trips)
-  - Trip truncation (threshold-based filtering for short trips)
-  - Statistical validation with TOST equivalence testing (`validate_incomplete_trips()`)
-  - Diagnostic comparison mode (`use_trips = "diagnostic"`)
-- **Default to Complete Trips**: Following Colorado C-SAP best practices
-- **Sample Size Warnings**: Alerts when <10% of interviews are complete trips
-- **Comprehensive Documentation**: Vignettes covering when and how to use incomplete trip estimation
+- **`creel_design()`** — single entry point with tidy selectors; supports instantaneous count and bus-route survey types
+- **`add_counts()`** — attach instantaneous count observations with data validation against the design
+- **`add_interviews()`** — attach angler interview data with tidy selectors for catch, effort, harvest, and trip metadata
 
-### v0.2.0
+### Estimation
 
-- Interview-based catch and harvest estimation
-- Ratio-of-means CPUE/harvest estimation
-- Total catch/harvest with delta method variance
-- Complete interview data workflow
+- **`estimate_effort()`** — total and grouped effort with Taylor linearization, bootstrap, or jackknife variance
+- **`estimate_cpue()`** — CPUE via ratio-of-means (default) or mean-of-ratios (for incomplete trips)
+- **`estimate_harvest()`** — harvest rate estimation from interview data
+- **`estimate_total_catch()`** / **`estimate_total_harvest()`** — expansion to totals with delta method variance propagation
 
-### v0.1.0
+### Bus-Route Surveys
 
-- Survey design constructor with tidy selectors
-- Instantaneous count data integration
-- Effort estimation with grouped analysis
-- Multiple variance methods (Taylor, bootstrap, jackknife)
+- Horvitz-Thompson estimators following Malvestuto et al. (1978) and Jones & Pollock (2012, Ch. 19)
+- Enumeration expansion that scales interviewed catch/effort to all anglers at each site
+- Helpers: `get_enumeration_counts()`, `get_inclusion_probs()`, `get_sampling_frame()`, `get_site_contributions()`
 
-## Usage
+### Incomplete Trips & Validation
 
-Documentation and examples coming soon as features are implemented.
+- **`summarize_trips()`** — summarize trip status, duration, and completeness across interviews
+- **`validate_incomplete_trips()`** — TOST equivalence testing to validate incomplete vs. complete trip comparability
+- Sample size warnings when \< 10% of interviews are complete trips, following Colorado C-SAP best practices
+
+### Survey Package Integration
+
+- **`as_survey_design()`** — extract the underlying `survey` design object for advanced use
+
+## Vignettes
+
+| Vignette | Description |
+|---|---|
+| [Getting Started](https://chrischizinski.github.io/tidycreel/articles/tidycreel.html) | Core workflow: design → counts → effort estimation |
+| [Bus-Route Surveys](https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html) | PPS site selection, enumeration expansion, HT estimators |
+| [Bus-Route Equations](https://chrischizinski.github.io/tidycreel/articles/bus-route-equations.html) | Statistical derivations and formulas |
+| [Interview Estimation](https://chrischizinski.github.io/tidycreel/articles/interview-estimation.html) | CPUE, catch, and harvest from interview data |
+| [Incomplete Trips](https://chrischizinski.github.io/tidycreel/articles/incomplete-trips.html) | When and how to use mean-of-ratios; TOST validation |
 
 ## License
 
-MIT License - see LICENSE.md for details.
+MIT License — see [LICENSE.md](LICENSE.md) for details.


### PR DESCRIPTION
## Summary

- Add R-CMD-check, MIT license, and lifecycle:experimental badges below the hex sticker
- Replace version-by-version feature list (stale at v0.3.0) with capability-organized sections reflecting the current v0.4.0 state
- Add Quick Start code examples for both instantaneous count and bus-route survey workflows
- Document bus-route survey support, which was entirely absent from the previous README
- Add a vignettes table with links to all five articles
- Replace "Documentation and examples coming soon" placeholder text with real usage examples

## Test plan

- [ ] Verify badges render correctly on the GitHub repo homepage once merged
- [ ] Confirm vignette links resolve (pkgdown site must be deployed)
- [ ] Confirm R-CMD-check badge shows current CI status