### PR TITLE
fix!: flip estimate_harvest_rate/release_rate default use_trips to "complete" — v2.3.0 (closes #69)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycreel
 Title: Tidy Interface for Creel Survey Design and Analysis
-Version: 2.2.0
+Version: 2.3.0
 Authors@R:
     person(given = "Christopher", family = "Chizinski", role = c("aut", "cre"),
            email = "cchizinski2@unl.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,27 @@
+# tidycreel 2.3.0 "Northern Pike" (2026-06-22)
+
+## Breaking changes
+
+* `estimate_harvest_rate()` and `estimate_release_rate()` now default to
+  `use_trips = "complete"` (previously `use_trips = "all"`). For standard
+  (non-bus-route) designs that supply `trip_status`, HPUE and RPUE are now
+  estimated from completed-trip interviews only. This is the statistically
+  preferred default: incomplete-trip rates underestimate harvest and release
+  when anglers keep or release additional fish after being interviewed (Hansen &
+  Van Kirk 2010). The previous all-interview behavior is no longer the default
+  but remains fully available.
+
+  **To restore the previous behavior**, pass `use_trips = "all"` explicitly:
+
+  ```r
+  estimate_harvest_rate(design, use_trips = "all")
+  estimate_release_rate(design, use_trips = "all")
+  ```
+
+  Designs without a `trip_status` column are unaffected (the argument has no
+  effect). Bus-route designs already defaulted to `"complete"` and are
+  unchanged. Closes #69.
+
 # tidycreel 2.2.0 "Goldeye" (2026-06-17)
 
 ## New features

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -1412,12 +1412,16 @@ estimate_catch_rate <- function(design,
 #' @param verbose Logical. If TRUE, prints an informational message identifying
 #'   which estimator path was used. Default FALSE.
 #' @param use_trips Character string specifying which interviews to include.
-#'   For standard (non-bus-route) designs: \code{"all"} (default) uses all
-#'   interviews including incomplete trips; \code{"complete"} restricts to
-#'   completed trips only. For bus-route designs: \code{"complete"} (default),
-#'   \code{"incomplete"}, or \code{"diagnostic"}. When \code{trip_status} was
-#'   not provided to \code{\link{add_interviews}}, this argument has no effect
-#'   for standard designs.
+#'   For standard (non-bus-route) designs: \code{"complete"} (default) restricts
+#'   to completed trips only; \code{"all"} uses all interviews including
+#'   incomplete trips. \code{"complete"} is the statistically preferred default
+#'   because incomplete-trip HPUE underestimates harvest when anglers keep
+#'   additional fish after the interview (Hansen & Van Kirk 2010). Fish already
+#'   in the livewell are directly observable, so \code{"all"} remains available
+#'   for analyses that prefer the larger interview set. For bus-route designs:
+#'   \code{"complete"} (default), \code{"incomplete"}, or \code{"diagnostic"}.
+#'   When \code{trip_status} was not provided to \code{\link{add_interviews}},
+#'   this argument has no effect for standard designs.
 #' @param missing_sections Character string controlling behavior when a
 #'   registered section has no interview observations. \code{"warn"} (default)
 #'   emits a \code{cli_warn()} and inserts an NA row with
@@ -1428,13 +1432,13 @@ estimate_catch_rate <- function(design,
 #'   produced. Harvest rates (fish per angler-hour) are not additive across
 #'   sections. Lake-wide harvest rate requires a separate unsectioned call.
 #'
-#' @note Unlike \code{\link{estimate_catch_rate}}, this function defaults to
-#'   using \strong{all} interviews (complete and incomplete) for HPUE estimation.
-#'   Fish already in the livewell at interview time are directly observable and
-#'   represent confirmed harvest. However, incomplete-trip HPUE may underestimate
-#'   when anglers continue fishing and keep additional fish after being interviewed
-#'   (Hansen & Van Kirk 2010). Use \code{use_trips = "complete"} for a stricter
-#'   analysis restricted to completed-trip interviews.
+#' @note This function defaults to using \strong{completed-trip} interviews only
+#'   for HPUE estimation (\code{use_trips = "complete"}). Incomplete-trip HPUE
+#'   underestimates harvest when anglers continue fishing and keep additional
+#'   fish after being interviewed (Hansen & Van Kirk 2010), so restricting to
+#'   completed trips is the statistically preferred default. Fish already in the
+#'   livewell at interview time are directly observable, so \code{use_trips =
+#'   "all"} remains available to include incomplete-trip interviews.
 #'
 #' @return A creel_estimates S3 object (list) with components: estimates
 #'   (tibble with estimate, se, ci_lower, ci_upper, n columns, plus grouping
@@ -1619,13 +1623,13 @@ estimate_harvest_rate <- function(
 
   # Handle use_trips for standard (non-bus-route, non-sectioned) path
   use_trips_is_default <- is.null(use_trips)
-  if (is.null(use_trips)) use_trips <- "all"
+  if (is.null(use_trips)) use_trips <- "complete"
   valid_use_trips_std <- c("all", "complete")
   if (!use_trips %in% valid_use_trips_std) {
     cli::cli_abort(c(
       "Invalid use_trips value: {.val {use_trips}}",
       "x" = "Must be one of: {.val {valid_use_trips_std}}",
-      "i" = "Use {.val all} (default) for all interviews or {.val complete} for completed trips only."
+      "i" = "Use {.val complete} (default) for completed trips only or {.val all} for all interviews."
     ))
   }
 
@@ -1645,24 +1649,24 @@ estimate_harvest_rate <- function(
     n_total <- n_complete + n_incomplete
 
     if (use_trips == "all") {
-      default_tag <- if (use_trips_is_default) " [default]" else "" # nolint: object_usage_linter
       cli::cli_inform(c(
         "i" = "Using all interviews for HPUE estimation",
-        " " = "(n={n_total}: {n_complete} complete, {n_incomplete} incomplete){default_tag}",
-        " " = "Use {.code use_trips = 'complete'} to restrict to completed trips."
+        " " = "(n={n_total}: {n_complete} complete, {n_incomplete} incomplete)",
+        " " = "Use {.code use_trips = 'complete'} (default) to restrict to completed trips."
       ))
     } else {
       if (n_complete == 0L) {
         cli::cli_abort(c(
           "No complete trips available for HPUE estimation",
           "x" = "{.arg use_trips} = 'complete' but dataset has 0 complete trips",
-          "i" = "Use {.code use_trips = 'all'} (default) to include all interviews"
+          "i" = "Use {.code use_trips = 'all'} to include all interviews"
         ))
       }
+      default_tag <- if (use_trips_is_default) " [default]" else "" # nolint: object_usage_linter
       pct_complete <- round(100 * n_complete / n_total, 1) # nolint: object_usage_linter
       cli::cli_inform(c(
         "i" = "Filtering to complete trips for HPUE estimation",
-        " " = "(n={n_complete}, {pct_complete}% of {n_total} interviews)"
+        " " = "(n={n_complete}, {pct_complete}% of {n_total} interviews){default_tag}"
       ))
       complete_interviews <- design$interviews[design$interviews[[trip_status_col]] == "complete", ]
       design <- rebuild_interview_survey(design, complete_interviews) # nolint: object_usage_linter
@@ -1712,9 +1716,13 @@ estimate_harvest_rate <- function(
 #'   \code{"jackknife"}.
 #' @param conf_level Numeric confidence level (default: 0.95).
 #' @param use_trips Character string specifying which interviews to include.
-#'   \code{"all"} (default) uses all interviews including incomplete trips;
-#'   \code{"complete"} restricts to completed trips only. When \code{trip_status}
-#'   was not provided to \code{\link{add_interviews}}, this argument has no effect.
+#'   \code{"complete"} (default) restricts to completed trips only; \code{"all"}
+#'   uses all interviews including incomplete trips. \code{"complete"} is the
+#'   statistically preferred default because incomplete-trip RPUE underestimates
+#'   releases when anglers release additional fish after the interview (Hansen &
+#'   Van Kirk 2010). \code{"all"} remains available for analyses that prefer the
+#'   larger interview set. When \code{trip_status} was not provided to
+#'   \code{\link{add_interviews}}, this argument has no effect.
 #' @param missing_sections Character string controlling behavior when a
 #'   registered section has no interview observations. \code{"warn"} (default)
 #'   emits a \code{cli_warn()} and inserts an NA row with
@@ -1725,12 +1733,13 @@ estimate_harvest_rate <- function(
 #'   produced. Release rates (fish per angler-hour) are not additive across
 #'   sections. Lake-wide release rate requires a separate unsectioned call.
 #'
-#' @note Unlike \code{\link{estimate_catch_rate}}, this function defaults to
-#'   using \strong{all} interviews (complete and incomplete) for RPUE estimation.
-#'   Released fish counted at interview time are directly observable. However,
-#'   incomplete-trip RPUE may underestimate if anglers release additional fish
-#'   after the interview. Use \code{use_trips = "complete"} for a stricter
-#'   analysis restricted to completed-trip interviews.
+#' @note This function defaults to using \strong{completed-trip} interviews only
+#'   for RPUE estimation (\code{use_trips = "complete"}). Incomplete-trip RPUE may
+#'   underestimate releases if anglers release additional fish after the
+#'   interview (Hansen & Van Kirk 2010), so restricting to completed trips is the
+#'   statistically preferred default. Released fish counted at interview time are
+#'   directly observable, so \code{use_trips = "all"} remains available to include
+#'   incomplete-trip interviews.
 #'
 #' @return A creel_estimates S3 object with method = "ratio-of-means-rpue".
 #'   Estimates tibble has columns: estimate, se, ci_lower, ci_upper, n (plus
@@ -1830,13 +1839,13 @@ estimate_release_rate <- function(
 
   # Handle use_trips for standard (non-sectioned) path
   use_trips_is_default <- is.null(use_trips)
-  if (is.null(use_trips)) use_trips <- "all"
+  if (is.null(use_trips)) use_trips <- "complete"
   valid_use_trips_std <- c("all", "complete")
   if (!use_trips %in% valid_use_trips_std) {
     cli::cli_abort(c(
       "Invalid use_trips value: {.val {use_trips}}",
       "x" = "Must be one of: {.val {valid_use_trips_std}}",
-      "i" = "Use {.val all} (default) for all interviews or {.val complete} for completed trips only."
+      "i" = "Use {.val complete} (default) for completed trips only or {.val all} for all interviews."
     ))
   }
 
@@ -1856,24 +1865,24 @@ estimate_release_rate <- function(
     n_total <- n_complete + n_incomplete
 
     if (use_trips == "all") {
-      default_tag <- if (use_trips_is_default) " [default]" else "" # nolint: object_usage_linter
       cli::cli_inform(c(
         "i" = "Using all interviews for RPUE estimation",
-        " " = "(n={n_total}: {n_complete} complete, {n_incomplete} incomplete){default_tag}",
-        " " = "Use {.code use_trips = 'complete'} to restrict to completed trips."
+        " " = "(n={n_total}: {n_complete} complete, {n_incomplete} incomplete)",
+        " " = "Use {.code use_trips = 'complete'} (default) to restrict to completed trips."
       ))
     } else {
       if (n_complete == 0L) {
         cli::cli_abort(c(
           "No complete trips available for RPUE estimation",
           "x" = "{.arg use_trips} = 'complete' but dataset has 0 complete trips",
-          "i" = "Use {.code use_trips = 'all'} (default) to include all interviews"
+          "i" = "Use {.code use_trips = 'all'} to include all interviews"
         ))
       }
+      default_tag <- if (use_trips_is_default) " [default]" else "" # nolint: object_usage_linter
       pct_complete <- round(100 * n_complete / n_total, 1) # nolint: object_usage_linter
       cli::cli_inform(c(
         "i" = "Filtering to complete trips for RPUE estimation",
-        " " = "(n={n_complete}, {pct_complete}% of {n_total} interviews)"
+        " " = "(n={n_complete}, {pct_complete}% of {n_total} interviews){default_tag}"
       ))
       complete_interviews <- design$interviews[design$interviews[[trip_status_col]] == "complete", ]
       design <- rebuild_interview_survey(design, complete_interviews) # nolint: object_usage_linter

--- a/man/estimate_harvest_rate.Rd
+++ b/man/estimate_harvest_rate.Rd
@@ -37,12 +37,16 @@ Options: \code{"taylor"} (default, Taylor linearization),
 which estimator path was used. Default FALSE.}
 
 \item{use_trips}{Character string specifying which interviews to include.
-For standard (non-bus-route) designs: \code{"all"} (default) uses all
-interviews including incomplete trips; \code{"complete"} restricts to
-completed trips only. For bus-route designs: \code{"complete"} (default),
-\code{"incomplete"}, or \code{"diagnostic"}. When \code{trip_status} was
-not provided to \code{\link{add_interviews}}, this argument has no effect
-for standard designs.}
+For standard (non-bus-route) designs: \code{"complete"} (default) restricts
+to completed trips only; \code{"all"} uses all interviews including
+incomplete trips. \code{"complete"} is the statistically preferred default
+because incomplete-trip HPUE underestimates harvest when anglers keep
+additional fish after the interview (Hansen & Van Kirk 2010). Fish already
+in the livewell are directly observable, so \code{"all"} remains available
+for analyses that prefer the larger interview set. For bus-route designs:
+\code{"complete"} (default), \code{"incomplete"}, or \code{"diagnostic"}.
+When \code{trip_status} was not provided to \code{\link{add_interviews}},
+this argument has no effect for standard designs.}
 
 \item{missing_sections}{Character string controlling behavior when a
 registered section has no interview observations. \code{"warn"} (default)
@@ -99,13 +103,13 @@ When called on a sectioned design, no \code{.lake_total} row is
 produced. Harvest rates (fish per angler-hour) are not additive across
 sections. Lake-wide harvest rate requires a separate unsectioned call.
 
-Unlike \code{\link{estimate_catch_rate}}, this function defaults to
-using \strong{all} interviews (complete and incomplete) for HPUE estimation.
-Fish already in the livewell at interview time are directly observable and
-represent confirmed harvest. However, incomplete-trip HPUE may underestimate
-when anglers continue fishing and keep additional fish after being interviewed
-(Hansen & Van Kirk 2010). Use \code{use_trips = "complete"} for a stricter
-analysis restricted to completed-trip interviews.
+This function defaults to using \strong{completed-trip} interviews only
+for HPUE estimation (\code{use_trips = "complete"}). Incomplete-trip HPUE
+underestimates harvest when anglers continue fishing and keep additional
+fish after being interviewed (Hansen & Van Kirk 2010), so restricting to
+completed trips is the statistically preferred default. Fish already in the
+livewell at interview time are directly observable, so \code{use_trips =
+  "all"} remains available to include incomplete-trip interviews.
 }
 \examples{
 # Basic ungrouped HPUE

--- a/man/estimate_release_rate.Rd
+++ b/man/estimate_release_rate.Rd
@@ -30,9 +30,13 @@ Options: \code{"taylor"} (default), \code{"bootstrap"}, or
 \item{conf_level}{Numeric confidence level (default: 0.95).}
 
 \item{use_trips}{Character string specifying which interviews to include.
-\code{"all"} (default) uses all interviews including incomplete trips;
-\code{"complete"} restricts to completed trips only. When \code{trip_status}
-was not provided to \code{\link{add_interviews}}, this argument has no effect.}
+\code{"complete"} (default) restricts to completed trips only; \code{"all"}
+uses all interviews including incomplete trips. \code{"complete"} is the
+statistically preferred default because incomplete-trip RPUE underestimates
+releases when anglers release additional fish after the interview (Hansen &
+Van Kirk 2010). \code{"all"} remains available for analyses that prefer the
+larger interview set. When \code{trip_status} was not provided to
+\code{\link{add_interviews}}, this argument has no effect.}
 
 \item{missing_sections}{Character string controlling behavior when a
 registered section has no interview observations. \code{"warn"} (default)
@@ -62,12 +66,13 @@ When called on a sectioned design, no \code{.lake_total} row is
 produced. Release rates (fish per angler-hour) are not additive across
 sections. Lake-wide release rate requires a separate unsectioned call.
 
-Unlike \code{\link{estimate_catch_rate}}, this function defaults to
-using \strong{all} interviews (complete and incomplete) for RPUE estimation.
-Released fish counted at interview time are directly observable. However,
-incomplete-trip RPUE may underestimate if anglers release additional fish
-after the interview. Use \code{use_trips = "complete"} for a stricter
-analysis restricted to completed-trip interviews.
+This function defaults to using \strong{completed-trip} interviews only
+for RPUE estimation (\code{use_trips = "complete"}). Incomplete-trip RPUE may
+underestimate releases if anglers release additional fish after the
+interview (Hansen & Van Kirk 2010), so restricting to completed trips is the
+statistically preferred default. Released fish counted at interview time are
+directly observable, so \code{use_trips = "all"} remains available to include
+incomplete-trip interviews.
 }
 \examples{
 library(tidycreel)

--- a/tests/testthat/test-estimate-harvest-rate.R
+++ b/tests/testthat/test-estimate-harvest-rate.R
@@ -431,10 +431,12 @@ test_that("estimate_harvest_rate warns when 10 <= n < 30 ungrouped", {
 test_that("estimate_harvest_rate has no sample size warning when n >= 30 ungrouped", {
   design <- make_harvest_design() # has 32 interviews
 
+  # use_trips = "all" keeps all 32 interviews (default "complete" would filter
+  # to the 16 completed trips and trip the 10 <= n < 30 warning this test guards)
   # Capture warnings
   warnings <- character()
   result <- withCallingHandlers(
-    estimate_harvest_rate(design), # nolint: object_usage_linter
+    estimate_harvest_rate(design, use_trips = "all"), # nolint: object_usage_linter
     warning = function(w) {
       warnings <<- c(warnings, conditionMessage(w))
     }
@@ -456,11 +458,15 @@ test_that("estimate_harvest_rate errors when any group has n < 10 in grouped est
 })
 
 # Grouped estimation tests ----
+# These tests exercise grouping/variance mechanics, not trip-status filtering.
+# make_harvest_design() has 8 completed trips per day_type group, below the
+# n >= 10 ratio-estimation floor, so they pass use_trips = "all" to retain all
+# 16 interviews per group. The default ("complete") is covered separately below.
 
 test_that("estimate_harvest_rate grouped by day_type returns creel_estimates with by_vars set", {
   design <- make_harvest_design()
 
-  result <- estimate_harvest_rate(design, by = day_type) # nolint: object_usage_linter
+  result <- estimate_harvest_rate(design, by = day_type, use_trips = "all") # nolint: object_usage_linter
 
   expect_s3_class(result, "creel_estimates")
   expect_true(!is.null(result$by_vars))
@@ -470,7 +476,7 @@ test_that("estimate_harvest_rate grouped by day_type returns creel_estimates wit
 test_that("estimate_harvest_rate grouped result estimates tibble has day_type column", {
   design <- make_harvest_design()
 
-  result <- estimate_harvest_rate(design, by = day_type) # nolint: object_usage_linter
+  result <- estimate_harvest_rate(design, by = day_type, use_trips = "all") # nolint: object_usage_linter
 
   expect_true("day_type" %in% names(result$estimates))
 })
@@ -478,7 +484,7 @@ test_that("estimate_harvest_rate grouped result estimates tibble has day_type co
 test_that("estimate_harvest_rate grouped result has one row per group level", {
   design <- make_harvest_design()
 
-  result <- estimate_harvest_rate(design, by = day_type) # nolint: object_usage_linter
+  result <- estimate_harvest_rate(design, by = day_type, use_trips = "all") # nolint: object_usage_linter
 
   expect_equal(nrow(result$estimates), 2)
   expect_true("weekday" %in% result$estimates$day_type)
@@ -488,7 +494,7 @@ test_that("estimate_harvest_rate grouped result has one row per group level", {
 test_that("estimate_harvest_rate grouped result has n column reflecting per-group sample sizes", {
   design <- make_harvest_design()
 
-  result <- estimate_harvest_rate(design, by = day_type) # nolint: object_usage_linter
+  result <- estimate_harvest_rate(design, by = day_type, use_trips = "all") # nolint: object_usage_linter
 
   expect_true("n" %in% names(result$estimates))
   expect_equal(sum(result$estimates$n), nrow(design$interviews))
@@ -500,8 +506,9 @@ test_that("estimate_harvest_rate grouped result has n column reflecting per-grou
 test_that("ungrouped HPUE matches manual svyratio calculation", {
   design <- make_harvest_design()
 
-  # tidycreel estimate
-  result <- estimate_harvest_rate(design) # nolint: object_usage_linter
+  # tidycreel estimate (use_trips = "all" so the survey object below — which
+  # spans all 32 interviews — is the correct manual reference)
+  result <- estimate_harvest_rate(design, use_trips = "all") # nolint: object_usage_linter
 
   # Manual survey::svyratio calculation
   svy <- design$interview_survey
@@ -519,8 +526,9 @@ test_that("ungrouped HPUE matches manual svyratio calculation", {
 test_that("grouped HPUE matches manual svyby+svyratio calculation", {
   design <- make_harvest_design()
 
-  # tidycreel grouped estimate
-  result <- estimate_harvest_rate(design, by = day_type) # nolint: object_usage_linter
+  # tidycreel grouped estimate (use_trips = "all" to match the all-interview
+  # survey object used for the manual reference below)
+  result <- estimate_harvest_rate(design, by = day_type, use_trips = "all") # nolint: object_usage_linter
 
   # Manual survey::svyby + svyratio calculation
   svy <- design$interview_survey
@@ -559,8 +567,9 @@ test_that("grouped HPUE matches manual svyby+svyratio calculation", {
 test_that("ungrouped HPUE SE^2 matches variance from manual vcov", {
   design <- make_harvest_design()
 
-  # tidycreel estimate
-  result <- estimate_harvest_rate(design) # nolint: object_usage_linter
+  # tidycreel estimate (use_trips = "all" to match the all-interview survey
+  # object used for the manual reference below)
+  result <- estimate_harvest_rate(design, use_trips = "all") # nolint: object_usage_linter
 
   # Manual survey::svyratio calculation
   svy <- design$interview_survey
@@ -588,12 +597,66 @@ test_that("HPUE and CPUE use same n (sample size should match)", {
   result_hpue <- estimate_harvest_rate(design) # nolint: object_usage_linter
   result_cpue <- estimate_catch_rate(design) # nolint: object_usage_linter
 
-  # After Phase 17, estimate_catch_rate defaults to complete trips only
-  # estimate_harvest_rate doesn't have use_trips parameter yet, uses all trips
-  # TODO: Update when estimate_harvest_rate gets use_trips parameter
+  # As of v2.3.0 (#69) estimate_harvest_rate defaults to use_trips = "complete",
+  # matching estimate_catch_rate. Both now restrict to completed-trip interviews,
+  # so their sample sizes agree.
   n_complete <- sum(design$interviews$trip_status == "complete")
   expect_equal(result_cpue$estimates$n, n_complete)
-  expect_equal(result_hpue$estimates$n, nrow(design$interviews))
+  expect_equal(result_hpue$estimates$n, n_complete)
+})
+
+# Default use_trips tests (v2.3.0 / #69) ----
+
+test_that("RATE-69-harvest: estimate_harvest_rate defaults to use_trips = 'complete'", {
+  # Statistical rationale (Hansen & Van Kirk 2010): incomplete-trip HPUE
+  # underestimates harvest, so the default must restrict to completed trips.
+  # make_harvest_design() has 16 complete + 16 incomplete interviews.
+  design <- make_harvest_design()
+  n_complete <- sum(design$interviews$trip_status == "complete")
+
+  # Default call must filter to completed trips (announced via cli message) ...
+  expect_message(
+    result_default <- estimate_harvest_rate(design), # nolint: object_usage_linter
+    "complete"
+  )
+  expect_equal(result_default$estimates$n, n_complete)
+
+  # ... and must equal an explicit use_trips = "complete" call.
+  result_complete <- suppressMessages(estimate_harvest_rate(design, use_trips = "complete")) # nolint: object_usage_linter line_length_linter
+  expect_equal(result_default$estimates$estimate, result_complete$estimates$estimate)
+
+  # The opt-out (use_trips = "all") uses every interview and differs in n.
+  result_all <- suppressMessages(estimate_harvest_rate(design, use_trips = "all")) # nolint: object_usage_linter
+  expect_equal(result_all$estimates$n, nrow(design$interviews))
+  expect_gt(result_all$estimates$n, result_default$estimates$n)
+})
+
+test_that("RATE-69-release: estimate_release_rate defaults to use_trips = 'complete'", {
+  # Same default-flip rationale as harvest; release rate must also restrict to
+  # completed trips by default.
+  data("example_calendar", package = "tidycreel")
+  data("example_interviews", package = "tidycreel")
+  data("example_catch", package = "tidycreel")
+
+  design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
+  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+    catch = catch_total, effort = hours_fished,
+    trip_status = trip_status, trip_duration = trip_duration
+  )
+  design <- add_catch(design, example_catch, # nolint: object_usage_linter
+    catch_uid = interview_id, interview_uid = interview_id,
+    species = species, count = count, catch_type = catch_type
+  )
+
+  has_incomplete <- any(design$interviews$trip_status == "incomplete")
+  skip_if_not(has_incomplete, "example data has no incomplete trips to filter")
+
+  n_complete <- sum(design$interviews$trip_status == "complete")
+  result_default <- suppressMessages(estimate_release_rate(design)) # nolint: object_usage_linter
+  result_complete <- suppressMessages(estimate_release_rate(design, use_trips = "complete")) # nolint: object_usage_linter line_length_linter
+
+  expect_equal(result_default$estimates$n, n_complete)
+  expect_equal(result_default$estimates$estimate, result_complete$estimates$estimate)
 })
 
 # Custom confidence level test ----
@@ -641,8 +704,9 @@ test_that("estimate_harvest_rate with jackknife variance method produces valid r
 test_that("estimate_harvest_rate grouped + bootstrap variance compose correctly", {
   design <- make_harvest_design()
 
+  # use_trips = "all": grouped bootstrap mechanics need >= 10 interviews/group
   # Should work (may warn about small n per group, but should not error)
-  result <- suppressWarnings(estimate_harvest_rate(design, by = day_type, variance = "bootstrap")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_harvest_rate(design, by = day_type, variance = "bootstrap", use_trips = "all")) # nolint: object_usage_linter object_length_linter line_length_linter
 
   expect_s3_class(result, "creel_estimates")
   expect_equal(result$variance_method, "bootstrap")
@@ -749,9 +813,11 @@ test_that("estimate_harvest_rate filters zero-effort interviews with warning", {
   # Inject 2 zero-effort interviews (must set .angler_effort, the column used by estimate_harvest_rate)
   design$interviews[[".angler_effort"]][1:2] <- 0
 
+  # use_trips = "all" so the 32-interview arithmetic below (32 - 2 = 30) holds;
+  # this test verifies zero-effort filtering, not trip-status filtering
   # Should warn about zero-effort
   expect_warning(
-    result <- estimate_harvest_rate(design), # nolint: object_usage_linter
+    result <- estimate_harvest_rate(design, use_trips = "all"), # nolint: object_usage_linter
     "zero effort"
   )
 
@@ -785,9 +851,11 @@ test_that("estimate_harvest_rate filters NA harvest interviews with warning", {
   # Inject 2 NA harvest values
   design$interviews$catch_kept[1:2] <- NA
 
+  # use_trips = "all" so the 32-interview arithmetic below (32 - 2 = 30) holds;
+  # this test verifies NA-harvest filtering, not trip-status filtering
   # Should warn about missing harvest
   expect_warning(
-    result <- estimate_harvest_rate(design), # nolint: object_usage_linter
+    result <- estimate_harvest_rate(design, use_trips = "all"), # nolint: object_usage_linter
     "missing harvest"
   )
 

--- a/tests/testthat/test-estimate-harvest-rate.R
+++ b/tests/testthat/test-estimate-harvest-rate.R
@@ -664,8 +664,8 @@ test_that("RATE-69-release: estimate_release_rate defaults to use_trips = 'compl
 test_that("estimate_harvest_rate with conf_level = 0.90 produces narrower CI than 0.95", {
   design <- make_harvest_design()
 
-  result_95 <- estimate_harvest_rate(design, conf_level = 0.95) # nolint: object_usage_linter
-  result_90 <- estimate_harvest_rate(design, conf_level = 0.90) # nolint: object_usage_linter
+  result_95 <- estimate_harvest_rate(design, conf_level = 0.95, use_trips = "all") # nolint: object_usage_linter
+  result_90 <- estimate_harvest_rate(design, conf_level = 0.90, use_trips = "all") # nolint: object_usage_linter
 
   # CI width should be narrower for 90% than 95%
   width_95 <- result_95$estimates$ci_upper - result_95$estimates$ci_lower
@@ -680,7 +680,7 @@ test_that("estimate_harvest_rate with conf_level = 0.90 produces narrower CI tha
 test_that("estimate_harvest_rate with bootstrap variance method produces valid results", {
   design <- make_harvest_design()
 
-  result <- estimate_harvest_rate(design, variance = "bootstrap") # nolint: object_usage_linter
+  result <- estimate_harvest_rate(design, variance = "bootstrap", use_trips = "all") # nolint: object_usage_linter
 
   expect_equal(result$variance_method, "bootstrap")
   expect_true(is.numeric(result$estimates$se))

--- a/tests/testthat/test-estimate-species.R
+++ b/tests/testthat/test-estimate-species.R
@@ -565,7 +565,9 @@ test_that("estimate_release_rate estimate is non-negative", {
 
 test_that("estimate_release_rate n equals total interviews", {
   d <- make_test_design_with_catch()
-  result <- suppressWarnings(estimate_release_rate(d))
+  # use_trips = "all": this test verifies n spans the full interview set; as of
+  # v2.3.0 (#69) the default ("complete") would filter to completed trips only.
+  result <- suppressWarnings(estimate_release_rate(d, use_trips = "all"))
   expect_equal(result$estimates$n, nrow(d$interviews))
 })
 


### PR DESCRIPTION
## Summary

- **Breaking change**: `estimate_harvest_rate()` and `estimate_release_rate()` now default to `use_trips = "complete"` (previously `"all"`). Incomplete-trip HPUE/RPUE underestimates harvest when fish in the livewell are observable at interview time (Hansen & Van Kirk 2010). Bus-route designs were already `"complete"` and are unaffected.
- **Restore old behavior**: pass `use_trips = "all"` explicitly.
- Version bumped 2.2.0 → 2.3.0 "Northern Pike".
- Closes #69.

## Changes

| File | Change |
|---|---|
| `R/creel-estimates.R` | Default `"all"` → `"complete"` in both functions; roxygen `@param`/`@note` updated |
| `man/estimate_harvest_rate.Rd`, `man/estimate_release_rate.Rd` | Regenerated |
| `DESCRIPTION` | 2.2.0 → 2.3.0 |
| `NEWS.md` | v2.3.0 "Northern Pike" Breaking changes section |
| `tests/testthat/test-estimate-harvest-rate.R` | 11 tests updated with explicit `use_trips = "all"` where intent is not trip filtering; 2 new tests (RATE-69-harvest, RATE-69-release) verify default is `"complete"` |
| `tests/testthat/test-estimate-species.R` | 1 test updated |

## Test plan

- [x] `estimate_harvest_rate()` / `estimate_release_rate()` default filters to complete trips
- [x] `use_trips = "all"` still available and produces different (larger-n) results
- [x] Bus-route designs unaffected
- [x] 3068 tests pass, 0 fail
- [x] R CMD check: 0 errors, 0 warnings