### PR TITLE
Release v2.4.0 "Bowfin" — bug-fix consolidation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -121,3 +121,4 @@
 ^\.contextatlas\.yml$
 ^\.contextatlas$
 ^\.gsd\.archive.*$
+^air\.toml$

--- a/.gitignore
+++ b/.gitignore
@@ -135,8 +135,9 @@ kairo.db
 kairo.db-shm
 kairo.db-wal
 
-# ContextAtlas: regenerable prompt artifacts (per `contextatlas init`)
-.contextatlas/prompts/
+# ContextAtlas: config and regenerable artifacts (per `contextatlas init`)
+.contextatlas.yml
+.contextatlas/
 
 # NGPC proprietary data — local only, not for distribution
 data/ngpc_creel_params.rda

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycreel
 Title: Tidy Interface for Creel Survey Design and Analysis
-Version: 2.3.0
+Version: 2.4.0
 Authors@R:
     person(given = "Christopher", family = "Chizinski", role = c("aut", "cre"),
            email = "cchizinski2@unl.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,119 @@
+# tidycreel 2.4.0 "Bowfin" (2026-06-25)
+
+## New features
+
+* `est_age_distribution()` estimates proportional age structure with SE and
+  confidence intervals from age-frequency interview data, fully integrated with
+  the `creel_design` workflow. Stratified and grouped estimation supported.
+
+* `est_mean_age()` estimates mean age (± SE, CI) from structured interview
+  data. Complements `est_age_distribution()` for reporting age-structured
+  harvest results.
+
+* `example_ages` — new built-in dataset of simulated age observations for use
+  in examples and tests.
+
+* `estimate_harvest_rate()` gains species-level dispatch: pass a species column
+  and the function routes harvest-rate estimation independently per species,
+  returning a tidy multi-species result in a single call.
+
+* `creel_design()` gains `open_start` parameter for GLMM aerial designs,
+  allowing the survey window to be anchored to the count time rather than
+  requiring a fixed open time.
+
+## Bug fixes
+
+### Statistical correctness
+
+* `estimate_total_catch()`, `estimate_total_harvest()`,
+  `estimate_total_release()`: strata with effort but no interview coverage were
+  silently dropped by an inner join in `compute_stratum_product_sum()`, biasing
+  season totals low. Fixed to warn and retain all effort strata (#Tier1-Bug1).
+
+* `estimate_angler_trips()`: `stats::sd()` on a single-interview stratum
+  returned `NA`, propagating silently into SE and CI. Guard added for `n < 2`;
+  emits `cli_warn()` and returns `NA_real_` for SE so the point estimate
+  remains usable (#Tier1-Bug2).
+
+* `estimate_effort()`: finite population correction (FPC) was not applied to
+  the expanded effort `svydesign`, causing inflated SE for designs with high
+  sampling fractions. Fixed (#Tier1-Bug5-adjacent).
+
+* `optimal_n()`: named `cost_ratio` vectors were applied positionally instead
+  of by stratum name, producing wrong allocations when stratum order differed.
+  Zero variance (`all s2_h = 0`) and zero total (`all ybar_h = 0`) produced
+  silent `NaN`; both now abort with informative errors. `n_total` floored at 1
+  to prevent degenerate zero-sample result.
+
+* `adjust_nonresponse()`: `method = "calibrate"` was accepted and matched but
+  silently ignored — both methods used direct weight rescaling. Now aborts with
+  an informative error directing users to `survey::calibrate()` directly
+  (#Tier1-Bug4).
+
+* `adjust_nonresponse()` replicate-design path: `svy$scale` (a variance
+  formula constant) was multiplied by `mean(wt_multipliers)`, affecting only
+  variance and using an average instead of per-observation values. Fixed to
+  scale `svy$pweights` per-observation and `svy$repweights` row-wise
+  (#Tier1-Bug5).
+
+### Validation and scheduling
+
+* `new_creel_validation()`: `all(logical(0)) == TRUE` caused a 0-row results
+  object to silently report `passed = TRUE`. Fixed with `nrow > 0` guard;
+  empty validation results now correctly return `passed = FALSE`.
+
+* `design-validator`: `ybar_h`, `s2_h`, and `n_proposed` were consumed
+  positionally against named `N_h`, producing wrong stratum indexing when order
+  differed. All three now rekeyed by `strata_names` before indexing.
+
+* `validate_incomplete_trips()`: `perform_tost()` crashed or silently passed
+  when `se_diff == 0` (identical SEs) or `df <= 0` (`n = 1` group). Early-
+  return guards added for both degenerate cases; `isTRUE()` used in grouped-
+  passed aggregation to prevent `NA` propagating into `if()`.
+
+* `schedule_generators()`: `inclusion_prob` could silently exceed 1 when
+  `p_site * (crew / n_circuits) > 1`. Now aborts with an actionable message.
+
+### Reporting helpers
+
+* `creel_palette(n)`: modular recycling used 0-based index at palette-length
+  multiples, returning `NA` at those positions. Fixed to 1-based modular
+  arithmetic.
+
+* `coerce_schedule_columns()`: unconditional `as.integer(period_id)` silently
+  coerced character labels (`"AM"` / `"PM"`) to all-`NA`, filtering all
+  downstream rows. Now only coerces when all non-`NA` values are numeric
+  strings; character period labels are preserved unchanged.
+
+* `compare_variance()`: Taylor and replicate SEs were paired by row position
+  rather than stratum key. If the two estimators returned rows in different
+  orders, divergence ratios were computed for mismatched strata. Fixed with a
+  keyed join; group-column detection now derived from `x$by_vars` rather than
+  a hardcoded exclusion list that would misclassify new output columns.
+
+* `validation_report()`, `standardize_species()`, `hybrid_design()`: second
+  positional string to `cli_abort()` / `cli_warn()` was silently dropped by
+  cli's argument handling. Merged into single message or named vector.
+
+### Age and length estimators
+
+* `est_age_distribution()` and `est_length_distribution()`: per-group `n` was
+  reporting the global interview count (`nrow(design$interviews)`) instead of
+  the within-group count. Fixed to `nrow(wide)` per group, consistent with
+  `estimate_total_catch()` and `estimate_total_harvest()`.
+
+* `est_age_distribution()` and `est_length_distribution()`: `left_join()` was
+  called inside the per-group loop against the full interviews table (constant
+  across iterations). Replaced with `match()` lookup and direct column
+  assignment, eliminating repeated dplyr overhead.
+
+## Documentation
+
+* Added a Quarto Creel Report starter template under
+  `inst/quarto/templates/creel-report/`. The template demonstrates a full
+  season workflow — design, validation, estimation, and plotting — using
+  `tidycreel` helpers end to end.
+
 # tidycreel 2.3.0 "Northern Pike" (2026-06-22)
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,11 @@
   effect). Bus-route designs already defaulted to `"complete"` and are
   unchanged. Closes #69.
 
+## Documentation
+
+* Added a Quarto Creel Report starter template scaffold that uses the
+  `tidycreel` design, validation, summary, and plotting helpers end to end.
+
 # tidycreel 2.2.0 "Goldeye" (2026-06-17)
 
 ## New features

--- a/R/autoplot-methods.R
+++ b/R/autoplot-methods.R
@@ -41,22 +41,19 @@ NULL
 #'
 #' @family "Visualisation"
 #' @export
-autoplot.creel_estimates <- function(object, title = NULL,
-                                     theme = c("default", "creel"), ...) {
+autoplot.creel_estimates <- function(object, title = NULL, theme = c("default", "creel"), ...) {
   theme <- match.arg(theme)
   theme_obj <- if (theme == "creel") theme_creel() else ggplot2::theme_bw() # nolint: object_usage_linter
   # Human-readable method label
-  method_label <- switch(object$method,
+  method_label <- switch(
+    object$method,
     total = "Total Effort",
     "ratio-of-means-cpue" = "CPUE (Ratio-of-Means)",
     "mean-of-ratios-cpue" = "CPUE (Mean-of-Ratios)",
     "ratio-of-means-hpue" = "HPUE (Ratio-of-Means)",
-    "ratio-of-means-cpue-per-angler" =
-      "CPUE per Angler (Ratio-of-Means)",
-    "mean-of-ratios-cpue-per-angler" =
-      "CPUE per Angler (Mean-of-Ratios)",
-    "ratio-of-means-hpue-per-angler" =
-      "HPUE per Angler (Ratio-of-Means)",
+    "ratio-of-means-cpue-per-angler" = "CPUE per Angler (Ratio-of-Means)",
+    "mean-of-ratios-cpue-per-angler" = "CPUE per Angler (Mean-of-Ratios)",
+    "ratio-of-means-hpue-per-angler" = "HPUE per Angler (Ratio-of-Means)",
     "product-total-catch" = "Total Catch",
     "product-total-harvest" = "Total Harvest",
     object$method
@@ -65,7 +62,9 @@ autoplot.creel_estimates <- function(object, title = NULL,
   effort_target <- object$effort_target %||% NULL
   if (!is.null(title)) {
     plot_title <- title
-  } else if (!is.null(effort_target) && method_label %in% c("Total Effort", "Total Catch", "Total Harvest")) {
+  } else if (
+    !is.null(effort_target) && method_label %in% c("Total Effort", "Total Catch", "Total Harvest")
+  ) {
     plot_title <- paste0(method_label, " (", effort_target, ")")
   } else {
     plot_title <- method_label
@@ -81,8 +80,13 @@ autoplot.creel_estimates <- function(object, title = NULL,
 
   # Identify group columns
   est_cols <- c(
-    "estimate", "se", "ci_lower", "ci_upper", "n",
-    "se_between", "se_within"
+    "estimate",
+    "se",
+    "ci_lower",
+    "ci_upper",
+    "n",
+    "se_between",
+    "se_within"
   )
   group_cols <- setdiff(names(est), est_cols)
 
@@ -90,16 +94,16 @@ autoplot.creel_estimates <- function(object, title = NULL,
     # Ungrouped: single point
     point_colour <- if (theme == "creel") creel_palette()[["primary"]] else "black" # nolint: object_usage_linter
     plot_df <- data.frame(
-      label     = method_label,
-      estimate  = est$estimate,
-      ci_lower  = est$ci_lower,
-      ci_upper  = est$ci_upper
+      label = method_label,
+      estimate = est$estimate,
+      ci_lower = est$ci_lower,
+      ci_upper = est$ci_upper
     )
     p <- ggplot2::ggplot(
       plot_df,
       ggplot2::aes(
-        x    = .data[["label"]], # nolint: object_usage_linter
-        y    = .data[["estimate"]],
+        x = .data[["label"]], # nolint: object_usage_linter
+        y = .data[["estimate"]],
         ymin = .data[["ci_lower"]],
         ymax = .data[["ci_upper"]]
       )
@@ -117,7 +121,7 @@ autoplot.creel_estimates <- function(object, title = NULL,
     # Grouped: one point per group row
     grp_col <- group_cols[[1L]]
     plot_df <- data.frame(
-      group    = as.character(est[[grp_col]]),
+      group = as.character(est[[grp_col]]),
       estimate = est$estimate,
       ci_lower = est$ci_lower,
       ci_upper = est$ci_upper
@@ -125,10 +129,10 @@ autoplot.creel_estimates <- function(object, title = NULL,
     p <- ggplot2::ggplot(
       plot_df,
       ggplot2::aes(
-        x     = .data[["group"]], # nolint: object_usage_linter
-        y     = .data[["estimate"]],
-        ymin  = .data[["ci_lower"]],
-        ymax  = .data[["ci_upper"]],
+        x = .data[["group"]], # nolint: object_usage_linter
+        y = .data[["estimate"]],
+        ymin = .data[["ci_lower"]],
+        ymax = .data[["ci_upper"]],
         color = .data[["group"]]
       )
     ) +
@@ -187,11 +191,16 @@ autoplot.creel_estimates <- function(object, title = NULL,
 #'
 #' @family "Visualisation"
 #' @export
-autoplot.creel_length_distribution <- function(object, title = NULL,
-                                               theme = c("default", "creel"), ...) {
+autoplot.creel_length_distribution <- function(
+  object,
+  title = NULL,
+  theme = c("default", "creel"),
+  ...
+) {
   theme <- match.arg(theme)
   theme_obj <- if (theme == "creel") theme_creel() else ggplot2::theme_bw() # nolint: object_usage_linter
-  type_label <- switch(attr(object, "type"),
+  type_label <- switch(
+    attr(object, "type"),
     catch = "Catch",
     harvest = "Harvest",
     release = "Release",
@@ -378,18 +387,22 @@ autoplot.creel_schedule <- function(object, title = "Creel Schedule", ...) {
 
   p <- ggplot2::ggplot(
     all_days,
-    ggplot2::aes( # nolint: object_usage_linter
-      x    = .data[["wday"]], # nolint: object_usage_linter
-      y    = .data[["week_row"]],
+    ggplot2::aes(
+      # nolint: object_usage_linter
+      x = .data[["wday"]], # nolint: object_usage_linter
+      y = .data[["week_row"]],
       fill = .data[["fill_group"]]
     )
   ) +
     ggplot2::geom_tile(
-      color = "white", linewidth = 0.5
+      color = "white",
+      linewidth = 0.5
     ) +
     ggplot2::geom_text(
       ggplot2::aes(label = .data[["day_label"]]), # nolint: object_usage_linter
-      size = 2.5, color = "white", fontface = "bold"
+      size = 2.5,
+      color = "white",
+      fontface = "bold"
     ) +
     ggplot2::scale_x_continuous(
       breaks = 0:6,
@@ -400,17 +413,26 @@ autoplot.creel_schedule <- function(object, title = "Creel Schedule", ...) {
 
   fill_scale <- if (has_circuit) {
     ggplot2::scale_fill_brewer(
-      palette  = "Set2",
+      palette = "Set2",
       na.value = "#cccccc",
-      name     = "Circuit"
+      name = "Circuit"
     )
   } else {
+    # Canonical day types get fixed colors; additional special-period types
+    # get creel_palette() colors so they don't render as unsampled grey.
+    canonical_colors <- c(weekday = "#2c7bb6", weekend = "#d7191c")
+    extra_types <- setdiff(
+      unique(all_days$fill_group[all_days$fill_group != "unsampled"]),
+      names(canonical_colors)
+    )
+    extra_colors <- if (length(extra_types) > 0L) {
+      stats::setNames(creel_palette(length(extra_types)), extra_types)
+    } else {
+      character(0)
+    }
+    day_colors <- c(canonical_colors, extra_colors, unsampled = "#cccccc")
     ggplot2::scale_fill_manual(
-      values = c(
-        weekday   = "#2c7bb6",
-        weekend   = "#d7191c",
-        unsampled = "#cccccc"
-      ),
+      values = day_colors,
       na.value = "#cccccc",
       name = NULL
     )
@@ -430,10 +452,10 @@ autoplot.creel_schedule <- function(object, title = "Creel Schedule", ...) {
     ) +
     ggplot2::theme_minimal() +
     ggplot2::theme(
-      axis.text.y  = ggplot2::element_blank(),
+      axis.text.y = ggplot2::element_blank(),
       axis.ticks.y = ggplot2::element_blank(),
-      panel.grid   = ggplot2::element_blank(),
-      strip.text   = ggplot2::element_text(face = "bold")
+      panel.grid = ggplot2::element_blank(),
+      strip.text = ggplot2::element_text(face = "bold")
     )
 
   p
@@ -482,7 +504,8 @@ autoplot.creel_schedule <- function(object, title = "Creel Schedule", ...) {
 #'
 #' @family "Visualisation"
 #' @export
-plot_design <- function(design, title = NULL, ...) { # nolint: object_usage_linter
+plot_design <- function(design, title = NULL, ...) {
+  # nolint: object_usage_linter
   if (!inherits(design, "creel_design")) {
     cli::cli_abort(c(
       "{.arg design} must be a {.cls creel_design} object.",
@@ -540,9 +563,9 @@ plot_design <- function(design, title = NULL, ...) { # nolint: object_usage_lint
       ggplot2::scale_fill_brewer(palette = "Set2") +
       ggplot2::labs(
         title = plot_title,
-        x     = strata_label,
-        y     = "Sampled days",
-        fill  = strata_label
+        x = strata_label,
+        y = "Sampled days",
+        fill = strata_label
       ) +
       ggplot2::theme_bw() +
       ggplot2::theme(
@@ -555,7 +578,10 @@ plot_design <- function(design, title = NULL, ...) { # nolint: object_usage_lint
 
     # Identify first numeric count column (excluding design metadata)
     excluded <- c(
-      design$date_col, design$strata_cols, design$psu_col, design$section_col
+      design$date_col,
+      design$strata_cols,
+      design$psu_col,
+      design$section_col
     )
     num_cols <- names(counts)[vapply(counts, is.numeric, logical(1L))]
     count_var <- setdiff(num_cols, excluded)[1]
@@ -582,7 +608,9 @@ plot_design <- function(design, title = NULL, ...) { # nolint: object_usage_lint
       )
     ) +
       ggplot2::geom_jitter(
-        width = 0.15, alpha = 0.6, size = 2
+        width = 0.15,
+        alpha = 0.6,
+        size = 2
       ) +
       ggplot2::stat_summary(
         fun.data = ggplot2::mean_cl_normal, # nolint: object_usage_linter
@@ -594,14 +622,14 @@ plot_design <- function(design, title = NULL, ...) { # nolint: object_usage_lint
       ) +
       ggplot2::scale_colour_brewer(palette = "Set2") +
       ggplot2::labs(
-        title  = plot_title,
-        x      = strata_label,
-        y      = count_var,
+        title = plot_title,
+        x = strata_label,
+        y = count_var,
         colour = strata_label
       ) +
       ggplot2::theme_bw() +
       ggplot2::theme(
-        plot.title      = ggplot2::element_text(face = "bold"),
+        plot.title = ggplot2::element_text(face = "bold"),
         legend.position = "none"
       )
   }

--- a/R/compare-designs.R
+++ b/R/compare-designs.R
@@ -116,8 +116,13 @@ compare_designs <- function(designs, metric = "estimate") {
 
   # Retain group columns (anything not in the standard set)
   std_cols <- c(
-    "estimate", "se", "se_between", "se_within",
-    "ci_lower", "ci_upper", "n"
+    "estimate",
+    "se",
+    "se_between",
+    "se_within",
+    "ci_lower",
+    "ci_upper",
+    "n"
   )
   grp_cols <- setdiff(names(est), c(std_cols, metric))
   if (length(grp_cols) > 0L) {
@@ -174,25 +179,26 @@ autoplot.creel_design_comparison <- function(object, title = NULL, ...) {
     ggplot2::geom_point(size = 3) +
     ggplot2::scale_colour_brewer(palette = "Set2") +
     ggplot2::labs(
-      title  = plot_title,
-      x      = "Estimate",
-      y      = "Design",
+      title = plot_title,
+      x = "Estimate",
+      y = "Design",
       colour = "Design"
     ) +
     ggplot2::theme_bw() +
     ggplot2::theme(
-      plot.title      = ggplot2::element_text(face = "bold"),
+      plot.title = ggplot2::element_text(face = "bold"),
       legend.position = "none"
     )
 
   if (has_ci) {
-    p <- p + ggplot2::geom_errorbarh(
-      ggplot2::aes(
-        xmin = .data[["ci_lower"]], # nolint: object_usage_linter
-        xmax = .data[["ci_upper"]] # nolint: object_usage_linter
-      ),
-      height = 0.2
-    )
+    p <- p +
+      ggplot2::geom_errorbarh(
+        ggplot2::aes(
+          xmin = .data[["ci_lower"]], # nolint: object_usage_linter
+          xmax = .data[["ci_upper"]] # nolint: object_usage_linter
+        ),
+        height = 0.2
+      )
   }
 
   p

--- a/R/compare-variance.R
+++ b/R/compare-variance.R
@@ -153,16 +153,26 @@ compare_variance <- function(x,
     }
   )
 
-  # Extract SEs
-  se_taylor <- x$estimates$se
-  se_replicate <- replicate_est$estimates$se
-
   # Build output tibble, preserving group columns
   est_df <- x$estimates
   group_cols <- setdiff(
     names(est_df),
     c("estimate", "se", "ci_lower", "ci_upper", "n", "method")
   )
+
+  # Extract SEs — join by group keys to avoid positional pairing errors when
+  # Taylor and replicate estimates return rows in different orders.
+  if (length(group_cols) > 0) {
+    rep_df <- replicate_est$estimates[, c(group_cols, "se"), drop = FALSE]
+    names(rep_df)[names(rep_df) == "se"] <- "se_replicate"
+    joined_est <- dplyr::left_join(est_df, rep_df, by = group_cols)
+    se_taylor    <- joined_est$se
+    se_replicate <- joined_est$se_replicate
+  } else {
+    # Ungrouped: single row, positional pairing safe
+    se_taylor    <- est_df$se
+    se_replicate <- replicate_est$estimates$se
+  }
 
   divergence_ratio <- ifelse(
     se_taylor == 0,

--- a/R/compare-variance.R
+++ b/R/compare-variance.R
@@ -70,11 +70,13 @@
 #'
 #' @family "Reporting & Diagnostics"
 #' @export
-compare_variance <- function(x,
-                             replicate_method = c("bootstrap", "jackknife"),
-                             conf_level = 0.95,
-                             divergence_threshold = 0.10,
-                             ...) {
+compare_variance <- function(
+  x,
+  replicate_method = c("bootstrap", "jackknife"),
+  conf_level = 0.95,
+  divergence_threshold = 0.10,
+  ...
+) {
   replicate_method <- match.arg(replicate_method)
 
   # Input validation
@@ -100,9 +102,11 @@ compare_variance <- function(x,
     ))
   }
 
-  if (!is.numeric(divergence_threshold) ||
-    length(divergence_threshold) != 1 || # nolint: indentation_linter
-    divergence_threshold <= 0) {
+  if (
+    !is.numeric(divergence_threshold) ||
+      length(divergence_threshold) != 1 || # nolint: indentation_linter
+      divergence_threshold <= 0
+  ) {
     cli::cli_abort(c(
       "{.arg divergence_threshold} must be a positive number.",
       "x" = "Got {.val {divergence_threshold}}."
@@ -122,7 +126,7 @@ compare_variance <- function(x,
       if (is.null(by_vars) || length(by_vars) == 0) {
         estimator_fn(
           x$design,
-          variance   = replicate_method,
+          variance = replicate_method,
           conf_level = conf_level,
           ...
         )
@@ -134,8 +138,8 @@ compare_variance <- function(x,
         by_vars_local <- by_vars
         estimator_fn(
           x$design,
-          by         = tidyselect::all_of(by_vars_local),
-          variance   = replicate_method,
+          by = tidyselect::all_of(by_vars_local),
+          variance = replicate_method,
           conf_level = conf_level,
           ...
         )
@@ -166,11 +170,11 @@ compare_variance <- function(x,
     rep_df <- replicate_est$estimates[, c(group_cols, "se"), drop = FALSE]
     names(rep_df)[names(rep_df) == "se"] <- "se_replicate"
     joined_est <- dplyr::left_join(est_df, rep_df, by = group_cols)
-    se_taylor    <- joined_est$se
+    se_taylor <- joined_est$se
     se_replicate <- joined_est$se_replicate
   } else {
     # Ungrouped: single row, positional pairing safe
-    se_taylor    <- est_df$se
+    se_taylor <- est_df$se
     se_replicate <- replicate_est$estimates$se
   }
 
@@ -183,10 +187,10 @@ compare_variance <- function(x,
     (abs(divergence_ratio - 1) > divergence_threshold)
 
   se_tbl <- tibble::tibble(
-    se_taylor        = se_taylor,
-    se_replicate     = se_replicate,
+    se_taylor = se_taylor,
+    se_replicate = se_replicate,
     divergence_ratio = divergence_ratio,
-    diverges_flag    = diverges_flag
+    diverges_flag = diverges_flag
   )
 
   if (length(group_cols) > 0) {

--- a/R/compare-variance.R
+++ b/R/compare-variance.R
@@ -159,10 +159,7 @@ compare_variance <- function(
 
   # Build output tibble, preserving group columns
   est_df <- x$estimates
-  group_cols <- setdiff(
-    names(est_df),
-    c("estimate", "se", "ci_lower", "ci_upper", "n", "method")
-  )
+  group_cols <- if (length(by_vars) > 0) by_vars else character(0)
 
   # Extract SEs — join by group keys to avoid positional pairing errors when
   # Taylor and replicate estimates return rows in different orders.

--- a/R/creel-design.R
+++ b/R/creel-design.R
@@ -254,21 +254,23 @@ VALID_SURVEY_TYPES <- c("instantaneous", "bus_route", "ice", "camera", "aerial")
 #'
 #' @family "Survey Design"
 #' @export
-creel_design <- function(calendar,
-                         date,
-                         strata,
-                         site = NULL,
-                         design_type = "instantaneous",
-                         survey_type = design_type,
-                         sampling_frame = NULL,
-                         p_site = NULL,
-                         p_period = NULL,
-                         circuit = NULL,
-                         effort_type = NULL,
-                         camera_mode = NULL,
-                         h_open = NULL,
-                         visibility_correction = NULL,
-                         open_start = NULL) {
+creel_design <- function(
+  calendar,
+  date,
+  strata,
+  site = NULL,
+  design_type = "instantaneous",
+  survey_type = design_type,
+  sampling_frame = NULL,
+  p_site = NULL,
+  p_period = NULL,
+  circuit = NULL,
+  effort_type = NULL,
+  camera_mode = NULL,
+  h_open = NULL,
+  visibility_correction = NULL,
+  open_start = NULL
+) {
   # 1. Structural validation (Phase 1 validator)
   validate_calendar_schema(calendar) # nolint: object_usage_linter
 
@@ -365,7 +367,12 @@ creel_design <- function(calendar,
       # Try as column selector first; if it fails, evaluate as expression (scalar numeric)
       tryCatch(
         {
-          p_period_col <- resolve_single_col(p_period_quo, sampling_frame, "p_period", rlang::caller_env())
+          p_period_col <- resolve_single_col(
+            p_period_quo,
+            sampling_frame,
+            "p_period",
+            rlang::caller_env()
+          )
         },
         error = function(e) {
           val <- rlang::eval_tidy(p_period_quo)
@@ -411,12 +418,12 @@ creel_design <- function(calendar,
 
     # Store resolved column mappings alongside the data
     bus_route <- list(
-      data         = br_df,
-      site_col     = site_frame_col,
-      circuit_col  = circuit_col,
-      p_site_col   = p_site_col,
+      data = br_df,
+      site_col = site_frame_col,
+      circuit_col = circuit_col,
+      p_site_col = p_site_col,
       p_period_col = p_period_col,
-      pi_i_col     = ".pi_i"
+      pi_i_col = ".pi_i"
     )
   }
 
@@ -443,7 +450,12 @@ creel_design <- function(calendar,
       p_site_quo_ice <- rlang::enquo(p_site)
       p_site_col_ice <- NULL
       if (!rlang::quo_is_null(p_site_quo_ice)) {
-        p_site_col_ice <- resolve_single_col(p_site_quo_ice, sampling_frame, "p_site", rlang::caller_env())
+        p_site_col_ice <- resolve_single_col(
+          p_site_quo_ice,
+          sampling_frame,
+          "p_site",
+          rlang::caller_env()
+        )
       } else if ("p_site" %in% names(sampling_frame)) {
         p_site_col_ice <- "p_site"
       }
@@ -469,7 +481,10 @@ creel_design <- function(calendar,
         tryCatch(
           {
             p_period_ice_col <- resolve_single_col(
-              p_period_quo_ice, sampling_frame, "p_period", rlang::caller_env()
+              p_period_quo_ice,
+              sampling_frame,
+              "p_period",
+              rlang::caller_env()
             )
           },
           error = function(e) {
@@ -502,7 +517,10 @@ creel_design <- function(calendar,
         tryCatch(
           {
             site_frame_col_ice <- resolve_single_col(
-              site_quo, sampling_frame, "site", rlang::caller_env()
+              site_quo,
+              sampling_frame,
+              "site",
+              rlang::caller_env()
             )
           },
           error = function(e) NULL
@@ -523,12 +541,12 @@ creel_design <- function(calendar,
       ice_sf[[".pi_i"]] <- ice_sf[[p_period_ice_col]]
 
       bus_route <- list(
-        data         = ice_sf,
-        site_col     = site_frame_col_ice,
-        circuit_col  = circuit_col_ice,
-        p_site_col   = NULL,
+        data = ice_sf,
+        site_col = site_frame_col_ice,
+        circuit_col = circuit_col_ice,
+        p_site_col = NULL,
         p_period_col = p_period_ice_col,
-        pi_i_col     = ".pi_i"
+        pi_i_col = ".pi_i"
       )
     } else {
       # No sampling_frame: build single-site synthetic bus_route frame
@@ -541,21 +559,21 @@ creel_design <- function(calendar,
         stringsAsFactors = FALSE
       )
       bus_route <- list(
-        data         = ice_sf,
-        site_col     = ".ice_site",
-        circuit_col  = ".circuit",
-        p_site_col   = NULL,
+        data = ice_sf,
+        site_col = ".ice_site",
+        circuit_col = ".circuit",
+        p_site_col = NULL,
         p_period_col = ".p_period",
-        pi_i_col     = ".pi_i"
+        pi_i_col = ".pi_i"
       )
     }
 
     # (d) Build ice slot
     ice <- list(
-      survey_type    = "ice",
-      effort_type    = effort_type,
-      p_period_col   = if (!is.null(p_period_ice_col)) p_period_ice_col else ".p_period",
-      pi_i_col       = ".pi_i"
+      survey_type = "ice",
+      effort_type = effort_type,
+      p_period_col = if (!is.null(p_period_ice_col)) p_period_ice_col else ".p_period",
+      pi_i_col = ".pi_i"
     )
     if (!is.null(p_period_ice_scalar)) {
       ice$p_period_scalar <- p_period_ice_scalar
@@ -596,12 +614,11 @@ creel_design <- function(calendar,
       ))
     }
     # visibility_correction validation: optional, must be in (0, 1] if supplied
-    vc_bad <- !is.null(visibility_correction) && (
-      !is.numeric(visibility_correction) ||
+    vc_bad <- !is.null(visibility_correction) &&
+      (!is.numeric(visibility_correction) ||
         length(visibility_correction) != 1L ||
         visibility_correction <= 0 ||
-        visibility_correction > 1
-    )
+        visibility_correction > 1)
     if (vc_bad) {
       cli::cli_abort(c(
         "{.arg visibility_correction} must be a single numeric value in (0, 1].",
@@ -610,9 +627,10 @@ creel_design <- function(calendar,
       ))
     }
     # open_start validation: optional, must be non-negative numeric scalar if supplied
-    if (!is.null(open_start) && (
-      !is.numeric(open_start) || length(open_start) != 1L || open_start < 0
-    )) {
+    if (
+      !is.null(open_start) &&
+        (!is.numeric(open_start) || length(open_start) != 1L || open_start < 0)
+    ) {
       cli::cli_abort(c(
         "{.arg open_start} must be a single non-negative number (decimal hours).",
         "x" = "Supplied value {.val {open_start}} is invalid.",
@@ -620,24 +638,24 @@ creel_design <- function(calendar,
       ))
     }
     aerial <- list(
-      survey_type           = "aerial",
-      h_open                = h_open,
+      survey_type = "aerial",
+      h_open = h_open,
       visibility_correction = visibility_correction,
-      open_start            = open_start
+      open_start = open_start
     )
   }
 
   # 3. Construct and validate
   design <- new_creel_design(
-    calendar    = calendar,
-    date_col    = date_col,
+    calendar = calendar,
+    date_col = date_col,
     strata_cols = strata_cols,
-    site_col    = site_col,
+    site_col = site_col,
     design_type = survey_type,
-    bus_route   = bus_route,
-    ice         = ice,
-    camera      = camera,
-    aerial      = aerial
+    bus_route = bus_route,
+    ice = ice,
+    camera = camera,
+    aerial = aerial
   )
   validate_creel_design(design)
 }
@@ -660,15 +678,17 @@ creel_design <- function(calendar,
 #'
 #' @keywords internal
 #' @noRd
-new_creel_design <- function(calendar,
-                             date_col,
-                             strata_cols,
-                             site_col = NULL,
-                             design_type = "instantaneous",
-                             bus_route = NULL,
-                             ice = NULL,
-                             camera = NULL,
-                             aerial = NULL) {
+new_creel_design <- function(
+  calendar,
+  date_col,
+  strata_cols,
+  site_col = NULL,
+  design_type = "instantaneous",
+  bus_route = NULL,
+  ice = NULL,
+  camera = NULL,
+  aerial = NULL
+) {
   stopifnot(is.data.frame(calendar))
   stopifnot(is.character(date_col), length(date_col) == 1)
   stopifnot(is.character(strata_cols), length(strata_cols) >= 1)
@@ -681,18 +701,18 @@ new_creel_design <- function(calendar,
 
   structure(
     list(
-      calendar    = calendar,
-      date_col    = date_col,
+      calendar = calendar,
+      date_col = date_col,
       strata_cols = strata_cols,
-      site_col    = site_col,
+      site_col = site_col,
       design_type = design_type,
-      counts      = NULL,
-      survey      = NULL,
-      bus_route   = bus_route, # NULL for non-bus_route designs
-      ice         = ice, # NULL for non-ice designs
-      camera      = camera, # NULL for non-camera designs
-      aerial      = aerial, # NULL for non-aerial designs
-      sections    = NULL,
+      counts = NULL,
+      survey = NULL,
+      bus_route = bus_route, # NULL for non-bus_route designs
+      ice = ice, # NULL for non-ice designs
+      camera = camera, # NULL for non-camera designs
+      aerial = aerial, # NULL for non-aerial designs
+      sections = NULL,
       section_col = NULL
     ),
     class = "creel_design"
@@ -1061,11 +1081,16 @@ resolve_multi_cols <- function(expr, data, arg_name, error_call = rlang::caller_
 #'
 #' @family "Survey Design"
 #' @export
-add_counts <- function(design, counts, psu = NULL, count_time_col = NULL,
-                       count_type = "instantaneous",
-                       circuit_time = NULL,
-                       period_length_col = NULL,
-                       allow_invalid = FALSE) {
+add_counts <- function(
+  design,
+  counts,
+  psu = NULL,
+  count_time_col = NULL,
+  count_type = "instantaneous",
+  circuit_time = NULL,
+  period_length_col = NULL,
+  allow_invalid = FALSE
+) {
   # Validate design is creel_design
   if (!inherits(design, "creel_design")) {
     cli::cli_abort(c(
@@ -1219,12 +1244,13 @@ add_counts <- function(design, counts, psu = NULL, count_time_col = NULL,
     numeric_cols <- names(counts)[vapply(counts, is.numeric, logical(1L))]
     count_var <- setdiff(numeric_cols, excluded)[1L]
 
-    agg_result <- aggregate_within_day( # nolint: object_usage_linter
-      counts         = counts,
-      psu_col        = psu,
-      count_var      = count_var,
+    agg_result <- aggregate_within_day(
+      # nolint: object_usage_linter
+      counts = counts,
+      psu_col = psu,
+      count_var = count_var,
       count_time_col = count_time_col_name,
-      key_cols       = key_cols
+      key_cols = key_cols
     )
     counts <- agg_result$aggregated
     within_day_var <- agg_result$within_day_var
@@ -1235,11 +1261,12 @@ add_counts <- function(design, counts, psu = NULL, count_time_col = NULL,
     excluded_prog <- c(psu, design$strata_cols, design$date_col)
     numeric_cols_prog <- names(counts)[vapply(counts, is.numeric, logical(1L))]
     count_var_prog <- setdiff(numeric_cols_prog, c(excluded_prog, period_length_col_name))[1L]
-    counts <- compute_progressive_effort( # nolint: object_usage_linter
-      counts            = counts,
-      count_var         = count_var_prog,
+    counts <- compute_progressive_effort(
+      # nolint: object_usage_linter
+      counts = counts,
+      count_var = count_var_prog,
       period_length_col = period_length_col_name,
-      circuit_time      = circuit_time
+      circuit_time = circuit_time
     )
   }
 
@@ -1338,12 +1365,14 @@ add_counts <- function(design, counts, psu = NULL, count_time_col = NULL,
 #'
 #' @family "Survey Design"
 #' @export
-add_sections <- function(design,
-                         sections,
-                         section_col,
-                         description_col = NULL,
-                         area_col = NULL,
-                         shoreline_col = NULL) {
+add_sections <- function(
+  design,
+  sections,
+  section_col,
+  description_col = NULL,
+  area_col = NULL,
+  shoreline_col = NULL
+) {
   # Guard: design must be creel_design
   if (!inherits(design, "creel_design")) {
     cli::cli_abort(c(
@@ -1429,7 +1458,10 @@ add_sections <- function(design,
     NULL
   } else {
     col <- resolve_single_col(
-      shoreline_col_quo, sections, "shoreline_col", rlang::caller_env()
+      shoreline_col_quo,
+      sections,
+      "shoreline_col",
+      rlang::caller_env()
     )
     vals <- sections[[col]]
     if (!is.numeric(vals) || any(!is.finite(vals)) || any(vals <= 0)) {
@@ -1639,22 +1671,27 @@ add_sections <- function(design,
 #'
 #' @family "Survey Design"
 #' @export
-add_interviews <- function(design, interviews,
-                           catch, effort, harvest = NULL,
-                           trip_status,
-                           trip_duration = NULL,
-                           trip_start = NULL,
-                           interview_time = NULL,
-                           n_counted = NULL,
-                           n_interviewed = NULL,
-                           angler_type = NULL,
-                           angler_method = NULL,
-                           species_sought = NULL,
-                           n_anglers = 1L,
-                           refused = NULL,
-                           date_col = NULL,
-                           interview_type = c("access", "roving"),
-                           allow_invalid = FALSE) {
+add_interviews <- function(
+  design,
+  interviews,
+  catch,
+  effort,
+  harvest = NULL,
+  trip_status,
+  trip_duration = NULL,
+  trip_start = NULL,
+  interview_time = NULL,
+  n_counted = NULL,
+  n_interviewed = NULL,
+  angler_type = NULL,
+  angler_method = NULL,
+  species_sought = NULL,
+  n_anglers = 1L,
+  refused = NULL,
+  date_col = NULL,
+  interview_type = c("access", "roving"),
+  allow_invalid = FALSE
+) {
   # Capture missing status before any default resolution
   n_anglers_missing <- missing(n_anglers)
 
@@ -1773,7 +1810,10 @@ add_interviews <- function(design, interviews,
   n_counted_quo <- rlang::enquo(n_counted)
   if (!rlang::quo_is_null(n_counted_quo)) {
     n_counted_col <- resolve_single_col(
-      n_counted_quo, interviews, "n_counted", rlang::caller_env()
+      n_counted_quo,
+      interviews,
+      "n_counted",
+      rlang::caller_env()
     )
   }
 
@@ -1782,7 +1822,10 @@ add_interviews <- function(design, interviews,
   n_interviewed_quo <- rlang::enquo(n_interviewed)
   if (!rlang::quo_is_null(n_interviewed_quo)) {
     n_interviewed_col <- resolve_single_col(
-      n_interviewed_quo, interviews, "n_interviewed", rlang::caller_env()
+      n_interviewed_quo,
+      interviews,
+      "n_interviewed",
+      rlang::caller_env()
     )
   }
 
@@ -1791,7 +1834,10 @@ add_interviews <- function(design, interviews,
   angler_type_quo <- rlang::enquo(angler_type)
   if (!rlang::quo_is_null(angler_type_quo)) {
     angler_type_col <- resolve_single_col(
-      angler_type_quo, interviews, "angler_type", rlang::caller_env()
+      angler_type_quo,
+      interviews,
+      "angler_type",
+      rlang::caller_env()
     )
   }
 
@@ -1800,7 +1846,10 @@ add_interviews <- function(design, interviews,
   angler_method_quo <- rlang::enquo(angler_method)
   if (!rlang::quo_is_null(angler_method_quo)) {
     angler_method_col <- resolve_single_col(
-      angler_method_quo, interviews, "angler_method", rlang::caller_env()
+      angler_method_quo,
+      interviews,
+      "angler_method",
+      rlang::caller_env()
     )
   }
 
@@ -1809,7 +1858,10 @@ add_interviews <- function(design, interviews,
   species_sought_quo <- rlang::enquo(species_sought)
   if (!rlang::quo_is_null(species_sought_quo)) {
     species_sought_col <- resolve_single_col(
-      species_sought_quo, interviews, "species_sought", rlang::caller_env()
+      species_sought_quo,
+      interviews,
+      "species_sought",
+      rlang::caller_env()
     )
   }
 
@@ -1819,7 +1871,10 @@ add_interviews <- function(design, interviews,
     n_anglers_quo <- rlang::enquo(n_anglers)
     if (!rlang::quo_is_null(n_anglers_quo)) {
       n_anglers_col <- resolve_single_col(
-        n_anglers_quo, interviews, "n_anglers", rlang::caller_env()
+        n_anglers_quo,
+        interviews,
+        "n_anglers",
+        rlang::caller_env()
       )
     }
   }
@@ -1829,7 +1884,10 @@ add_interviews <- function(design, interviews,
   refused_quo <- rlang::enquo(refused)
   if (!rlang::quo_is_null(refused_quo)) {
     refused_col <- resolve_single_col(
-      refused_quo, interviews, "refused", rlang::caller_env()
+      refused_quo,
+      interviews,
+      "refused",
+      rlang::caller_env()
     )
   }
 
@@ -1842,25 +1900,39 @@ add_interviews <- function(design, interviews,
   interview_type <- match.arg(interview_type)
 
   # Validate interviews structure (Tier 1)
-  validation <- validate_interviews_tier1(interviews, design, catch_col, effort_col, harvest_col, date_col, allow_invalid) # nolint: object_usage_linter
+  validation <- validate_interviews_tier1(
+    interviews,
+    design,
+    catch_col,
+    effort_col,
+    harvest_col,
+    date_col,
+    allow_invalid
+  ) # nolint: object_usage_linter
 
   # Validate trip metadata
-  validate_trip_metadata(interviews, trip_status_col, trip_duration_col, trip_start_col, interview_time_col) # nolint: object_usage_linter
+  validate_trip_metadata(
+    interviews,
+    trip_status_col,
+    trip_duration_col,
+    trip_start_col,
+    interview_time_col
+  ) # nolint: object_usage_linter
 
   # Tier 3: Bus-route specific validation (skip site/circuit checks for ice)
   if (!is.null(design$bus_route) && !identical(design$design_type, "ice")) {
     validate_br_interviews_tier3(
-      interviews         = interviews,
-      design             = design,
-      n_counted_col      = n_counted_col,
-      n_interviewed_col  = n_interviewed_col
+      interviews = interviews,
+      design = design,
+      n_counted_col = n_counted_col,
+      n_interviewed_col = n_interviewed_col
     )
   }
 
   # Tier 3: Ice-specific validation — n_counted and n_interviewed required
   if (identical(design$design_type, "ice")) {
     validate_ice_interviews_tier3(
-      n_counted_col     = n_counted_col,
+      n_counted_col = n_counted_col,
       n_interviewed_col = n_interviewed_col
     )
   }
@@ -1876,11 +1948,17 @@ add_interviews <- function(design, interviews,
   # Normalize trip_status to lowercase
   interviews[[trip_status_col]] <- tolower(interviews[[trip_status_col]])
 
-  # Join interviews with calendar
+  # Join interviews with calendar on date + any shared strata columns.
+  # Using only date causes row duplication when multiple sites/strata share a date.
+  shared_strata <- intersect(design$strata_cols, colnames(interviews))
+  cal_join_by <- c(
+    stats::setNames(design$date_col, date_col),
+    stats::setNames(shared_strata, shared_strata)
+  )
   interviews_joined <- dplyr::left_join(
     interviews,
     design$calendar,
-    by = stats::setNames(design$date_col, date_col),
+    by = cal_join_by,
     suffix = c("", "_cal")
   )
 
@@ -2010,12 +2088,17 @@ add_interviews <- function(design, interviews,
   status_table <- table(tolower(new_design$interviews[[trip_status_col]]))
   n_complete <- as.integer(status_table["complete"])
   n_incomplete <- as.integer(status_table["incomplete"])
-  if (is.na(n_complete)) n_complete <- 0L
-  if (is.na(n_incomplete)) n_incomplete <- 0L
+  if (is.na(n_complete)) {
+    n_complete <- 0L
+  }
+  if (is.na(n_incomplete)) {
+    n_incomplete <- 0L
+  }
   n_total <- n_complete + n_incomplete
   pct_complete <- round(100 * n_complete / n_total, 0) # nolint: object_usage_linter
   pct_incomplete <- round(100 * n_incomplete / n_total, 0) # nolint: object_usage_linter
-  cli::cli_inform(c( # nolint: line_length_linter
+  cli::cli_inform(c(
+    # nolint: line_length_linter
     "i" = "Added {n_total} interview{?s}: {n_complete} complete ({pct_complete}%), {n_incomplete} incomplete ({pct_incomplete}%)" # nolint: line_length_linter
   ))
 
@@ -2107,8 +2190,12 @@ format.creel_design <- function(x, ...) {
         status_table <- table(tolower(x$interviews[[trip_status_col]])) # nolint: object_usage_linter
         n_complete <- as.integer(status_table["complete"]) # nolint: object_usage_linter
         n_incomplete <- as.integer(status_table["incomplete"]) # nolint: object_usage_linter
-        if (is.na(n_complete)) n_complete <- 0L
-        if (is.na(n_incomplete)) n_incomplete <- 0L
+        if (is.na(n_complete)) {
+          n_complete <- 0L
+        }
+        if (is.na(n_incomplete)) {
+          n_incomplete <- 0L
+        }
         cli::cli_text("  Trip status: {n_complete} complete, {n_incomplete} incomplete")
       }
       if (!is.null(x$angler_type_col)) {
@@ -2276,19 +2363,23 @@ format.creel_design <- function(x, ...) {
         ivw <- x$interviews
 
         cli::cli_h2("Enumeration Counts")
-        cli::cli_text("(n_counted observed, n_interviewed interviewed, expansion = n_counted/n_interviewed)")
+        cli::cli_text(
+          "(n_counted observed, n_interviewed interviewed, expansion = n_counted/n_interviewed)"
+        )
 
         # Summarize by site + circuit: sum n_counted, sum n_interviewed
         grp_keys <- c(site_col_br, circ_col_br)
         agg_nc <- stats::aggregate(
           ivw[[nc_col]],
           by = ivw[grp_keys],
-          FUN = sum, na.rm = TRUE
+          FUN = sum,
+          na.rm = TRUE
         )
         agg_ni <- stats::aggregate(
           ivw[[ni_col]],
           by = ivw[grp_keys],
-          FUN = sum, na.rm = TRUE
+          FUN = sum,
+          na.rm = TRUE
         )
         names(agg_nc)[length(agg_nc)] <- "nc_sum"
         names(agg_ni)[length(agg_ni)] <- "ni_sum"
@@ -2305,7 +2396,8 @@ format.creel_design <- function(x, ...) {
           cv <- enum_summary[[circ_col_br]][i] # nolint: object_usage_linter
           nc <- enum_summary$nc_sum[i] # nolint: object_usage_linter
           ni <- enum_summary$ni_sum[i] # nolint: object_usage_linter
-          exp_val <- if (is.na(enum_summary$expansion[i])) { # nolint: object_usage_linter
+          exp_val <- if (is.na(enum_summary$expansion[i])) {
+            # nolint: object_usage_linter
             "NA (0 interviewed)"
           } else {
             round(enum_summary$expansion[i], 2)
@@ -2662,8 +2754,12 @@ summarize_trips <- function(design) {
   status_table <- table(trip_status)
   n_complete <- as.integer(status_table["complete"])
   n_incomplete <- as.integer(status_table["incomplete"])
-  if (is.na(n_complete)) n_complete <- 0L
-  if (is.na(n_incomplete)) n_incomplete <- 0L
+  if (is.na(n_complete)) {
+    n_complete <- 0L
+  }
+  if (is.na(n_incomplete)) {
+    n_incomplete <- 0L
+  }
   n_total <- n_complete + n_incomplete
 
   # Compute percentages
@@ -2728,9 +2824,12 @@ format.creel_trip_summary <- function(x, ...) {
   # Format duration_stats table
   for (i in seq_len(nrow(x$duration_stats))) {
     row <- x$duration_stats[i, ] # nolint: object_usage_linter
-    lines <- c(lines, cli::format_inline(
-      "  {row$status}: min={row$min}, median={row$median}, mean={row$mean}, max={row$max}"
-    ))
+    lines <- c(
+      lines,
+      cli::format_inline(
+        "  {row$status}: min={row$min}, median={row$median}, mean={row$mean}, max={row$max}"
+      )
+    )
   }
   lines
 }
@@ -2758,9 +2857,7 @@ print.creel_trip_summary <- function(x, ...) {
 #'
 #' @keywords internal
 #' @noRd
-validate_br_interviews_tier3 <- function(interviews, design,
-                                         n_counted_col,
-                                         n_interviewed_col) {
+validate_br_interviews_tier3 <- function(interviews, design, n_counted_col, n_interviewed_col) {
   collection <- checkmate::makeAssertCollection()
   br <- design$bus_route
   site_col <- br$site_col
@@ -2972,12 +3069,7 @@ validate_ice_interviews_tier3 <- function(n_counted_col, n_interviewed_col) {
 #'
 #' @family "Survey Design"
 #' @export
-add_catch <- function(design, data,
-                      catch_uid,
-                      interview_uid,
-                      species,
-                      count,
-                      catch_type) {
+add_catch <- function(design, data, catch_uid, interview_uid, species, count, catch_type) {
   # Guard: must be a creel_design
   if (!inherits(design, "creel_design")) {
     cli::cli_abort(
@@ -3004,19 +3096,34 @@ add_catch <- function(design, data,
 
   # Resolve tidy selectors
   catch_uid_col <- resolve_single_col(
-    rlang::enquo(catch_uid), data, "catch_uid", rlang::caller_env()
+    rlang::enquo(catch_uid),
+    data,
+    "catch_uid",
+    rlang::caller_env()
   )
   interview_uid_col <- resolve_single_col(
-    rlang::enquo(interview_uid), design$interviews, "interview_uid", rlang::caller_env()
+    rlang::enquo(interview_uid),
+    design$interviews,
+    "interview_uid",
+    rlang::caller_env()
   )
   species_col <- resolve_single_col(
-    rlang::enquo(species), data, "species", rlang::caller_env()
+    rlang::enquo(species),
+    data,
+    "species",
+    rlang::caller_env()
   )
   count_col <- resolve_single_col(
-    rlang::enquo(count), data, "count", rlang::caller_env()
+    rlang::enquo(count),
+    data,
+    "count",
+    rlang::caller_env()
   )
   catch_type_col <- resolve_single_col(
-    rlang::enquo(catch_type), data, "catch_type", rlang::caller_env()
+    rlang::enquo(catch_type),
+    data,
+    "catch_type",
+    rlang::caller_env()
   )
 
   # Normalize catch_type to lowercase
@@ -3209,14 +3316,17 @@ add_catch <- function(design, data,
 #'
 #' @family "Survey Design"
 #' @export
-add_lengths <- function(design, data,
-                        length_uid,
-                        interview_uid,
-                        species,
-                        length,
-                        length_type,
-                        count = NULL,
-                        release_format = "individual") {
+add_lengths <- function(
+  design,
+  data,
+  length_uid,
+  interview_uid,
+  species,
+  length,
+  length_type,
+  count = NULL,
+  release_format = "individual"
+) {
   # Guard: must be a creel_design
   if (!inherits(design, "creel_design")) {
     cli::cli_abort("{.arg design} must be a {.cls creel_design} object.")
@@ -3249,19 +3359,34 @@ add_lengths <- function(design, data,
 
   # Resolve tidy selectors
   length_uid_col <- resolve_single_col(
-    rlang::enquo(length_uid), data, "length_uid", rlang::caller_env()
+    rlang::enquo(length_uid),
+    data,
+    "length_uid",
+    rlang::caller_env()
   )
   interview_uid_col <- resolve_single_col(
-    rlang::enquo(interview_uid), design$interviews, "interview_uid", rlang::caller_env()
+    rlang::enquo(interview_uid),
+    design$interviews,
+    "interview_uid",
+    rlang::caller_env()
   )
   species_col <- resolve_single_col(
-    rlang::enquo(species), data, "species", rlang::caller_env()
+    rlang::enquo(species),
+    data,
+    "species",
+    rlang::caller_env()
   )
   length_col <- resolve_single_col(
-    rlang::enquo(length), data, "length", rlang::caller_env()
+    rlang::enquo(length),
+    data,
+    "length",
+    rlang::caller_env()
   )
   type_col <- resolve_single_col(
-    rlang::enquo(length_type), data, "length_type", rlang::caller_env()
+    rlang::enquo(length_type),
+    data,
+    "length_type",
+    rlang::caller_env()
   )
 
   # Handle optional count argument — check enexpr BEFORE enquo
@@ -3411,12 +3536,7 @@ add_lengths <- function(design, data,
 #'
 #' @seealso [add_lengths()]
 #' @export
-add_ages <- function(design, data,
-                     age_uid,
-                     interview_uid,
-                     species,
-                     age,
-                     age_type) {
+add_ages <- function(design, data, age_uid, interview_uid, species, age, age_type) {
   if (!inherits(design, "creel_design")) {
     cli::cli_abort("{.arg design} must be a {.cls creel_design} object.")
   }
@@ -3434,19 +3554,34 @@ add_ages <- function(design, data,
   }
 
   age_uid_col <- resolve_single_col(
-    rlang::enquo(age_uid), data, "age_uid", rlang::caller_env()
+    rlang::enquo(age_uid),
+    data,
+    "age_uid",
+    rlang::caller_env()
   )
   interview_uid_col <- resolve_single_col(
-    rlang::enquo(interview_uid), design$interviews, "interview_uid", rlang::caller_env()
+    rlang::enquo(interview_uid),
+    design$interviews,
+    "interview_uid",
+    rlang::caller_env()
   )
   species_col <- resolve_single_col(
-    rlang::enquo(species), data, "species", rlang::caller_env()
+    rlang::enquo(species),
+    data,
+    "species",
+    rlang::caller_env()
   )
   age_col <- resolve_single_col(
-    rlang::enquo(age), data, "age", rlang::caller_env()
+    rlang::enquo(age),
+    data,
+    "age",
+    rlang::caller_env()
   )
   type_col <- resolve_single_col(
-    rlang::enquo(age_type), data, "age_type", rlang::caller_env()
+    rlang::enquo(age_type),
+    data,
+    "age_type",
+    rlang::caller_env()
   )
 
   data[[type_col]] <- tolower(data[[type_col]])
@@ -3521,10 +3656,7 @@ add_ages <- function(design, data,
 #'
 #' @family "Camera Survey"
 #' @export
-preprocess_camera_timestamps <- function(timestamps,
-                                         date_col,
-                                         ingress_col,
-                                         egress_col) {
+preprocess_camera_timestamps <- function(timestamps, date_col, ingress_col, egress_col) {
   if (!is.data.frame(timestamps)) {
     cli::cli_abort(c(
       "{.arg timestamps} must be a data frame.",

--- a/R/creel-design.R
+++ b/R/creel-design.R
@@ -152,6 +152,14 @@ VALID_SURVEY_TYPES <- c("instantaneous", "bus_route", "ice", "camera", "aerial")
 #'   aircraft. Used only when `survey_type = "aerial"`. Defaults to `1.0`
 #'   (all anglers visible) when `NULL`. A value of 0.85 means 85% of anglers
 #'   are detected; the effort estimate is scaled up by \eqn{1 / 0.85}.
+#' @param open_start Optional non-negative numeric scalar specifying the
+#'   hour of day (decimal, 24-hour clock) when the fishery opens. Used only
+#'   when `survey_type = "aerial"` and only by [estimate_effort_aerial_glmm()]
+#'   to anchor the numerical integration window. If `NULL` (default), the
+#'   GLMM estimator derives the window start from the earliest observed flight
+#'   time minus 0.5 hours, with an informational message. Supplying
+#'   `open_start` fixes the window across surveys for consistent comparisons.
+#'   Example: `open_start = 5.5` means fishing begins at 5:30 AM.
 #'
 #' @return A `creel_design` S3 object (list) with components:
 #'   \item{calendar}{The original calendar data frame}
@@ -259,7 +267,8 @@ creel_design <- function(calendar,
                          effort_type = NULL,
                          camera_mode = NULL,
                          h_open = NULL,
-                         visibility_correction = NULL) {
+                         visibility_correction = NULL,
+                         open_start = NULL) {
   # 1. Structural validation (Phase 1 validator)
   validate_calendar_schema(calendar) # nolint: object_usage_linter
 
@@ -600,10 +609,21 @@ creel_design <- function(calendar,
         "i" = "Valid range: 0 < {.arg visibility_correction} <= 1."
       ))
     }
+    # open_start validation: optional, must be non-negative numeric scalar if supplied
+    if (!is.null(open_start) && (
+      !is.numeric(open_start) || length(open_start) != 1L || open_start < 0
+    )) {
+      cli::cli_abort(c(
+        "{.arg open_start} must be a single non-negative number (decimal hours).",
+        "x" = "Supplied value {.val {open_start}} is invalid.",
+        "i" = "Example: {.code open_start = 5.5} means fishing begins at 5:30 AM."
+      ))
+    }
     aerial <- list(
       survey_type           = "aerial",
       h_open                = h_open,
-      visibility_correction = visibility_correction
+      visibility_correction = visibility_correction,
+      open_start            = open_start
     )
   }
 

--- a/R/creel-estimates-aerial-glmm.R
+++ b/R/creel-estimates-aerial-glmm.R
@@ -151,7 +151,7 @@ estimate_effort_aerial_glmm <- function(
   # Using only the observed flight range would truncate the integral and understate
   # effort for unsampled morning/evening hours — the whole point of the GLMM.
   h_open <- design$aerial$h_open
-  v      <- design$aerial$visibility_correction %||% 1.0
+  v <- design$aerial$visibility_correction %||% 1.0
   if (!is.null(design$aerial$open_start)) {
     open_start <- design$aerial$open_start
   } else {
@@ -159,13 +159,14 @@ estimate_effort_aerial_glmm <- function(
     cli::cli_inform(c(
       "i" = paste0(
         "Integration window start derived from data: ",
-        round(open_start, 2), " h (earliest flight - 0.5 h)."
+        round(open_start, 2),
+        " h (earliest flight - 0.5 h)."
       ),
       " " = "Specify {.arg open_start} in {.fn creel_design} for a fixed fishery opening time."
     ))
   }
-  open_end   <- open_start + h_open               # always spans the full fishing day
-  hour_grid  <- seq(open_start, open_end, length.out = 100)
+  open_end <- open_start + h_open # always spans the full fishing day
+  hour_grid <- seq(open_start, open_end, length.out = 100)
 
   new_data <- stats::setNames(
     data.frame(hour_grid, NA_character_, stringsAsFactors = FALSE),
@@ -176,7 +177,7 @@ estimate_effort_aerial_glmm <- function(
   x_mat <- stats::model.matrix(terms_obj, data = new_data) # nolint: object_name_linter
   beta <- lme4::fixef(model)
   mu <- as.numeric(exp(x_mat %*% beta))
-  scale_factor <- h_open / (length(hour_grid) - 1L)  # interval width: 100 pts = 99 gaps
+  scale_factor <- h_open / (length(hour_grid) - 1L) # interval width: 100 pts = 99 gaps
   # sum(mu) * scale_factor integrates the fitted count-vs-time curve over h_open
   # hours, yielding angler-hours directly. Only the visibility correction (1/v)
   # is applied — multiplying by h_open again would double-count the time dimension.
@@ -223,23 +224,24 @@ estimate_effort_aerial_glmm <- function(
 
   # 10. Assemble output
   estimates_df <- tibble::tibble(
-    estimate   = total_effort,
-    se         = se,
+    estimate = total_effort,
+    se = se,
     se_between = se_between,
-    se_within  = NA_real_,
-    ci_lower   = ci_lower,
-    ci_upper   = ci_upper,
-    n          = nrow(counts_data)
+    se_within = NA_real_,
+    ci_lower = ci_lower,
+    ci_upper = ci_upper,
+    n = nrow(counts_data)
   )
 
   variance_method_str <- if (boot) "bootstrap" else "delta"
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = estimates_df,
-    method          = "aerial_glmm_total",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = estimates_df,
+    method = "aerial_glmm_total",
     variance_method = variance_method_str,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL
   )
 }

--- a/R/creel-estimates-aerial-glmm.R
+++ b/R/creel-estimates-aerial-glmm.R
@@ -147,12 +147,23 @@ estimate_effort_aerial_glmm <- function(
   }
 
   # 7. Build prediction grid for numerical integration over the fishing day.
-  # Integrate over exactly h_open hours anchored at the earliest observed flight.
+  # Integrate over exactly h_open hours anchored at open_start.
   # Using only the observed flight range would truncate the integral and understate
   # effort for unsampled morning/evening hours — the whole point of the GLMM.
   h_open <- design$aerial$h_open
   v      <- design$aerial$visibility_correction %||% 1.0
-  open_start <- min(counts_data[[time_col_name]]) - 0.5
+  if (!is.null(design$aerial$open_start)) {
+    open_start <- design$aerial$open_start
+  } else {
+    open_start <- min(counts_data[[time_col_name]]) - 0.5
+    cli::cli_inform(c(
+      "i" = paste0(
+        "Integration window start derived from data: ",
+        round(open_start, 2), " h (earliest flight - 0.5 h)."
+      ),
+      " " = "Specify {.arg open_start} in {.fn creel_design} for a fixed fishery opening time."
+    ))
+  }
   open_end   <- open_start + h_open               # always spans the full fishing day
   hour_grid  <- seq(open_start, open_end, length.out = 100)
 

--- a/R/creel-estimates-aerial.R
+++ b/R/creel-estimates-aerial.R
@@ -21,8 +21,14 @@
 #'
 #' @keywords internal
 #' @noRd
-estimate_effort_aerial <- function(design, variance_method, conf_level, verbose,
-                                   effort_target = "sampled_days") { # nolint: object_usage_linter
+estimate_effort_aerial <- function(
+  design,
+  variance_method,
+  conf_level,
+  verbose,
+  effort_target = "sampled_days"
+) {
+  # nolint: object_usage_linter
   # Calibration constant: h_open / visibility_correction (v defaults to 1.0)
   h_over_v <- design$aerial$h_open / (design$aerial$visibility_correction %||% 1.0)
 
@@ -54,7 +60,12 @@ estimate_effort_aerial <- function(design, variance_method, conf_level, verbose,
   se_between <- as.numeric(survey::SE(svy_result)) * h_over_v
 
   # Within-day Rasmussen component (same as estimate_effort_total)
-  var_within <- compute_within_day_var_contribution(design, by_vars = NULL, target = "sampled_days") * h_over_v^2 # nolint: object_usage_linter
+  var_within <- compute_within_day_var_contribution(
+    design,
+    by_vars = NULL,
+    target = "sampled_days"
+  ) *
+    h_over_v^2 # nolint: object_usage_linter
   se_within <- sqrt(var_within)
 
   # Combined SE
@@ -70,22 +81,23 @@ estimate_effort_aerial <- function(design, variance_method, conf_level, verbose,
   n <- nrow(counts_data)
 
   estimates_df <- tibble::tibble(
-    estimate   = estimate,
-    se         = se,
+    estimate = estimate,
+    se = se,
     se_between = se_between,
-    se_within  = se_within,
-    ci_lower   = ci_lower,
-    ci_upper   = ci_upper,
-    n          = n
+    se_within = se_within,
+    ci_lower = ci_lower,
+    ci_upper = ci_upper,
+    n = n
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = estimates_df,
-    method          = "aerial_total",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = estimates_df,
+    method = "aerial_total",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL,
-    effort_target   = effort_target
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL,
+    effort_target = effort_target
   )
 }

--- a/R/creel-estimates-age.R
+++ b/R/creel-estimates-age.R
@@ -50,11 +50,13 @@
 #'
 #' @family "Estimation"
 #' @export
-est_age_distribution <- function(design,
-                                 by = NULL,
-                                 type = "catch",
-                                 variance = "taylor",
-                                 conf_level = 0.95) {
+est_age_distribution <- function(
+  design,
+  by = NULL,
+  type = "catch",
+  variance = "taylor",
+  conf_level = 0.95
+) {
   by_quo <- rlang::enquo(by)
 
   if (!inherits(design, "creel_design")) {
@@ -88,8 +90,8 @@ est_age_distribution <- function(design,
     ))
   }
 
-  if (!is.numeric(conf_level) || length(conf_level) != 1L ||
-    conf_level <= 0 || conf_level >= 1) { # nolint: indentation_linter
+  if (!is.numeric(conf_level) || length(conf_level) != 1L || conf_level <= 0 || conf_level >= 1) {
+    # nolint: indentation_linter
     cli::cli_abort(c(
       "{.arg conf_level} must be a single number in (0, 1).",
       "x" = "{.arg conf_level} is {.val {conf_level}}."
@@ -223,15 +225,34 @@ est_age_distribution <- function(design,
       for (v in by_vars) {
         group_df[[v]] <- group_info[[v]][1]
       }
-      group_df <- group_df[, c(
-        by_vars, "age", "estimate", "se", "ci_lower", "ci_upper",
-        "percent", "cumulative_percent", "n"
-      ), drop = FALSE]
+      group_df <- group_df[,
+        c(
+          by_vars,
+          "age",
+          "estimate",
+          "se",
+          "ci_lower",
+          "ci_upper",
+          "percent",
+          "cumulative_percent",
+          "n"
+        ),
+        drop = FALSE
+      ]
     } else {
-      group_df <- group_df[, c(
-        "age", "estimate", "se", "ci_lower", "ci_upper",
-        "percent", "cumulative_percent", "n"
-      ), drop = FALSE]
+      group_df <- group_df[,
+        c(
+          "age",
+          "estimate",
+          "se",
+          "ci_lower",
+          "ci_upper",
+          "percent",
+          "cumulative_percent",
+          "n"
+        ),
+        drop = FALSE
+      ]
     }
 
     result_rows[[length(result_rows) + 1L]] <- group_df
@@ -253,12 +274,14 @@ est_age_distribution <- function(design,
 #'
 #' @keywords internal
 #' @noRd
-.build_age_distribution_records <- function(ages_data, # nolint: object_length_linter
-                                            type,
-                                            by_vars,
-                                            age_col,
-                                            type_col,
-                                            interview_uid_col) {
+.build_age_distribution_records <- function(
+  ages_data, # nolint: object_length_linter
+  type,
+  by_vars,
+  age_col,
+  type_col,
+  interview_uid_col
+) {
   if (type == "harvest") {
     ages_data <- ages_data[ages_data[[type_col]] == "harvest", , drop = FALSE]
   } else if (type == "release") {
@@ -272,7 +295,9 @@ est_age_distribution <- function(design,
       .fish_count = numeric(0),
       stringsAsFactors = FALSE
     )
-    for (v in by_vars) out[[v]] <- ages_data[[v]]
+    for (v in by_vars) {
+      out[[v]] <- ages_data[[v]]
+    }
     return(out)
   }
 
@@ -290,7 +315,9 @@ est_age_distribution <- function(design,
     .fish_count = rep(1, nrow(ages_data)),
     stringsAsFactors = FALSE
   )
-  for (v in by_vars) out[[v]] <- ages_data[[v]]
+  for (v in by_vars) {
+    out[[v]] <- ages_data[[v]]
+  }
   out
 }
 
@@ -359,8 +386,8 @@ est_mean_age <- function(ad, conf_level = NULL) {
   if (is.null(conf_level)) {
     conf_level <- if (!is.null(ad_conf)) ad_conf else 0.95
   } else {
-    if (!is.numeric(conf_level) || length(conf_level) != 1L ||
-      conf_level <= 0 || conf_level >= 1) { # nolint: indentation_linter
+    if (!is.numeric(conf_level) || length(conf_level) != 1L || conf_level <= 0 || conf_level >= 1) {
+      # nolint: indentation_linter
       cli::cli_abort(c(
         "{.arg conf_level} must be a single number in (0, 1).",
         "x" = "{.arg conf_level} is {.val {conf_level}}."
@@ -369,7 +396,9 @@ est_mean_age <- function(ad, conf_level = NULL) {
   }
 
   by_vars <- attr(ad, "by_vars")
-  if (is.null(by_vars)) by_vars <- character(0)
+  if (is.null(by_vars)) {
+    by_vars <- character(0)
+  }
   z <- stats::qnorm((1 + conf_level) / 2)
 
   compute_mean_age <- function(rows) {

--- a/R/creel-estimates-age.R
+++ b/R/creel-estimates-age.R
@@ -132,6 +132,8 @@ est_age_distribution <- function(
   }
 
   result_rows <- vector("list", 0)
+  base_interviews <- design$interviews
+  uid_col <- design$ages_interview_uid_col
 
   if (length(by_vars) == 0L) {
     group_indices <- list(seq_len(nrow(records)))
@@ -174,19 +176,14 @@ est_age_distribution <- function(
       direction = "wide"
     )
     names(wide) <- sub("^age_count\\.", "", names(wide))
-    names(wide)[names(wide) == "uid"] <- design$ages_interview_uid_col
+    names(wide)[names(wide) == "uid"] <- uid_col
 
-    interviews_aug <- dplyr::left_join(
-      design$interviews,
-      wide,
-      by = design$ages_interview_uid_col
-    )
-
+    row_map <- match(base_interviews[[uid_col]], wide[[uid_col]])
+    interviews_aug <- base_interviews
     for (col in age_lookup$age_col) {
-      if (!col %in% names(interviews_aug)) {
-        interviews_aug[[col]] <- 0
-      }
-      interviews_aug[[col]][is.na(interviews_aug[[col]])] <- 0
+      val <- wide[[col]][row_map]
+      val[is.na(val)] <- 0L
+      interviews_aug[[col]] <- val
     }
 
     temp_design <- rebuild_interview_survey(design, interviews_aug) # nolint: object_usage_linter

--- a/R/creel-estimates-age.R
+++ b/R/creel-estimates-age.R
@@ -207,7 +207,7 @@ est_age_distribution <- function(
       se = ses,
       ci_lower = cis[, 1],
       ci_upper = cis[, 2],
-      n = nrow(design$interviews),
+      n = nrow(wide),
       stringsAsFactors = FALSE
     )
 

--- a/R/creel-estimates-bus-route.R
+++ b/R/creel-estimates-bus-route.R
@@ -18,29 +18,43 @@
 #'
 #' @keywords internal
 #' @noRd
-estimate_effort_br <- function(design, by_vars, variance_method, conf_level, verbose,
-                               effort_target = "sampled_days", call = rlang::caller_env()) { # nolint: object_usage_linter
+estimate_effort_br <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  verbose,
+  effort_target = "sampled_days",
+  call = rlang::caller_env()
+) {
+  # nolint: object_usage_linter
   # Retrieve interview data (contains .pi_i and .expansion from add_interviews())
   interviews <- design$interviews
 
   # Defensive check: .expansion column must exist
   if (!".expansion" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route effort estimation requires .expansion column.",
-      "x" = ".expansion not found in interview data.",
-      "i" = paste0(
-        "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
-      )
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route effort estimation requires .expansion column.",
+        "x" = ".expansion not found in interview data.",
+        "i" = paste0(
+          "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
+        )
+      ),
+      call = call
+    )
   }
 
   # Defensive check: .pi_i column must exist
   if (!".pi_i" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route effort estimation requires .pi_i column.",
-      "x" = ".pi_i not found in interview data.",
-      "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route effort estimation requires .pi_i column.",
+        "x" = ".pi_i not found in interview data.",
+        "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
+      ),
+      call = call
+    )
   }
 
   # Check for missing .pi_i values — hard error listing site+circuit combinations
@@ -54,12 +68,15 @@ estimate_effort_br <- function(design, by_vars, variance_method, conf_level, ver
       paste0(site_col, "=", r[[site_col]], ", ", circuit_col, "=", r[[circuit_col]])
     })
     msg_parts <- stats::setNames(combo_strs, rep("*", length(combo_strs)))
-    cli::cli_abort(c(
-      "Missing inclusion probability (.pi_i) for {n_combos} site+circuit combination{?s}:",
-      msg_parts,
-      "x" = "All interview site+circuit combinations must appear in the sampling frame.",
-      "i" = "Check that interview data site and circuit values match sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Missing inclusion probability (.pi_i) for {n_combos} site+circuit combination{?s}:",
+        msg_parts,
+        "x" = "All interview site+circuit combinations must appear in the sampling frame.",
+        "i" = "Check that interview data site and circuit values match sampling frame."
+      ),
+      call = call
+    )
   }
 
   # Identify the effort column stored during add_interviews()
@@ -123,7 +140,8 @@ estimate_effort_br <- function(design, by_vars, variance_method, conf_level, ver
       n = n
     )
 
-    result <- new_creel_estimates( # nolint: object_usage_linter
+    result <- new_creel_estimates(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = "total",
       variance_method = variance_method,
@@ -185,7 +203,8 @@ estimate_effort_br <- function(design, by_vars, variance_method, conf_level, ver
     col_order <- c(by_vars, "estimate", "se", "ci_lower", "ci_upper", "proportion", "n")
     estimates_df <- estimates_df[col_order]
 
-    result <- new_creel_estimates( # nolint: object_usage_linter
+    result <- new_creel_estimates(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = "total",
       variance_method = variance_method,
@@ -223,7 +242,12 @@ estimate_effort_br <- function(design, by_vars, variance_method, conf_level, ver
 #' @noRd
 estimate_harvest_br <- function(
   # nolint: object_usage_linter
-  design, by_vars, variance_method, conf_level, verbose, use_trips,
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  verbose,
+  use_trips,
   call = rlang::caller_env()
 ) {
   if (verbose) {
@@ -239,20 +263,26 @@ estimate_harvest_br <- function(
     msg <- paste0(
       "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
     )
-    cli::cli_abort(c(
-      "Bus-route harvest estimation requires .expansion column.",
-      "x" = ".expansion not found in interview data.",
-      "i" = msg
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route harvest estimation requires .expansion column.",
+        "x" = ".expansion not found in interview data.",
+        "i" = msg
+      ),
+      call = call
+    )
   }
 
   # Defensive check: .pi_i column must exist
   if (!".pi_i" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route harvest estimation requires .pi_i column.",
-      "x" = ".pi_i not found in interview data.",
-      "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route harvest estimation requires .pi_i column.",
+        "x" = ".pi_i not found in interview data.",
+        "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
+      ),
+      call = call
+    )
   }
 
   # Check for missing .pi_i values — hard error listing site+circuit combinations
@@ -266,23 +296,36 @@ estimate_harvest_br <- function(
       paste0(site_col, "=", r[[site_col]], ", ", circuit_col, "=", r[[circuit_col]])
     })
     msg_parts <- stats::setNames(combo_strs, rep("*", length(combo_strs)))
-    cli::cli_abort(c(
-      "Missing .pi_i for {n_combos} site+circuit combination{?s}:",
-      msg_parts,
-      "x" = "All interview site+circuit combinations must appear in the sampling frame.",
-      "i" = "Check that interview data site and circuit values match sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Missing .pi_i for {n_combos} site+circuit combination{?s}:",
+        msg_parts,
+        "x" = "All interview site+circuit combinations must appear in the sampling frame.",
+        "i" = "Check that interview data site and circuit values match sampling frame."
+      ),
+      call = call
+    )
   }
 
   # Diagnostic mode: run both complete and incomplete paths, return diagnostic
   if (use_trips == "diagnostic") {
     complete_result <- estimate_harvest_br(
-      design, by_vars, variance_method, conf_level,
-      verbose = FALSE, use_trips = "complete", call = call
+      design,
+      by_vars,
+      variance_method,
+      conf_level,
+      verbose = FALSE,
+      use_trips = "complete",
+      call = call
     )
     incomplete_result <- suppressWarnings(estimate_harvest_br(
-      design, by_vars, variance_method, conf_level,
-      verbose = FALSE, use_trips = "incomplete", call = call
+      design,
+      by_vars,
+      variance_method,
+      conf_level,
+      verbose = FALSE,
+      use_trips = "incomplete",
+      call = call
     ))
     result <- list(complete = complete_result, incomplete = incomplete_result)
     class(result) <- c("creel_estimates_diagnostic", "list")
@@ -329,8 +372,13 @@ estimate_harvest_br <- function(
     names(site_table)[names(site_table) == ".contribution"] <- "h_ratio_i_over_pi_i"
 
     return(br_build_estimates(
-      interviews, by_vars, variance_method, conf_level, design,
-      site_table, harvest_col
+      interviews,
+      by_vars,
+      variance_method,
+      conf_level,
+      design,
+      site_table,
+      harvest_col
     ))
   }
 
@@ -358,8 +406,13 @@ estimate_harvest_br <- function(
   names(site_table)[names(site_table) == ".contribution"] <- "h_i_over_pi_i"
 
   br_build_estimates(
-    interviews, by_vars, variance_method, conf_level, design,
-    site_table, harvest_col
+    interviews,
+    by_vars,
+    variance_method,
+    conf_level,
+    design,
+    site_table,
+    harvest_col
   )
 }
 
@@ -386,7 +439,11 @@ estimate_harvest_br <- function(
 #' @noRd
 estimate_total_catch_br <- function(
   # nolint: object_usage_linter
-  design, by_vars, variance_method, conf_level, verbose,
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  verbose,
   ci_method = "delta",
   call = rlang::caller_env()
 ) {
@@ -403,20 +460,26 @@ estimate_total_catch_br <- function(
     msg <- paste0(
       "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
     )
-    cli::cli_abort(c(
-      "Bus-route total catch estimation requires .expansion column.",
-      "x" = ".expansion not found in interview data.",
-      "i" = msg
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route total catch estimation requires .expansion column.",
+        "x" = ".expansion not found in interview data.",
+        "i" = msg
+      ),
+      call = call
+    )
   }
 
   # Defensive check: .pi_i column must exist
   if (!".pi_i" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route total catch estimation requires .pi_i column.",
-      "x" = ".pi_i not found in interview data.",
-      "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route total catch estimation requires .pi_i column.",
+        "x" = ".pi_i not found in interview data.",
+        "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
+      ),
+      call = call
+    )
   }
 
   # Check for missing .pi_i values — hard error listing site+circuit combinations
@@ -428,17 +491,25 @@ estimate_total_catch_br <- function(
     n_combos <- nrow(combos) # nolint: object_usage_linter
     combo_strs <- apply(combos, 1, function(r) {
       paste0(
-        site_col_name, "=", r[[site_col_name]], ", ",
-        circuit_col_name, "=", r[[circuit_col_name]]
+        site_col_name,
+        "=",
+        r[[site_col_name]],
+        ", ",
+        circuit_col_name,
+        "=",
+        r[[circuit_col_name]]
       )
     })
     msg_parts <- stats::setNames(combo_strs, rep("*", length(combo_strs)))
-    cli::cli_abort(c(
-      "Missing .pi_i for {n_combos} site+circuit combination{?s}:",
-      msg_parts,
-      "x" = "All interview site+circuit combinations must appear in the sampling frame.",
-      "i" = "Check that interview data site and circuit values match sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Missing .pi_i for {n_combos} site+circuit combination{?s}:",
+        msg_parts,
+        "x" = "All interview site+circuit combinations must appear in the sampling frame.",
+        "i" = "Check that interview data site and circuit values match sampling frame."
+      ),
+      call = call
+    )
   }
 
   catch_col <- design$catch_col
@@ -471,8 +542,13 @@ estimate_total_catch_br <- function(
   names(site_table)[names(site_table) == ".contribution"] <- "c_i_over_pi_i"
 
   br_build_estimates(
-    interviews, by_vars, variance_method, conf_level, design,
-    site_table, catch_col,
+    interviews,
+    by_vars,
+    variance_method,
+    conf_level,
+    design,
+    site_table,
+    catch_col,
     ci_method = ci_method
   )
 }
@@ -501,7 +577,11 @@ estimate_total_catch_br <- function(
 #' @noRd
 estimate_total_harvest_br <- function(
   # nolint: object_usage_linter
-  design, by_vars, variance_method, conf_level, verbose,
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  verbose,
   ci_method = "delta",
   call = rlang::caller_env()
 ) {
@@ -515,20 +595,26 @@ estimate_total_harvest_br <- function(
 
   # Defensive checks
   if (!".expansion" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route total harvest estimation requires .expansion column.",
-      "x" = ".expansion not found in interview data.",
-      "i" = paste0(
-        "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
-      )
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route total harvest estimation requires .expansion column.",
+        "x" = ".expansion not found in interview data.",
+        "i" = paste0(
+          "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
+        )
+      ),
+      call = call
+    )
   }
   if (!".pi_i" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route total harvest estimation requires .pi_i column.",
-      "x" = ".pi_i not found in interview data.",
-      "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route total harvest estimation requires .pi_i column.",
+        "x" = ".pi_i not found in interview data.",
+        "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
+      ),
+      call = call
+    )
   }
 
   harvest_col <- design$harvest_col
@@ -567,8 +653,13 @@ estimate_total_harvest_br <- function(
   names(site_table)[names(site_table) == ".contribution"] <- "h_i_over_pi_i"
 
   br_build_estimates(
-    interviews, by_vars, variance_method, conf_level, design,
-    site_table, harvest_col,
+    interviews,
+    by_vars,
+    variance_method,
+    conf_level,
+    design,
+    site_table,
+    harvest_col,
     ci_method = ci_method
   )
 }
@@ -597,7 +688,11 @@ estimate_total_harvest_br <- function(
 #' @noRd
 estimate_total_release_br <- function(
   # nolint: object_usage_linter
-  design, by_vars, variance_method, conf_level, verbose,
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  verbose,
   call = rlang::caller_env()
 ) {
   if (verbose) {
@@ -611,20 +706,26 @@ estimate_total_release_br <- function(
 
   # Defensive checks
   if (!".expansion" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route total release estimation requires .expansion column.",
-      "x" = ".expansion not found in interview data.",
-      "i" = paste0(
-        "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
-      )
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route total release estimation requires .expansion column.",
+        "x" = ".expansion not found in interview data.",
+        "i" = paste0(
+          "Call {.fn add_interviews} with {.arg n_counted} and {.arg n_interviewed} parameters."
+        )
+      ),
+      call = call
+    )
   }
   if (!".pi_i" %in% names(interviews)) {
-    cli::cli_abort(c(
-      "Bus-route total release estimation requires .pi_i column.",
-      "x" = ".pi_i not found in interview data.",
-      "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
-    ), call = call)
+    cli::cli_abort(
+      c(
+        "Bus-route total release estimation requires .pi_i column.",
+        "x" = ".pi_i not found in interview data.",
+        "i" = "Bus-route design must have inclusion probabilities computed via sampling frame."
+      ),
+      call = call
+    )
   }
 
   n_counted_col <- design$n_counted_col
@@ -655,8 +756,13 @@ estimate_total_release_br <- function(
   names(site_table)[names(site_table) == ".contribution"] <- "r_i_over_pi_i"
 
   br_build_estimates(
-    interviews, by_vars, variance_method, conf_level, design,
-    site_table, ".release_count"
+    interviews,
+    by_vars,
+    variance_method,
+    conf_level,
+    design,
+    site_table,
+    ".release_count"
   )
 }
 
@@ -683,7 +789,13 @@ estimate_total_release_br <- function(
 #' @noRd
 br_build_estimates <- function(
   # nolint: object_usage_linter
-  interviews, by_vars, variance_method, conf_level, design, site_table, key_col,
+  interviews,
+  by_vars,
+  variance_method,
+  conf_level,
+  design,
+  site_table,
+  key_col,
   ci_method = "delta"
 ) {
   ci_method <- match.arg(ci_method, c("delta", "bootstrap"))
@@ -715,14 +827,15 @@ br_build_estimates <- function(
     )
 
     if (ci_method == "bootstrap") {
-      svy_br_boot  <- get_variance_design(svy_br_base, "bootstrap")
+      svy_br_boot <- get_variance_design(svy_br_base, "bootstrap")
       svy_boot_res <- suppressWarnings(survey::svytotal(~.contribution, svy_br_boot))
-      ci_boot      <- confint(svy_boot_res, level = conf_level)
+      ci_boot <- confint(svy_boot_res, level = conf_level)
       estimates_df$ci_lo_boot <- ci_boot[1, 1]
       estimates_df$ci_hi_boot <- ci_boot[1, 2]
     }
 
-    result <- new_creel_estimates( # nolint: object_usage_linter
+    result <- new_creel_estimates(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = "total",
       variance_method = variance_method,
@@ -781,19 +894,20 @@ br_build_estimates <- function(
     if (ci_method == "bootstrap") {
       svy_br_boot <- get_variance_design(svy_br_base, "bootstrap")
       svy_boot_by <- suppressWarnings(survey::svyby(
-        formula    = ~.contribution,
-        by         = by_formula,
-        design     = svy_br_boot,
-        FUN        = survey::svytotal,
-        vartype    = c("se", "ci"),
-        ci.level   = conf_level,
+        formula = ~.contribution,
+        by = by_formula,
+        design = svy_br_boot,
+        FUN = survey::svytotal,
+        vartype = c("se", "ci"),
+        ci.level = conf_level,
         keep.names = FALSE
       ))
       estimates_df$ci_lo_boot <- svy_boot_by[["ci_l"]]
       estimates_df$ci_hi_boot <- svy_boot_by[["ci_u"]]
     }
 
-    result <- new_creel_estimates( # nolint: object_usage_linter
+    result <- new_creel_estimates(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = "total",
       variance_method = variance_method,

--- a/R/creel-estimates-camera.R
+++ b/R/creel-estimates-camera.R
@@ -60,8 +60,10 @@ estimate_effort_camera <- function(
 
   # Identify count variable
   excluded_cols <- c(
-    design$date_col, design$strata_cols,
-    design$psu_col, "camera_status"
+    design$date_col,
+    design$strata_cols,
+    design$psu_col,
+    "camera_status"
   )
   num_cols <- names(counts_data)[vapply(counts_data, is.numeric, logical(1L))]
   count_var <- if (!is.null(intercept_col) && intercept_col %in% names(counts_data)) {
@@ -102,7 +104,10 @@ estimate_effort_camera <- function(
 
       # Aggregate to daily effort totals (hours/day on interview days)
       daily_effort <- tapply(
-        int_sub[[effort_col]], int_sub[[date_col]], sum, na.rm = TRUE
+        int_sub[[effort_col]],
+        int_sub[[date_col]],
+        sum,
+        na.rm = TRUE
       )
       int_dates <- names(daily_effort)
 
@@ -137,11 +142,11 @@ estimate_effort_camera <- function(
       }
 
       data.frame(
-        stratum   = s,
-        rho       = rho,
-        var_rho   = var_rho,
-        n_cam     = nrow(cnt_sub),
-        n_int     = nrow(int_sub),
+        stratum = s,
+        rho = rho,
+        var_rho = var_rho,
+        n_cam = nrow(cnt_sub),
+        n_int = nrow(int_sub),
         stringsAsFactors = FALSE
       )
     })
@@ -161,16 +166,16 @@ estimate_effort_camera <- function(
       )
     )
 
-    strata_order   <- as.character(svy_raw[[strata_col]])
-    rho_matched    <- cal$rho[match(strata_order, as.character(cal$stratum))]
+    strata_order <- as.character(svy_raw[[strata_col]])
+    rho_matched <- cal$rho[match(strata_order, as.character(cal$stratum))]
     var_rho_matched <- cal$var_rho[match(strata_order, as.character(cal$stratum))]
-    total_counts_h  <- as.numeric(coef(svy_raw))
+    total_counts_h <- as.numeric(coef(svy_raw))
 
     estimate <- sum(total_counts_h * rho_matched)
     # SE via delta method: Var(E_h) = rho_h^2 * Var(total_count_h) + total_count_h^2 * Var(rho_h)
     se_between <- sqrt(
       sum((survey::SE(svy_raw) * rho_matched)^2) +
-      sum(total_counts_h^2 * var_rho_matched)
+        sum(total_counts_h^2 * var_rho_matched)
     )
     method_label <- "camera_ratio"
   } else {
@@ -206,21 +211,22 @@ estimate_effort_camera <- function(
   n <- nrow(counts_data)
 
   estimates_df <- tibble::tibble(
-    estimate   = estimate,
-    se         = se,
+    estimate = estimate,
+    se = se,
     se_between = se_between,
-    se_within  = 0,
-    ci_lower   = ci_lower,
-    ci_upper   = ci_upper,
-    n          = n
+    se_within = 0,
+    ci_lower = ci_lower,
+    ci_upper = ci_upper,
+    n = n
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = estimates_df,
-    method          = method_label,
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = estimates_df,
+    method = method_label,
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL
   )
 }

--- a/R/creel-estimates-exploitation-rate.R
+++ b/R/creel-estimates-exploitation-rate.R
@@ -135,52 +135,62 @@
 #' )
 #' print(result_strat)
 estimate_exploitation_rate <- function(
-    T              = NULL,
-    C              = NULL,
-    se_C           = NULL,
-    n              = NULL,
-    m              = NULL,
-    conf_level     = 0.95,
-    reporting_rate = 1.0,
-    strata         = NULL,
-    by             = NULL,
-    aggregate      = TRUE
+  T = NULL,
+  C = NULL,
+  se_C = NULL,
+  n = NULL,
+  m = NULL,
+  conf_level = 0.95,
+  reporting_rate = 1.0,
+  strata = NULL,
+  by = NULL,
+  aggregate = TRUE
 ) {
   # Route to stratified path if strata data frame provided
   if (!is.null(strata)) {
     return(.estimate_exploitation_rate_stratified(
-      strata, by = if (is.null(by)) "stratum" else by,
-      aggregate = aggregate, conf_level = conf_level,
+      strata,
+      by = if (is.null(by)) "stratum" else by,
+      aggregate = aggregate,
+      conf_level = conf_level,
       reporting_rate = reporting_rate
     ))
   }
 
   # --- input validation (unstratified path) ---
-  if (T <= 0)
+  if (T <= 0) {
     cli::cli_abort("{.arg T} must be > 0, not {T}.")
-  if (n <= 0)
+  }
+  if (n <= 0) {
     cli::cli_abort("{.arg n} must be > 0, not {n}.")
-  if (m > n)
+  }
+  if (m > n) {
     cli::cli_abort("{.arg m} ({m}) cannot exceed {.arg n} ({n}).")
-  if (m < 0)
+  }
+  if (m < 0) {
     cli::cli_abort("{.arg m} must be >= 0.")
-  if (C < 0)
+  }
+  if (C < 0) {
     cli::cli_abort("{.arg C} must be >= 0.")
-  if (se_C < 0)
+  }
+  if (se_C < 0) {
     cli::cli_abort("{.arg se_C} must be >= 0.")
-  if (reporting_rate <= 0 || reporting_rate > 1)
+  }
+  if (reporting_rate <= 0 || reporting_rate > 1) {
     cli::cli_abort("{.arg reporting_rate} must be in (0, 1], not {reporting_rate}.")
+  }
 
   # --- point estimate ---
   p_hat <- m / n
   r_hat <- C / T
-  u_hat <- r_hat * p_hat / reporting_rate   # adjust for reporting rate
+  u_hat <- r_hat * p_hat / reporting_rate # adjust for reporting rate
 
   if (u_hat > 1 || u_hat < 0) {
     cli::cli_warn(
       c(
         "!" = paste0(
-          "Estimated exploitation rate ", round(u_hat, 4),
+          "Estimated exploitation rate ",
+          round(u_hat, 4),
           " is outside [0, 1]. ",
           "Check {.arg C}, {.arg T}, and {.arg m}. CI will be clamped to [0, 1]."
         )
@@ -204,10 +214,10 @@ estimate_exploitation_rate <- function(
   var_p <- p_for_var * (1 - p_for_var) / n
   var_r <- se_C^2 / T^2
   var_u <- (r_hat^2 * var_p + p_hat^2 * var_r) / reporting_rate^2
-  se_u  <- sqrt(var_u)
+  se_u <- sqrt(var_u)
 
   # --- CI ---
-  z     <- stats::qnorm(1 - (1 - conf_level) / 2)
+  z <- stats::qnorm(1 - (1 - conf_level) / 2)
   ci_lo <- max(0, u_hat - z * se_u)
   ci_hi <- min(1, u_hat + z * se_u)
 
@@ -215,27 +225,30 @@ estimate_exploitation_rate <- function(
   new_creel_estimates(
     estimates = tibble::tibble(
       estimate = u_hat,
-      se       = se_u,
+      se = se_u,
       ci_lower = ci_lo,
       ci_upper = ci_hi,
-      n        = n,
-      T        = T,
-      C        = C,
-      m        = m
+      n = n,
+      T = T,
+      C = C,
+      m = m
     ),
-    method          = "exploitation-rate",
+    method = "exploitation-rate",
     variance_method = "delta",
-    design          = NULL,
-    conf_level      = conf_level,
-    by_vars         = NULL
+    design = NULL,
+    conf_level = conf_level,
+    by_vars = NULL
   )
 }
 
 # Internal helper: stratified exploitation rate estimator ----
 
 .estimate_exploitation_rate_stratified <- function(
-    strata, by = "stratum", aggregate = TRUE,
-    conf_level = 0.95, reporting_rate = 1.0
+  strata,
+  by = "stratum",
+  aggregate = TRUE,
+  conf_level = 0.95,
+  reporting_rate = 1.0
 ) {
   # Validate required columns
   req_cols <- c(by, "T_h", "C_h", "se_C_h", "n_h", "m_h")
@@ -245,15 +258,15 @@ estimate_exploitation_rate <- function(
   }
 
   # Per-stratum estimates (vectorised)
-  T_h    <- strata[["T_h"]]
-  C_h    <- strata[["C_h"]]
+  T_h <- strata[["T_h"]]
+  C_h <- strata[["C_h"]]
   se_C_h <- strata[["se_C_h"]]
-  n_h    <- strata[["n_h"]]
-  m_h    <- strata[["m_h"]]
+  n_h <- strata[["n_h"]]
+  m_h <- strata[["m_h"]]
 
-  p_h    <- m_h / n_h
-  r_h    <- C_h / T_h
-  u_h    <- r_h * p_h / reporting_rate
+  p_h <- m_h / n_h
+  r_h <- C_h / T_h
+  u_h <- r_h * p_h / reporting_rate
 
   # Half-observation correction for strata with zero recoveries (same logic as
   # the unstratified path): Wald var collapses to 0 when m_h=0, producing false
@@ -270,51 +283,51 @@ estimate_exploitation_rate <- function(
   var_p_h <- p_for_var_h * (1 - p_for_var_h) / n_h
   var_r_h <- se_C_h^2 / T_h^2
   var_u_h <- (r_h^2 * var_p_h + p_h^2 * var_r_h) / reporting_rate^2
-  se_u_h  <- sqrt(var_u_h)
+  se_u_h <- sqrt(var_u_h)
 
   z <- stats::qnorm(1 - (1 - conf_level) / 2)
 
   stratum_rows <- tibble::tibble(
-    stratum  = strata[[by]],
+    stratum = strata[[by]],
     estimate = u_h,
-    se       = se_u_h,
+    se = se_u_h,
     ci_lower = pmax(0, u_h - z * se_u_h),
     ci_upper = pmin(1, u_h + z * se_u_h),
-    n        = n_h,
-    T        = T_h,
-    C        = C_h,
-    m        = m_h
+    n = n_h,
+    T = T_h,
+    C = C_h,
+    m = m_h
   )
   # Rename stratum col to match by
   names(stratum_rows)[1] <- by
 
   if (aggregate) {
-    sum_T    <- sum(T_h)
-    u_agg    <- sum(T_h * u_h) / sum_T
-    var_agg  <- sum(T_h^2 * var_u_h) / sum_T^2
-    se_agg   <- sqrt(var_agg)
+    sum_T <- sum(T_h)
+    u_agg <- sum(T_h * u_h) / sum_T
+    var_agg <- sum(T_h^2 * var_u_h) / sum_T^2
+    se_agg <- sqrt(var_agg)
 
     overall_row <- tibble::tibble(
-      stratum  = ".overall",
+      stratum = ".overall",
       estimate = u_agg,
-      se       = se_agg,
+      se = se_agg,
       ci_lower = max(0, u_agg - z * se_agg),
       ci_upper = min(1, u_agg + z * se_agg),
-      n        = sum(n_h),
-      T        = sum_T,
-      C        = sum(C_h),
-      m        = sum(m_h)
+      n = sum(n_h),
+      T = sum_T,
+      C = sum(C_h),
+      m = sum(m_h)
     )
     names(overall_row)[1] <- by
     stratum_rows <- dplyr::bind_rows(stratum_rows, overall_row)
   }
 
   new_creel_estimates(
-    estimates       = stratum_rows,
-    method          = "exploitation-rate",
+    estimates = stratum_rows,
+    method = "exploitation-rate",
     variance_method = "delta",
-    design          = NULL,
-    conf_level      = conf_level,
-    by_vars         = by
+    design = NULL,
+    conf_level = conf_level,
+    by_vars = by
   )
 }

--- a/R/creel-estimates-length.R
+++ b/R/creel-estimates-length.R
@@ -265,7 +265,7 @@ est_length_distribution <- function(
       se = ses,
       ci_lower = cis[, 1],
       ci_upper = cis[, 2],
-      n = nrow(design$interviews),
+      n = nrow(wide),
       stringsAsFactors = FALSE
     )
 

--- a/R/creel-estimates-length.R
+++ b/R/creel-estimates-length.R
@@ -179,6 +179,8 @@ est_length_distribution <- function(
 
   ordered_labs <- bin_labels[bin_labels %in% as.character(unique(records$length_bin))]
   result_rows <- vector("list", 0)
+  base_interviews <- design$interviews
+  uid_col <- design$lengths_interview_uid_col
 
   if (length(by_vars) == 0L) {
     group_indices <- list(seq_len(nrow(records)))
@@ -226,19 +228,14 @@ est_length_distribution <- function(
       direction = "wide"
     )
     names(wide) <- sub("^bin_count\\.", "", names(wide))
-    names(wide)[names(wide) == "uid"] <- design$lengths_interview_uid_col
+    names(wide)[names(wide) == "uid"] <- uid_col
 
-    interviews_aug <- dplyr::left_join(
-      design$interviews,
-      wide,
-      by = design$lengths_interview_uid_col
-    )
-
+    row_map <- match(base_interviews[[uid_col]], wide[[uid_col]])
+    interviews_aug <- base_interviews
     for (col in bin_lookup$bin_col) {
-      if (!col %in% names(interviews_aug)) {
-        interviews_aug[[col]] <- 0
-      }
-      interviews_aug[[col]][is.na(interviews_aug[[col]])] <- 0
+      val <- wide[[col]][row_map]
+      val[is.na(val)] <- 0L
+      interviews_aug[[col]] <- val
     }
 
     temp_design <- rebuild_interview_survey(design, interviews_aug) # nolint: object_usage_linter

--- a/R/creel-estimates-length.R
+++ b/R/creel-estimates-length.R
@@ -58,13 +58,15 @@
 #'
 #' @family "Estimation"
 #' @export
-est_length_distribution <- function(design,
-                                    type = "catch",
-                                    by = NULL,
-                                    bin_width = 1,
-                                    length_col = NULL,
-                                    variance = "taylor",
-                                    conf_level = 0.95) {
+est_length_distribution <- function(
+  design,
+  type = "catch",
+  by = NULL,
+  bin_width = 1,
+  length_col = NULL,
+  variance = "taylor",
+  conf_level = 0.95
+) {
   by_quo <- rlang::enquo(by)
 
   if (!inherits(design, "creel_design")) {
@@ -105,8 +107,8 @@ est_length_distribution <- function(design,
     ))
   }
 
-  if (!is.numeric(conf_level) || length(conf_level) != 1L ||
-    conf_level <= 0 || conf_level >= 1) { # nolint: indentation_linter
+  if (!is.numeric(conf_level) || length(conf_level) != 1L || conf_level <= 0 || conf_level >= 1) {
+    # nolint: indentation_linter
     cli::cli_abort(c(
       "{.arg conf_level} must be a single number in (0, 1).",
       "x" = "{.arg conf_level} is {.val {conf_level}}."
@@ -281,11 +283,22 @@ est_length_distribution <- function(design,
       for (v in by_vars) {
         group_df[[v]] <- group_info[[v]][1]
       }
-      group_df <- group_df[, c(
-        by_vars, "length_bin", "bin_lower", "bin_upper",
-        "estimate", "se", "ci_lower", "ci_upper", "percent",
-        "cumulative_percent", "n"
-      ), drop = FALSE]
+      group_df <- group_df[,
+        c(
+          by_vars,
+          "length_bin",
+          "bin_lower",
+          "bin_upper",
+          "estimate",
+          "se",
+          "ci_lower",
+          "ci_upper",
+          "percent",
+          "cumulative_percent",
+          "n"
+        ),
+        drop = FALSE
+      ]
     }
 
     result_rows[[length(result_rows) + 1L]] <- group_df
@@ -308,14 +321,16 @@ est_length_distribution <- function(design,
 #'
 #' @keywords internal
 #' @noRd
-build_length_distribution_records <- function(lengths_data, # nolint: object_length_linter
-                                              type,
-                                              by_vars,
-                                              length_col,
-                                              type_col,
-                                              count_col,
-                                              interview_uid_col,
-                                              release_format) {
+build_length_distribution_records <- function(
+  lengths_data, # nolint: object_length_linter
+  type,
+  by_vars,
+  length_col,
+  type_col,
+  count_col,
+  interview_uid_col,
+  release_format
+) {
   if (type == "harvest") {
     lengths_data <- lengths_data[lengths_data[[type_col]] == "harvest", , drop = FALSE]
   } else if (type == "release") {
@@ -333,7 +348,9 @@ build_length_distribution_records <- function(lengths_data, # nolint: object_len
         .fish_count = numeric(0),
         stringsAsFactors = FALSE
       )
-      for (v in by_vars) out[[v]] <- rows[[v]]
+      for (v in by_vars) {
+        out[[v]] <- rows[[v]]
+      }
       return(out)
     }
 
@@ -372,7 +389,9 @@ build_length_distribution_records <- function(lengths_data, # nolint: object_len
       .fish_count = fish_count,
       stringsAsFactors = FALSE
     )
-    for (v in by_vars) out[[v]] <- rows[[v]]
+    for (v in by_vars) {
+      out[[v]] <- rows[[v]]
+    }
     out
   }
 
@@ -476,8 +495,8 @@ est_biomass <- function(ld, a, b, conf_level = NULL) {
   if (is.null(conf_level)) {
     conf_level <- if (!is.null(ld_conf)) ld_conf else 0.95
   } else {
-    if (!is.numeric(conf_level) || length(conf_level) != 1L ||
-      conf_level <= 0 || conf_level >= 1) { # nolint: indentation_linter
+    if (!is.numeric(conf_level) || length(conf_level) != 1L || conf_level <= 0 || conf_level >= 1) {
+      # nolint: indentation_linter
       cli::cli_abort(c(
         "{.arg conf_level} must be a single number in (0, 1).",
         "x" = "{.arg conf_level} is {.val {conf_level}}."
@@ -486,7 +505,9 @@ est_biomass <- function(ld, a, b, conf_level = NULL) {
   }
 
   by_vars <- attr(ld, "by_vars")
-  if (is.null(by_vars)) by_vars <- character(0)
+  if (is.null(by_vars)) {
+    by_vars <- character(0)
+  }
 
   z <- stats::qnorm((1 + conf_level) / 2)
 
@@ -595,8 +616,8 @@ est_mean_length <- function(ld, conf_level = NULL) {
   if (is.null(conf_level)) {
     conf_level <- if (!is.null(ld_conf)) ld_conf else 0.95
   } else {
-    if (!is.numeric(conf_level) || length(conf_level) != 1L ||
-      conf_level <= 0 || conf_level >= 1) { # nolint: indentation_linter
+    if (!is.numeric(conf_level) || length(conf_level) != 1L || conf_level <= 0 || conf_level >= 1) {
+      # nolint: indentation_linter
       cli::cli_abort(c(
         "{.arg conf_level} must be a single number in (0, 1).",
         "x" = "{.arg conf_level} is {.val {conf_level}}."
@@ -605,7 +626,9 @@ est_mean_length <- function(ld, conf_level = NULL) {
   }
 
   by_vars <- attr(ld, "by_vars")
-  if (is.null(by_vars)) by_vars <- character(0)
+  if (is.null(by_vars)) {
+    by_vars <- character(0)
+  }
   z <- stats::qnorm((1 + conf_level) / 2)
 
   compute_mean_length <- function(rows) {
@@ -712,8 +735,8 @@ est_compliance <- function(ld, min_length, conf_level = NULL) {
       "i" = "Create one with {.fn est_length_distribution}."
     ))
   }
-  if (!is.numeric(min_length) || length(min_length) != 1L ||
-    is.na(min_length) || min_length <= 0) { # nolint: indentation_linter
+  if (!is.numeric(min_length) || length(min_length) != 1L || is.na(min_length) || min_length <= 0) {
+    # nolint: indentation_linter
     cli::cli_abort(c(
       "{.arg min_length} must be a single positive number.",
       "x" = "{.arg min_length} is {.val {min_length}}."
@@ -724,8 +747,8 @@ est_compliance <- function(ld, min_length, conf_level = NULL) {
   if (is.null(conf_level)) {
     conf_level <- if (!is.null(ld_conf)) ld_conf else 0.95
   } else {
-    if (!is.numeric(conf_level) || length(conf_level) != 1L ||
-      conf_level <= 0 || conf_level >= 1) { # nolint: indentation_linter
+    if (!is.numeric(conf_level) || length(conf_level) != 1L || conf_level <= 0 || conf_level >= 1) {
+      # nolint: indentation_linter
       cli::cli_abort(c(
         "{.arg conf_level} must be a single number in (0, 1).",
         "x" = "{.arg conf_level} is {.val {conf_level}}."
@@ -734,7 +757,9 @@ est_compliance <- function(ld, min_length, conf_level = NULL) {
   }
 
   by_vars <- attr(ld, "by_vars")
-  if (is.null(by_vars)) by_vars <- character(0)
+  if (is.null(by_vars)) {
+    by_vars <- character(0)
+  }
   z <- stats::qnorm((1 + conf_level) / 2)
 
   compute_compliance <- function(rows) {

--- a/R/creel-estimates-mark-recapture.R
+++ b/R/creel-estimates-mark-recapture.R
@@ -69,9 +69,16 @@
 #'   method = "schnabel"
 #' )
 #' print(result_s)
-estimate_angler_n <- function(M, n, m, method = "chapman", conf_level = 0.95,
-                              ci_method = c("delta", "bootstrap"), B = 2000L) {
-  method    <- match.arg(method, c("chapman", "petersen", "schnabel"))
+estimate_angler_n <- function(
+  M,
+  n,
+  m,
+  method = "chapman",
+  conf_level = 0.95,
+  ci_method = c("delta", "bootstrap"),
+  B = 2000L
+) {
+  method <- match.arg(method, c("chapman", "petersen", "schnabel"))
   ci_method <- match.arg(ci_method)
 
   # Coerce to numeric before validation to prevent integer overflow in products
@@ -81,43 +88,59 @@ estimate_angler_n <- function(M, n, m, method = "chapman", conf_level = 0.95,
   m <- as.numeric(m)
 
   # --- input validation ---
-  if (any(n <= 0))
+  if (any(n <= 0)) {
     cli::cli_abort("{.arg n} must be > 0.")
-  if (any(m < 0))
+  }
+  if (any(m < 0)) {
     cli::cli_abort("{.arg m} must be >= 0.")
+  }
 
   if (method == "schnabel") {
     # Schnabel: length checks must come before any per-element guards
-    if (!all(lengths(list(M, n, m)) == length(M)))
-      cli::cli_abort("{.arg M}, {.arg n}, and {.arg m} must be the same length for method = 'schnabel'.")
-    if (length(M) < 2L)
+    if (!all(lengths(list(M, n, m)) == length(M))) {
+      cli::cli_abort(
+        "{.arg M}, {.arg n}, and {.arg m} must be the same length for method = 'schnabel'."
+      )
+    }
+    if (length(M) < 2L) {
       cli::cli_abort(c(
         "Schnabel requires >= 2 occasions.",
         "i" = "Use {.code method = 'chapman'} or {.code method = 'petersen'} for a single occasion."
       ))
+    }
     # For Schnabel, M[1] = 0 is valid (no marked fish at large before first sample)
-    if (any(M < 0))
+    if (any(M < 0)) {
       cli::cli_abort("{.arg M} must be >= 0.")
-    if (any(m > pmin(M, n)))
+    }
+    if (any(m > pmin(M, n))) {
       cli::cli_abort("{.arg m} cannot exceed {.code min(M, n)} at any occasion.")
-    if (sum(m) == 0L)
-      cli::cli_abort("Total recaptures {.code sum(m)} is 0. Schnabel requires at least one recapture.")
+    }
+    if (sum(m) == 0L) {
+      cli::cli_abort(
+        "Total recaptures {.code sum(m)} is 0. Schnabel requires at least one recapture."
+      )
+    }
   } else {
     # single-occasion guards (Chapman and Petersen)
-    if (M <= 0)
+    if (M <= 0) {
       cli::cli_abort("{.arg M} must be > 0.")
-    if (m == 0)
+    }
+    if (m == 0) {
       cli::cli_abort("{.arg m} = 0: no recaptures makes N_hat undefined. Increase sampling effort.")
-    if (m > n)
+    }
+    if (m > n) {
       cli::cli_abort("{.arg m} ({m}) cannot exceed {.arg n} ({n}).")
-    if (m > M)
+    }
+    if (m > M) {
       cli::cli_abort("{.arg m} ({m}) cannot exceed {.arg M} ({M}).")
-    if (method == "petersen" && m < 7L)
+    }
+    if (method == "petersen" && m < 7L) {
       cli::cli_abort(c(
         "{.arg m} = {m} is too small for the Petersen estimator.",
         "i" = "Petersen requires m >= 7 to avoid large positive bias.",
         "i" = "Use {.code method = 'chapman'} instead."
       ))
+    }
   }
 
   if (method == "chapman") {
@@ -126,103 +149,105 @@ estimate_angler_n <- function(M, n, m, method = "chapman", conf_level = 0.95,
 
     # --- variance ---
     var_N <- ((M + 1) * (n + 1) * (M - m) * (n - m)) / ((m + 2) * (m + 1)^2)
-    se_N  <- sqrt(var_N)
+    se_N <- sqrt(var_N)
 
     # --- CI ---
-    z     <- stats::qnorm(1 - (1 - conf_level) / 2)
+    z <- stats::qnorm(1 - (1 - conf_level) / 2)
     ci_lo <- N_hat - z * se_N
     ci_hi <- N_hat + z * se_N
 
     # --- return ---
     estimates_df <- tibble::tibble(
       parameter = "N_hat",
-      estimate  = N_hat,
-      se        = se_N,
-      ci_lower  = ci_lo,
-      ci_upper  = ci_hi,
-      n         = as.integer(m)
+      estimate = N_hat,
+      se = se_N,
+      ci_lower = ci_lo,
+      ci_upper = ci_hi,
+      n = as.integer(m)
     )
     if (ci_method == "bootstrap") {
       m_b <- stats::rbinom(B, size = n, prob = m / n)
       # No zero-guard needed: denominator is (m_b + 1), never zero even when m_b = 0.
       # Zero-guard belongs only on the Petersen path where m_b is the bare denominator.
-      N_hat_b    <- ((M + 1L) * (n + 1L)) / (m_b + 1L) - 1
-      alpha      <- 1 - conf_level
-      ci_lo_boot <- stats::quantile(N_hat_b, alpha / 2,       names = FALSE)
-      ci_hi_boot <- stats::quantile(N_hat_b, 1 - alpha / 2,   names = FALSE)
+      N_hat_b <- ((M + 1L) * (n + 1L)) / (m_b + 1L) - 1
+      alpha <- 1 - conf_level
+      ci_lo_boot <- stats::quantile(N_hat_b, alpha / 2, names = FALSE)
+      ci_hi_boot <- stats::quantile(N_hat_b, 1 - alpha / 2, names = FALSE)
       estimates_df$ci_lo_boot <- ci_lo_boot
       estimates_df$ci_hi_boot <- ci_hi_boot
     }
     result <- new_creel_estimates(
-      estimates       = estimates_df,
-      method          = "mark-recapture-chapman",
+      estimates = estimates_df,
+      method = "mark-recapture-chapman",
       variance_method = "chapman",
-      design          = NULL,
-      conf_level      = conf_level,
-      by_vars         = NULL
+      design = NULL,
+      conf_level = conf_level,
+      by_vars = NULL
     )
-    if (ci_method == "bootstrap") attr(result, "boot_samples") <- N_hat_b
+    if (ci_method == "bootstrap") {
+      attr(result, "boot_samples") <- N_hat_b
+    }
     result
-
   } else if (method == "petersen") {
     # --- point estimate ---
     N_hat <- (M * n) / m
 
     # --- variance (equivalent form: N_hat^2 * (1/m - 1/n)) ---
     var_N <- N_hat^2 * (1 / m - 1 / n)
-    se_N  <- sqrt(var_N)
+    se_N <- sqrt(var_N)
 
     # --- CI ---
-    z     <- stats::qnorm(1 - (1 - conf_level) / 2)
+    z <- stats::qnorm(1 - (1 - conf_level) / 2)
     ci_lo <- N_hat - z * se_N
     ci_hi <- N_hat + z * se_N
 
     # --- return ---
     estimates_df <- tibble::tibble(
       parameter = "N_hat",
-      estimate  = N_hat,
-      se        = se_N,
-      ci_lower  = ci_lo,
-      ci_upper  = ci_hi,
-      n         = as.integer(m)
+      estimate = N_hat,
+      se = se_N,
+      ci_lower = ci_lo,
+      ci_upper = ci_hi,
+      n = as.integer(m)
     )
     if (ci_method == "bootstrap") {
       m_b <- stats::rbinom(B, size = n, prob = m / n)
       m_b[m_b == 0L] <- 1L
-      N_hat_b    <- (M * n) / m_b
-      alpha      <- 1 - conf_level
-      ci_lo_boot <- stats::quantile(N_hat_b, alpha / 2,       names = FALSE)
-      ci_hi_boot <- stats::quantile(N_hat_b, 1 - alpha / 2,   names = FALSE)
+      N_hat_b <- (M * n) / m_b
+      alpha <- 1 - conf_level
+      ci_lo_boot <- stats::quantile(N_hat_b, alpha / 2, names = FALSE)
+      ci_hi_boot <- stats::quantile(N_hat_b, 1 - alpha / 2, names = FALSE)
       estimates_df$ci_lo_boot <- ci_lo_boot
       estimates_df$ci_hi_boot <- ci_hi_boot
     }
     result <- new_creel_estimates(
-      estimates       = estimates_df,
-      method          = "mark-recapture-petersen",
+      estimates = estimates_df,
+      method = "mark-recapture-petersen",
       variance_method = "petersen",
-      design          = NULL,
-      conf_level      = conf_level,
-      by_vars         = NULL
+      design = NULL,
+      conf_level = conf_level,
+      by_vars = NULL
     )
-    if (ci_method == "bootstrap") attr(result, "boot_samples") <- N_hat_b
+    if (ci_method == "bootstrap") {
+      attr(result, "boot_samples") <- N_hat_b
+    }
     result
-
   } else {
     # method == "schnabel"
     # --- point estimate ---
     sum_Mn <- sum(M * n)
-    sum_m  <- sum(m)
-    N_hat  <- sum_Mn / sum_m
+    sum_m <- sum(m)
+    N_hat <- sum_Mn / sum_m
 
     # --- SE (delta method on 1/N_hat) ---
     se_inv <- sqrt(sum_m / sum_Mn^2)
-    se_N   <- N_hat^2 * se_inv
+    se_N <- N_hat^2 * se_inv
 
     # --- CI ---
     alpha <- 1 - conf_level
     if (sum_m < 50L) {
-      lo_m  <- stats::qpois(alpha / 2,       lambda = sum_m)
-      hi_m  <- stats::qpois(1 - alpha / 2,   lambda = sum_m)
+      lo_m <- stats::qpois(alpha / 2, lambda = sum_m)
+      hi_m <- stats::qpois(1 - alpha / 2, lambda = sum_m)
       # Guard against hi_m == 0 (degenerate Poisson quantile)
       ci_lo <- if (hi_m == 0) Inf else sum_Mn / hi_m
       if (lo_m == 0L) {
@@ -230,7 +255,7 @@ estimate_angler_n <- function(M, n, m, method = "chapman", conf_level = 0.95,
       }
       ci_hi <- if (lo_m == 0L) Inf else sum_Mn / lo_m
     } else {
-      z     <- stats::qnorm(1 - (1 - conf_level) / 2)
+      z <- stats::qnorm(1 - (1 - conf_level) / 2)
       inv_N <- 1 / N_hat
       ci_lo <- 1 / (inv_N + z * se_inv)
       ci_hi <- 1 / (inv_N - z * se_inv)
@@ -239,36 +264,38 @@ estimate_angler_n <- function(M, n, m, method = "chapman", conf_level = 0.95,
     # --- return ---
     estimates_df <- tibble::tibble(
       parameter = "N_hat",
-      estimate  = N_hat,
-      se        = se_N,
-      ci_lower  = ci_lo,
-      ci_upper  = ci_hi,
-      n         = as.integer(sum_m)
+      estimate = N_hat,
+      se = se_N,
+      ci_lower = ci_lo,
+      ci_upper = ci_hi,
+      n = as.integer(sum_m)
     )
     if (ci_method == "bootstrap") {
       m_b_matrix <- vapply(
         seq_along(m),
         function(i) stats::rbinom(B, size = n[i], prob = m[i] / n[i]),
         numeric(B)
-      )  # matrix B x k (each column is one occasion)
-      sum_m_b    <- rowSums(m_b_matrix)
+      ) # matrix B x k (each column is one occasion)
+      sum_m_b <- rowSums(m_b_matrix)
       sum_m_b[sum_m_b == 0L] <- 1L
-      N_hat_b    <- sum(M * n) / sum_m_b
-      alpha      <- 1 - conf_level
-      ci_lo_boot <- stats::quantile(N_hat_b, alpha / 2,       names = FALSE)
-      ci_hi_boot <- stats::quantile(N_hat_b, 1 - alpha / 2,   names = FALSE)
+      N_hat_b <- sum(M * n) / sum_m_b
+      alpha <- 1 - conf_level
+      ci_lo_boot <- stats::quantile(N_hat_b, alpha / 2, names = FALSE)
+      ci_hi_boot <- stats::quantile(N_hat_b, 1 - alpha / 2, names = FALSE)
       estimates_df$ci_lo_boot <- ci_lo_boot
       estimates_df$ci_hi_boot <- ci_hi_boot
     }
     result <- new_creel_estimates(
-      estimates       = estimates_df,
-      method          = "mark-recapture-schnabel",
+      estimates = estimates_df,
+      method = "mark-recapture-schnabel",
       variance_method = "delta",
-      design          = NULL,
-      conf_level      = conf_level,
-      by_vars         = NULL
+      design = NULL,
+      conf_level = conf_level,
+      by_vars = NULL
     )
-    if (ci_method == "bootstrap") attr(result, "boot_samples") <- N_hat_b
+    if (ci_method == "bootstrap") {
+      attr(result, "boot_samples") <- N_hat_b
+    }
     result
   }
 }
@@ -324,51 +351,60 @@ estimate_angler_n <- function(M, n, m, method = "chapman", conf_level = 0.95,
 #' # Step 2: compute total harvest
 #' harvest <- estimate_mr_harvest(angler_n = result, harvest_rate = 0.35)
 #' print(harvest)
-estimate_mr_harvest <- function(angler_n, harvest_rate, conf_level = 0.95,
-                                ci_method = c("delta", "bootstrap")) {
+estimate_mr_harvest <- function(
+  angler_n,
+  harvest_rate,
+  conf_level = 0.95,
+  ci_method = c("delta", "bootstrap")
+) {
   ci_method <- match.arg(ci_method)
   # --- input validation ---
-  if (!inherits(angler_n, "creel_estimates"))
+  if (!inherits(angler_n, "creel_estimates")) {
     cli::cli_abort(
       c(
         "{.arg angler_n} must be a {.cls creel_estimates} object.",
         "i" = "Use {.code estimate_angler_n()} to produce the required input."
       )
     )
-  if (!grepl("^mark-recapture-", angler_n$method))
+  }
+  if (!grepl("^mark-recapture-", angler_n$method)) {
     cli::cli_abort(
       c(
         "{.arg angler_n} must come from {.fn estimate_angler_n}.",
         "i" = "Received method: {.val {angler_n$method}}."
       )
     )
-  if (nrow(angler_n$estimates) != 1L)
+  }
+  if (nrow(angler_n$estimates) != 1L) {
     cli::cli_abort("{.arg angler_n} must be a single-occasion (single-row) estimate.")
-  if (!is.numeric(harvest_rate) || length(harvest_rate) != 1L)
+  }
+  if (!is.numeric(harvest_rate) || length(harvest_rate) != 1L) {
     cli::cli_abort("{.arg harvest_rate} must be a single numeric value.")
-  if (harvest_rate <= 0 || harvest_rate > 1)
+  }
+  if (harvest_rate <= 0 || harvest_rate > 1) {
     cli::cli_abort("{.arg harvest_rate} must be in (0, 1], not {harvest_rate}.")
+  }
 
   # --- extract N_hat and se_N from the creel_estimates object ---
   N_hat <- angler_n$estimates$estimate
-  se_N  <- angler_n$estimates$se
+  se_N <- angler_n$estimates$se
 
   # --- delta-method harvest estimate (H = N_hat * harvest_rate) ---
   harvest_hat <- N_hat * harvest_rate
-  se_H        <- harvest_rate * se_N
+  se_H <- harvest_rate * se_N
 
   # --- CI ---
-  z     <- stats::qnorm(1 - (1 - conf_level) / 2)
+  z <- stats::qnorm(1 - (1 - conf_level) / 2)
   ci_lo <- harvest_hat - z * se_H
   ci_hi <- harvest_hat + z * se_H
 
   # --- return ---
   estimates_df <- tibble::tibble(
     parameter = "total_harvest",
-    estimate  = harvest_hat,
-    se        = se_H,
-    ci_lower  = ci_lo,
-    ci_upper  = ci_hi
+    estimate = harvest_hat,
+    se = se_H,
+    ci_lower = ci_lo,
+    ci_upper = ci_hi
   )
   if (ci_method == "bootstrap") {
     boot_samples <- attr(angler_n, "boot_samples")
@@ -378,18 +414,18 @@ estimate_mr_harvest <- function(angler_n, harvest_rate, conf_level = 0.95,
         "i" = "Call estimate_angler_n(..., ci_method = 'bootstrap') first."
       ))
     }
-    harvest_b  <- boot_samples * harvest_rate
-    ci_lo_boot <- stats::quantile(harvest_b, (1 - conf_level) / 2,     names = FALSE)
+    harvest_b <- boot_samples * harvest_rate
+    ci_lo_boot <- stats::quantile(harvest_b, (1 - conf_level) / 2, names = FALSE)
     ci_hi_boot <- stats::quantile(harvest_b, 1 - (1 - conf_level) / 2, names = FALSE)
     estimates_df$ci_lo_boot <- ci_lo_boot
     estimates_df$ci_hi_boot <- ci_hi_boot
   }
   new_creel_estimates(
-    estimates       = estimates_df,
-    method          = "mark-recapture-harvest",
+    estimates = estimates_df,
+    method = "mark-recapture-harvest",
     variance_method = "delta",
-    design          = NULL,
-    conf_level      = conf_level,
-    by_vars         = NULL
+    design = NULL,
+    conf_level = conf_level,
+    by_vars = NULL
   )
 }

--- a/R/creel-estimates-regression-cpue.R
+++ b/R/creel-estimates-regression-cpue.R
@@ -7,7 +7,7 @@
 #' @importFrom stats lm coef qt
 estimate_cpue_regression_total <- function(design, conf_level, force_origin) {
   interviews_data <- design$interviews
-  catch_col  <- design$catch_col
+  catch_col <- design$catch_col
   effort_col <- design$angler_effort_col
 
   if (is.null(catch_col) || is.null(effort_col)) {
@@ -28,9 +28,9 @@ estimate_cpue_regression_total <- function(design, conf_level, force_origin) {
     interviews_data <- interviews_data[!zero_eff, , drop = FALSE]
   }
 
-  catch  <- as.numeric(interviews_data[[catch_col]])
+  catch <- as.numeric(interviews_data[[catch_col]])
   effort <- as.numeric(interviews_data[[effort_col]])
-  n      <- length(catch)
+  n <- length(catch)
 
   if (n < 3L) {
     cli::cli_abort(c(
@@ -40,26 +40,27 @@ estimate_cpue_regression_total <- function(design, conf_level, force_origin) {
   }
 
   beta_hat <- .ols_slope(catch, effort, force_origin)
-  jk_se    <- .jackknife_slope_se(catch, effort, force_origin)
+  jk_se <- .jackknife_slope_se(catch, effort, force_origin)
 
-  df  <- n - 1L
+  df <- n - 1L
   t_c <- qt((1 + conf_level) / 2, df = df)
 
   estimates_df <- tibble::tibble(
     estimate = beta_hat,
-    se       = jk_se,
+    se = jk_se,
     ci_lower = beta_hat - t_c * jk_se,
     ci_upper = beta_hat + t_c * jk_se,
-    n        = n
+    n = n
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = estimates_df,
-    method          = "regression-cpue",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = estimates_df,
+    method = "regression-cpue",
     variance_method = "jackknife",
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL
   )
 }
 
@@ -68,10 +69,14 @@ estimate_cpue_regression_total <- function(design, conf_level, force_origin) {
 #'
 #' @keywords internal
 #' @noRd
-estimate_cpue_reg_grouped <- function(design, by_vars, conf_level,  # nolint: object_length_linter
-                                      force_origin) {
+estimate_cpue_reg_grouped <- function(
+  design,
+  by_vars,
+  conf_level, # nolint: object_length_linter
+  force_origin
+) {
   interviews_data <- design$interviews
-  catch_col  <- design$catch_col
+  catch_col <- design$catch_col
   effort_col <- design$angler_effort_col
 
   if (is.null(catch_col) || is.null(effort_col)) {
@@ -93,14 +98,14 @@ estimate_cpue_reg_grouped <- function(design, by_vars, conf_level,  # nolint: ob
   }
 
   group_key <- do.call(paste, c(interviews_data[by_vars], sep = ""))
-  groups    <- sort(unique(group_key))
+  groups <- sort(unique(group_key))
 
   rows <- lapply(groups, function(gk) {
-    idx    <- group_key == gk
-    sub    <- interviews_data[idx, , drop = FALSE]
-    catch  <- as.numeric(sub[[catch_col]])
+    idx <- group_key == gk
+    sub <- interviews_data[idx, , drop = FALSE]
+    catch <- as.numeric(sub[[catch_col]])
     effort <- as.numeric(sub[[effort_col]])
-    n_g    <- length(catch)
+    n_g <- length(catch)
 
     if (n_g < 3L) {
       cli::cli_warn(c(
@@ -110,9 +115,9 @@ estimate_cpue_reg_grouped <- function(design, by_vars, conf_level,  # nolint: ob
     }
 
     beta_hat <- .ols_slope(catch, effort, force_origin)
-    jk_se    <- .jackknife_slope_se(catch, effort, force_origin)
-    df       <- n_g - 1L
-    t_c      <- qt((1 + conf_level) / 2, df = max(df, 1L))
+    jk_se <- .jackknife_slope_se(catch, effort, force_origin)
+    df <- n_g - 1L
+    t_c <- qt((1 + conf_level) / 2, df = max(df, 1L))
 
     grp_vals <- sub[1L, by_vars, drop = FALSE]
     rownames(grp_vals) <- NULL
@@ -121,23 +126,24 @@ estimate_cpue_reg_grouped <- function(design, by_vars, conf_level,  # nolint: ob
       grp_vals,
       tibble::tibble(
         estimate = beta_hat,
-        se       = jk_se,
+        se = jk_se,
         ci_lower = beta_hat - t_c * jk_se,
         ci_upper = beta_hat + t_c * jk_se,
-        n        = n_g
+        n = n_g
       )
     )
   })
 
   estimates_df <- tibble::as_tibble(do.call(rbind, rows))
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = estimates_df,
-    method          = "regression-cpue",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = estimates_df,
+    method = "regression-cpue",
     variance_method = "jackknife",
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = by_vars
+    design = design,
+    conf_level = conf_level,
+    by_vars = by_vars
   )
 }
 
@@ -162,11 +168,15 @@ estimate_cpue_reg_grouped <- function(design, by_vars, conf_level,  # nolint: ob
 #' @keywords internal
 #' @noRd
 .jackknife_slope_se <- function(catch, effort, force_origin) {
-  n        <- length(catch)
+  n <- length(catch)
   beta_hat <- .ols_slope(catch, effort, force_origin)
-  theta_i  <- vapply(seq_len(n), function(i) {
-    .ols_slope(catch[-i], effort[-i], force_origin)
-  }, numeric(1L))
+  theta_i <- vapply(
+    seq_len(n),
+    function(i) {
+      .ols_slope(catch[-i], effort[-i], force_origin)
+    },
+    numeric(1L)
+  )
   # Jackknife variance: (n-1)/n * sum((theta_i - mean(theta_i))^2)
   jk_var <- (n - 1L) / n * sum((theta_i - mean(theta_i))^2)
   sqrt(jk_var)
@@ -233,8 +243,13 @@ estimate_cpue_reg_grouped <- function(design, by_vars, conf_level,  # nolint: ob
 #' @seealso \code{\link{estimate_catch_rate}}
 #' @family "Estimation"
 #' @export
-compare_cpue_estimators <- function(design, by = NULL, conf_level = 0.95,
-                                    force_origin = TRUE, verbose = FALSE) {
+compare_cpue_estimators <- function(
+  design,
+  by = NULL,
+  conf_level = 0.95,
+  force_origin = TRUE,
+  verbose = FALSE
+) {
   checkmate::assert_class(design, "creel_design")
   checkmate::assert_number(conf_level, lower = 0.5, upper = 1.0)
   checkmate::assert_flag(force_origin)
@@ -243,43 +258,50 @@ compare_cpue_estimators <- function(design, by = NULL, conf_level = 0.95,
   by_quo <- rlang::enquo(by)
 
   .run <- function(est_name, est_str, use_trips_val = "complete") {
-    if (verbose) cli::cli_inform("Running {.val {est_name}} estimator...")
-    tryCatch({
-      if (rlang::quo_is_null(by_quo)) {
-        r <- estimate_catch_rate( # nolint: object_usage_linter
-          design,
-          variance     = if (est_str == "regression") "jackknife" else "taylor",
-          conf_level   = conf_level,
-          estimator    = est_str,
-          use_trips    = use_trips_val,
-          force_origin = force_origin
-        )
-      } else {
-        r <- estimate_catch_rate( # nolint: object_usage_linter
-          design,
-          by           = !!by_quo,
-          variance     = if (est_str == "regression") "jackknife" else "taylor",
-          conf_level   = conf_level,
-          estimator    = est_str,
-          use_trips    = use_trips_val,
-          force_origin = force_origin
-        )
+    if (verbose) {
+      cli::cli_inform("Running {.val {est_name}} estimator...")
+    }
+    tryCatch(
+      {
+        if (rlang::quo_is_null(by_quo)) {
+          r <- estimate_catch_rate(
+            # nolint: object_usage_linter
+            design,
+            variance = if (est_str == "regression") "jackknife" else "taylor",
+            conf_level = conf_level,
+            estimator = est_str,
+            use_trips = use_trips_val,
+            force_origin = force_origin
+          )
+        } else {
+          r <- estimate_catch_rate(
+            # nolint: object_usage_linter
+            design,
+            by = !!by_quo,
+            variance = if (est_str == "regression") "jackknife" else "taylor",
+            conf_level = conf_level,
+            estimator = est_str,
+            use_trips = use_trips_val,
+            force_origin = force_origin
+          )
+        }
+        df <- r$estimates
+        df$cpue_method <- est_name
+        df
+      },
+      error = function(e) {
+        cli::cli_warn(c(
+          "Estimator {.val {est_name}} failed.",
+          "x" = conditionMessage(e)
+        ))
+        NULL
       }
-      df <- r$estimates
-      df$cpue_method <- est_name
-      df
-    }, error = function(e) {
-      cli::cli_warn(c(
-        "Estimator {.val {est_name}} failed.",
-        "x" = conditionMessage(e)
-      ))
-      NULL
-    })
+    )
   }
 
-  rom_df  <- .run("rom",        "ratio-of-means", "complete")
-  mor_df  <- .run("mor",        "mor",            "complete")
-  reg_df  <- .run("regression", "regression",     "complete")
+  rom_df <- .run("rom", "ratio-of-means", "complete")
+  mor_df <- .run("mor", "mor", "complete")
+  reg_df <- .run("regression", "regression", "complete")
 
   rows <- Filter(Negate(is.null), list(rom_df, mor_df, reg_df))
   if (length(rows) == 0L) {
@@ -298,20 +320,19 @@ compare_cpue_estimators <- function(design, by = NULL, conf_level = 0.95,
 
 #' @export
 #' @importFrom ggplot2 ggplot aes geom_point geom_errorbar facet_wrap labs theme_bw theme
-autoplot.cpue_comparison <- function(object, ...) {  # nolint: object_name_linter
+autoplot.cpue_comparison <- function(object, ...) {
+  # nolint: object_name_linter
   if (!requireNamespace("ggplot2", quietly = TRUE)) {
     cli::cli_abort("{.pkg ggplot2} is required for {.fn autoplot.cpue_comparison}.")
   }
-  by_cols <- setdiff(names(object),
-                     c("cpue_method", "estimate", "se",
-                       "ci_lower", "ci_upper", "n"))
+  by_cols <- setdiff(names(object), c("cpue_method", "estimate", "se", "ci_lower", "ci_upper", "n"))
   p <- ggplot2::ggplot(
     object,
     ggplot2::aes(
-      x      = .data[["cpue_method"]],
-      y      = .data[["estimate"]],
-      ymin   = .data[["ci_lower"]],
-      ymax   = .data[["ci_upper"]],
+      x = .data[["cpue_method"]],
+      y = .data[["estimate"]],
+      ymin = .data[["ci_lower"]],
+      ymax = .data[["ci_upper"]],
       colour = .data[["cpue_method"]]
     )
   ) +

--- a/R/creel-estimates-total-catch.R
+++ b/R/creel-estimates-total-catch.R
@@ -300,6 +300,8 @@ estimate_total_catch_ungrouped <- function(design, variance_method, conf_level,
   )
   cpue_df <- cpue_result$estimates
 
+  warn_missing_rate_strata(effort_df, cpue_df, strata_cols, "estimate_total_catch") # nolint: object_usage_linter
+
   # Stratified-sum product estimator: sum(E_h * CPUE_h) across strata h
   estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
     effort_df         = effort_df,
@@ -347,6 +349,8 @@ estimate_total_catch_grouped <- function(design, by_vars, variance_method, conf_
     design, stratum_by_vars, variance_method, conf_level, use_trips = use_trips
   )
   cpue_df <- cpue_result$estimates
+
+  warn_missing_rate_strata(effort_df, cpue_df, stratum_by_vars, "estimate_total_catch(by=)") # nolint: object_usage_linter
 
   # Stratified-sum within each by_vars group
   estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter

--- a/R/creel-estimates-total-catch.R
+++ b/R/creel-estimates-total-catch.R
@@ -166,16 +166,27 @@ estimate_total_catch <- function(
       )
       by_vars_br <- names(by_cols_br)
     }
-    return(estimate_total_catch_br( # nolint: object_usage_linter
-      design, by_vars_br, variance, conf_level,
-      verbose = FALSE, ci_method = ci_method
+    return(estimate_total_catch_br(
+      # nolint: object_usage_linter
+      design,
+      by_vars_br,
+      variance,
+      conf_level,
+      verbose = FALSE,
+      ci_method = ci_method
     ))
   }
 
   # Section dispatch guard (v0.7.0+ — only fires when add_sections() was called)
   if (!is.null(design[["sections"]])) {
-    return(estimate_total_catch_sections( # nolint: object_usage_linter
-      design, by_quo, variance, conf_level, aggregate_sections, missing_sections,
+    return(estimate_total_catch_sections(
+      # nolint: object_usage_linter
+      design,
+      by_quo,
+      variance,
+      conf_level,
+      aggregate_sections,
+      missing_sections,
       target = target
     ))
   }
@@ -193,29 +204,37 @@ estimate_total_catch <- function(
         "x" = "Call {.fn add_catch} before using species grouping in {.fn estimate_total_catch}."
       ))
     }
-    estimates_df <- estimate_total_catch_species( # nolint: object_usage_linter
+    estimates_df <- estimate_total_catch_species(
+      # nolint: object_usage_linter
       design,
-      species_col       = by_info$species_var,
+      species_col = by_info$species_var,
       interview_by_vars = by_info$interview_vars,
-      variance_method   = variance,
-      conf_level        = conf_level,
-      target            = target
-    )
-    return(new_creel_estimates( # nolint: object_usage_linter
-      estimates       = tibble::as_tibble(estimates_df),
-      method          = "product-total-catch",
       variance_method = variance,
-      design          = design,
-      conf_level      = conf_level,
-      by_vars         = by_info$all_vars,
-      effort_target   = target
+      conf_level = conf_level,
+      target = target
+    )
+    return(new_creel_estimates(
+      # nolint: object_usage_linter
+      estimates = tibble::as_tibble(estimates_df),
+      method = "product-total-catch",
+      variance_method = variance,
+      design = design,
+      conf_level = conf_level,
+      by_vars = by_info$all_vars,
+      effort_target = target
     ))
   }
 
   # Standard (non-species) routing
   if (rlang::quo_is_null(by_quo)) {
     # Ungrouped estimation
-    return(estimate_total_catch_ungrouped(design, variance, conf_level, target = target, use_trips = use_trips)) # nolint: object_usage_linter
+    return(estimate_total_catch_ungrouped(
+      design,
+      variance,
+      conf_level,
+      target = target,
+      use_trips = use_trips
+    )) # nolint: object_usage_linter
   } else {
     # Grouped estimation
     # Resolve by parameter to column names
@@ -231,7 +250,14 @@ estimate_total_catch <- function(
     # Validate grouping compatibility
     validate_grouping_compatibility(design, by_vars) # nolint: object_usage_linter
 
-    return(estimate_total_catch_grouped(design, by_vars, variance, conf_level, target = target, use_trips = use_trips)) # nolint: object_usage_linter
+    return(estimate_total_catch_grouped(
+      design,
+      by_vars,
+      variance,
+      conf_level,
+      target = target,
+      use_trips = use_trips
+    )) # nolint: object_usage_linter
   }
 }
 
@@ -251,8 +277,13 @@ estimate_total_catch <- function(
 #'
 #' @keywords internal
 #' @noRd
-cpue_for_stratum_product <- function(design, by_vars, variance_method, conf_level,
-                                     use_trips = "complete") {
+cpue_for_stratum_product <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  use_trips = "complete"
+) {
   use_trips <- match.arg(use_trips, c("complete", "all"))
 
   # Apply trip filter before computing CPUE so that total-catch and
@@ -260,7 +291,8 @@ cpue_for_stratum_product <- function(design, by_vars, variance_method, conf_leve
   trip_status_col <- design$trip_status_col
   if (!is.null(trip_status_col) && use_trips != "all") {
     filtered_interviews <- design$interviews[
-      tolower(design$interviews[[trip_status_col]]) == use_trips, ,
+      tolower(design$interviews[[trip_status_col]]) == use_trips,
+      ,
       drop = FALSE
     ]
     design <- rebuild_interview_survey(design, filtered_interviews) # nolint: object_usage_linter
@@ -282,44 +314,61 @@ cpue_for_stratum_product <- function(design, by_vars, variance_method, conf_leve
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_catch_ungrouped <- function(design, variance_method, conf_level,
-                                           target = "sampled_days",
-                                           use_trips = "complete") {
+estimate_total_catch_ungrouped <- function(
+  design,
+  variance_method,
+  conf_level,
+  target = "sampled_days",
+  use_trips = "complete"
+) {
   strata_cols <- design$strata_cols %||% character(0)
 
   # Per-stratum effort
   if (length(strata_cols) == 0L) {
     effort_result <- estimate_effort_total(design, variance_method, conf_level, target = target) # nolint: object_usage_linter
   } else {
-    effort_result <- estimate_effort_grouped(design, strata_cols, variance_method, conf_level, target = target) # nolint: object_usage_linter
+    effort_result <- estimate_effort_grouped(
+      design,
+      strata_cols,
+      variance_method,
+      conf_level,
+      target = target
+    ) # nolint: object_usage_linter
   }
   effort_df <- effort_result$estimates
 
-  cpue_result <- cpue_for_stratum_product( # nolint: object_usage_linter
-    design, strata_cols, variance_method, conf_level, use_trips = use_trips
+  cpue_result <- cpue_for_stratum_product(
+    # nolint: object_usage_linter
+    design,
+    strata_cols,
+    variance_method,
+    conf_level,
+    use_trips = use_trips
   )
   cpue_df <- cpue_result$estimates
 
   warn_missing_rate_strata(effort_df, cpue_df, strata_cols, "estimate_total_catch") # nolint: object_usage_linter
 
   # Stratified-sum product estimator: sum(E_h * CPUE_h) across strata h
-  estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
-    effort_df         = effort_df,
-    rate_df           = cpue_df,
-    stratum_by_vars   = strata_cols,
+  estimates_df <- compute_stratum_product_sum(
+    # nolint: object_usage_linter
+    effort_df = effort_df,
+    rate_df = cpue_df,
+    stratum_by_vars = strata_cols,
     interview_by_vars = NULL,
-    conf_level        = conf_level,
-    rate_suffix       = "cpue"
+    conf_level = conf_level,
+    rate_suffix = "cpue"
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = tibble::as_tibble(estimates_df),
-    method          = "product-total-catch",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = tibble::as_tibble(estimates_df),
+    method = "product-total-catch",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL,
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL,
+    effort_target = target
   )
 }
 
@@ -334,42 +383,60 @@ estimate_total_catch_ungrouped <- function(design, variance_method, conf_level,
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_catch_grouped <- function(design, by_vars, variance_method, conf_level,
-                                         target = "sampled_days",
-                                         use_trips = "complete") {
+estimate_total_catch_grouped <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days",
+  use_trips = "complete"
+) {
   strata_cols <- design$strata_cols %||% character(0)
   # Union of calendar strata and user grouping: ensures per-stratum products
   stratum_by_vars <- unique(c(strata_cols, by_vars))
 
   # Per-stratum effort grouped by union of strata and user vars
-  effort_result <- estimate_effort_grouped(design, stratum_by_vars, variance_method, conf_level, target = target) # nolint: object_usage_linter
+  effort_result <- estimate_effort_grouped(
+    design,
+    stratum_by_vars,
+    variance_method,
+    conf_level,
+    target = target
+  ) # nolint: object_usage_linter
   effort_df <- effort_result$estimates
 
-  cpue_result <- cpue_for_stratum_product( # nolint: object_usage_linter
-    design, stratum_by_vars, variance_method, conf_level, use_trips = use_trips
+  cpue_result <- cpue_for_stratum_product(
+    # nolint: object_usage_linter
+    design,
+    stratum_by_vars,
+    variance_method,
+    conf_level,
+    use_trips = use_trips
   )
   cpue_df <- cpue_result$estimates
 
   warn_missing_rate_strata(effort_df, cpue_df, stratum_by_vars, "estimate_total_catch(by=)") # nolint: object_usage_linter
 
   # Stratified-sum within each by_vars group
-  estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
-    effort_df         = effort_df,
-    rate_df           = cpue_df,
-    stratum_by_vars   = stratum_by_vars,
+  estimates_df <- compute_stratum_product_sum(
+    # nolint: object_usage_linter
+    effort_df = effort_df,
+    rate_df = cpue_df,
+    stratum_by_vars = stratum_by_vars,
     interview_by_vars = if (length(by_vars) > 0L) by_vars else NULL,
-    conf_level        = conf_level,
-    rate_suffix       = "cpue"
+    conf_level = conf_level,
+    rate_suffix = "cpue"
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = tibble::as_tibble(estimates_df),
-    method          = "product-total-catch",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = tibble::as_tibble(estimates_df),
+    method = "product-total-catch",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = by_vars,
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = by_vars,
+    effort_target = target
   )
 }
 
@@ -382,32 +449,45 @@ estimate_total_catch_grouped <- function(design, by_vars, variance_method, conf_
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_catch_species <- function(design, species_col, interview_by_vars,
-                                         variance_method, conf_level,
-                                         target = "sampled_days") {
+estimate_total_catch_species <- function(
+  design,
+  species_col,
+  interview_by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, interview_by_vars))
 
   # Per-stratum species CPUE (grouped by strata + interview grouping vars)
   rate_by <- if (length(stratum_by_vars) > 0L) stratum_by_vars else NULL
-  all_rate_df <- estimate_cpue_species( # nolint: object_usage_linter
+  all_rate_df <- estimate_cpue_species(
+    # nolint: object_usage_linter
     design,
-    species_col       = species_col,
+    species_col = species_col,
     interview_by_vars = rate_by,
-    variance_method   = variance_method,
-    conf_level        = conf_level,
-    validate          = FALSE
+    variance_method = variance_method,
+    conf_level = conf_level,
+    validate = FALSE
   )
 
   # Per-stratum effort (grouped by same vars)
   if (length(stratum_by_vars) == 0L) {
     effort_result <- estimate_effort_total(design, variance_method, conf_level, target = target) # nolint: object_usage_linter
   } else {
-    effort_result <- estimate_effort_grouped(design, stratum_by_vars, variance_method, conf_level, target = target) # nolint: object_usage_linter
+    effort_result <- estimate_effort_grouped(
+      design,
+      stratum_by_vars,
+      variance_method,
+      conf_level,
+      target = target
+    ) # nolint: object_usage_linter
   }
   effort_df <- effort_result$estimates
 
-  warn_missing_rate_strata( # nolint: object_usage_linter
+  warn_missing_rate_strata(
+    # nolint: object_usage_linter
     effort_df = effort_df,
     rate_df = all_rate_df[, setdiff(names(all_rate_df), species_col), drop = FALSE],
     stratum_by_vars = stratum_by_vars,
@@ -422,13 +502,14 @@ estimate_total_catch_species <- function(design, species_col, interview_by_vars,
     rate_sp_df <- all_rate_df[all_rate_df[[species_col]] == sp, , drop = FALSE]
     rate_no_sp <- rate_sp_df[, setdiff(names(rate_sp_df), species_col), drop = FALSE]
 
-    sp_result <- compute_stratum_product_sum( # nolint: object_usage_linter
-      effort_df         = effort_df,
-      rate_df           = rate_no_sp,
-      stratum_by_vars   = stratum_by_vars,
+    sp_result <- compute_stratum_product_sum(
+      # nolint: object_usage_linter
+      effort_df = effort_df,
+      rate_df = rate_no_sp,
+      stratum_by_vars = stratum_by_vars,
       interview_by_vars = interview_by_vars,
-      conf_level        = conf_level,
-      rate_suffix       = "cpue"
+      conf_level = conf_level,
+      rate_suffix = "cpue"
     )
 
     sp_result[[species_col]] <- sp
@@ -443,10 +524,15 @@ estimate_total_catch_species <- function(design, species_col, interview_by_vars,
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_catch_sections <- function(design, by_quo, variance_method, # nolint: object_length_linter
-                                          conf_level, aggregate_sections,
-                                          missing_sections,
-                                          target = "sampled_days") {
+estimate_total_catch_sections <- function(
+  design,
+  by_quo,
+  variance_method, # nolint: object_length_linter
+  conf_level,
+  aggregate_sections,
+  missing_sections,
+  target = "sampled_days"
+) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
   present_count_sections <- unique(design$counts[[section_col]])
@@ -514,8 +600,12 @@ estimate_total_catch_sections <- function(design, by_quo, variance_method, # nol
 
       if (!is.null(by_vars)) {
         # Grouped path: delegates to existing grouped helper
-        result <- estimate_total_catch_grouped( # nolint: object_usage_linter
-          sec_design, by_vars, variance_method, conf_level,
+        result <- estimate_total_catch_grouped(
+          # nolint: object_usage_linter
+          sec_design,
+          by_vars,
+          variance_method,
+          conf_level,
           target = target
         )
         row_df <- tibble::add_column(result$estimates, section = sec, .before = 1)
@@ -523,7 +613,12 @@ estimate_total_catch_sections <- function(design, by_quo, variance_method, # nol
         section_rows[[sec]] <- row_df
       } else {
         # Ungrouped path: call internal helpers directly to bypass sample-size validation
-        effort_res <- estimate_effort_total(sec_design, variance_method, conf_level, target = target) # nolint: object_usage_linter
+        effort_res <- estimate_effort_total(
+          sec_design,
+          variance_method,
+          conf_level,
+          target = target
+        ) # nolint: object_usage_linter
         cpue_res <- estimate_cpue_total(sec_design, variance_method, conf_level, "ratio") # nolint: object_usage_linter
         effort_est <- effort_res$estimates$estimate
         cpue_est <- cpue_res$estimates$estimate
@@ -532,7 +627,7 @@ estimate_total_catch_sections <- function(design, by_quo, variance_method, # nol
         sec_estimate <- effort_est * cpue_est
         sec_var <- (effort_est^2 * cpue_se^2) + (cpue_est^2 * effort_se^2)
         sec_se <- sqrt(sec_var)
-        sec_n  <- cpue_res$estimates$n
+        sec_n <- cpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))
         section_rows[[sec]] <- tibble::tibble(
           section = sec,
@@ -584,13 +679,14 @@ estimate_total_catch_sections <- function(design, by_quo, variance_method, # nol
     result_df <- dplyr::bind_rows(result_df, lake_row)
   }
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = result_df,
-    method          = "product-total-catch-sections",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = result_df,
+    method = "product-total-catch-sections",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = if (!is.null(by_vars)) c("section", by_vars) else "section",
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = if (!is.null(by_vars)) c("section", by_vars) else "section",
+    effort_target = target
   )
 }

--- a/R/creel-estimates-total-harvest.R
+++ b/R/creel-estimates-total-harvest.R
@@ -253,6 +253,8 @@ estimate_total_harvest_ungrouped <- function(design, variance_method, conf_level
   }
   hpue_df <- hpue_result$estimates
 
+  warn_missing_rate_strata(effort_df, hpue_df, strata_cols, "estimate_total_harvest") # nolint: object_usage_linter
+
   # Stratified-sum product estimator: sum(E_h * HPUE_h) across strata h
   estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
     effort_df         = effort_df,
@@ -290,6 +292,8 @@ estimate_total_harvest_grouped <- function(design, by_vars, variance_method, con
 
   hpue_result <- estimate_harvest_grouped(design, stratum_by_vars, variance_method, conf_level) # nolint: object_usage_linter
   hpue_df <- hpue_result$estimates
+
+  warn_missing_rate_strata(effort_df, hpue_df, stratum_by_vars, "estimate_total_harvest(by=)") # nolint: object_usage_linter
 
   estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
     effort_df         = effort_df,

--- a/R/creel-estimates-total-harvest.R
+++ b/R/creel-estimates-total-harvest.R
@@ -144,9 +144,14 @@ estimate_total_harvest <- function(
       )
       by_vars_br <- names(by_cols_br)
     }
-    return(estimate_total_harvest_br( # nolint: object_usage_linter
-      design, by_vars_br, variance, conf_level,
-      verbose = FALSE, ci_method = ci_method
+    return(estimate_total_harvest_br(
+      # nolint: object_usage_linter
+      design,
+      by_vars_br,
+      variance,
+      conf_level,
+      verbose = FALSE,
+      ci_method = ci_method
     ))
   }
 
@@ -163,22 +168,24 @@ estimate_total_harvest <- function(
         "x" = "Call {.fn add_catch} before using species grouping in {.fn estimate_total_harvest}."
       ))
     }
-    estimates_df <- estimate_total_harvest_species( # nolint: object_usage_linter
+    estimates_df <- estimate_total_harvest_species(
+      # nolint: object_usage_linter
       design,
-      species_col       = by_info$species_var,
+      species_col = by_info$species_var,
       interview_by_vars = by_info$interview_vars,
-      variance_method   = variance,
-      conf_level        = conf_level,
-      target            = target
-    )
-    return(new_creel_estimates( # nolint: object_usage_linter
-      estimates       = tibble::as_tibble(estimates_df),
-      method          = "product-total-harvest",
       variance_method = variance,
-      design          = design,
-      conf_level      = conf_level,
-      by_vars         = by_info$all_vars,
-      effort_target   = target
+      conf_level = conf_level,
+      target = target
+    )
+    return(new_creel_estimates(
+      # nolint: object_usage_linter
+      estimates = tibble::as_tibble(estimates_df),
+      method = "product-total-harvest",
+      variance_method = variance,
+      design = design,
+      conf_level = conf_level,
+      by_vars = by_info$all_vars,
+      effort_target = target
     ))
   }
 
@@ -197,8 +204,14 @@ estimate_total_harvest <- function(
 
   # Section dispatch guard (v0.7.0+ — only fires when add_sections() was called)
   if (!is.null(design[["sections"]])) {
-    return(estimate_total_harvest_sections( # nolint: object_usage_linter
-      design, by_quo, variance, conf_level, aggregate_sections, missing_sections,
+    return(estimate_total_harvest_sections(
+      # nolint: object_usage_linter
+      design,
+      by_quo,
+      variance,
+      conf_level,
+      aggregate_sections,
+      missing_sections,
       target = target
     ))
   }
@@ -234,14 +247,26 @@ estimate_total_harvest <- function(
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_harvest_ungrouped <- function(design, variance_method, conf_level, target = "sampled_days") { # nolint: object_length_linter
+estimate_total_harvest_ungrouped <- function(
+  design,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
+  # nolint: object_length_linter
   strata_cols <- design$strata_cols %||% character(0)
 
   # Per-stratum effort
   if (length(strata_cols) == 0L) {
     effort_result <- estimate_effort_total(design, variance_method, conf_level, target = target) # nolint: object_usage_linter
   } else {
-    effort_result <- estimate_effort_grouped(design, strata_cols, variance_method, conf_level, target = target) # nolint: object_usage_linter
+    effort_result <- estimate_effort_grouped(
+      design,
+      strata_cols,
+      variance_method,
+      conf_level,
+      target = target
+    ) # nolint: object_usage_linter
   }
   effort_df <- effort_result$estimates
 
@@ -256,23 +281,25 @@ estimate_total_harvest_ungrouped <- function(design, variance_method, conf_level
   warn_missing_rate_strata(effort_df, hpue_df, strata_cols, "estimate_total_harvest") # nolint: object_usage_linter
 
   # Stratified-sum product estimator: sum(E_h * HPUE_h) across strata h
-  estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
-    effort_df         = effort_df,
-    rate_df           = hpue_df,
-    stratum_by_vars   = strata_cols,
+  estimates_df <- compute_stratum_product_sum(
+    # nolint: object_usage_linter
+    effort_df = effort_df,
+    rate_df = hpue_df,
+    stratum_by_vars = strata_cols,
     interview_by_vars = NULL,
-    conf_level        = conf_level,
-    rate_suffix       = "hpue"
+    conf_level = conf_level,
+    rate_suffix = "hpue"
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = tibble::as_tibble(estimates_df),
-    method          = "product-total-harvest",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = tibble::as_tibble(estimates_df),
+    method = "product-total-harvest",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL,
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL,
+    effort_target = target
   )
 }
 
@@ -283,11 +310,23 @@ estimate_total_harvest_ungrouped <- function(design, variance_method, conf_level
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_harvest_grouped <- function(design, by_vars, variance_method, conf_level, target = "sampled_days") {
+estimate_total_harvest_grouped <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, by_vars))
 
-  effort_result <- estimate_effort_grouped(design, stratum_by_vars, variance_method, conf_level, target = target) # nolint: object_usage_linter
+  effort_result <- estimate_effort_grouped(
+    design,
+    stratum_by_vars,
+    variance_method,
+    conf_level,
+    target = target
+  ) # nolint: object_usage_linter
   effort_df <- effort_result$estimates
 
   hpue_result <- estimate_harvest_grouped(design, stratum_by_vars, variance_method, conf_level) # nolint: object_usage_linter
@@ -295,23 +334,25 @@ estimate_total_harvest_grouped <- function(design, by_vars, variance_method, con
 
   warn_missing_rate_strata(effort_df, hpue_df, stratum_by_vars, "estimate_total_harvest(by=)") # nolint: object_usage_linter
 
-  estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
-    effort_df         = effort_df,
-    rate_df           = hpue_df,
-    stratum_by_vars   = stratum_by_vars,
+  estimates_df <- compute_stratum_product_sum(
+    # nolint: object_usage_linter
+    effort_df = effort_df,
+    rate_df = hpue_df,
+    stratum_by_vars = stratum_by_vars,
     interview_by_vars = if (length(by_vars) > 0L) by_vars else NULL,
-    conf_level        = conf_level,
-    rate_suffix       = "hpue"
+    conf_level = conf_level,
+    rate_suffix = "hpue"
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = tibble::as_tibble(estimates_df),
-    method          = "product-total-harvest",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = tibble::as_tibble(estimates_df),
+    method = "product-total-harvest",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = by_vars,
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = by_vars,
+    effort_target = target
   )
 }
 
@@ -319,32 +360,45 @@ estimate_total_harvest_grouped <- function(design, by_vars, variance_method, con
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_harvest_species <- function(design, species_col, interview_by_vars,
-                                           variance_method, conf_level,
-                                           target = "sampled_days") {
+estimate_total_harvest_species <- function(
+  design,
+  species_col,
+  interview_by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, interview_by_vars))
 
   # Per-stratum species HPUE
   rate_by <- if (length(stratum_by_vars) > 0L) stratum_by_vars else NULL
-  all_rate_df <- estimate_hpue_species( # nolint: object_usage_linter
+  all_rate_df <- estimate_hpue_species(
+    # nolint: object_usage_linter
     design,
-    species_col       = species_col,
+    species_col = species_col,
     interview_by_vars = rate_by,
-    variance_method   = variance_method,
-    conf_level        = conf_level,
-    validate          = FALSE
+    variance_method = variance_method,
+    conf_level = conf_level,
+    validate = FALSE
   )
 
   # Per-stratum effort
   if (length(stratum_by_vars) == 0L) {
     effort_result <- estimate_effort_total(design, variance_method, conf_level, target = target) # nolint: object_usage_linter
   } else {
-    effort_result <- estimate_effort_grouped(design, stratum_by_vars, variance_method, conf_level, target = target) # nolint: object_usage_linter
+    effort_result <- estimate_effort_grouped(
+      design,
+      stratum_by_vars,
+      variance_method,
+      conf_level,
+      target = target
+    ) # nolint: object_usage_linter
   }
   effort_df <- effort_result$estimates
 
-  warn_missing_rate_strata( # nolint: object_usage_linter
+  warn_missing_rate_strata(
+    # nolint: object_usage_linter
     effort_df = effort_df,
     rate_df = all_rate_df[, setdiff(names(all_rate_df), species_col), drop = FALSE],
     stratum_by_vars = stratum_by_vars,
@@ -359,13 +413,14 @@ estimate_total_harvest_species <- function(design, species_col, interview_by_var
     rate_sp_df <- all_rate_df[all_rate_df[[species_col]] == sp, , drop = FALSE]
     rate_no_sp <- rate_sp_df[, setdiff(names(rate_sp_df), species_col), drop = FALSE]
 
-    sp_result <- compute_stratum_product_sum( # nolint: object_usage_linter
-      effort_df         = effort_df,
-      rate_df           = rate_no_sp,
-      stratum_by_vars   = stratum_by_vars,
+    sp_result <- compute_stratum_product_sum(
+      # nolint: object_usage_linter
+      effort_df = effort_df,
+      rate_df = rate_no_sp,
+      stratum_by_vars = stratum_by_vars,
       interview_by_vars = interview_by_vars,
-      conf_level        = conf_level,
-      rate_suffix       = "hpue"
+      conf_level = conf_level,
+      rate_suffix = "hpue"
     )
 
     sp_result[[species_col]] <- sp
@@ -380,10 +435,15 @@ estimate_total_harvest_species <- function(design, species_col, interview_by_var
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_harvest_sections <- function(design, by_quo, variance_method, # nolint: object_length_linter
-                                            conf_level, aggregate_sections,
-                                            missing_sections,
-                                            target = "sampled_days") {
+estimate_total_harvest_sections <- function(
+  design,
+  by_quo,
+  variance_method, # nolint: object_length_linter
+  conf_level,
+  aggregate_sections,
+  missing_sections,
+  target = "sampled_days"
+) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
   present_count_sections <- unique(design$counts[[section_col]])
@@ -451,8 +511,12 @@ estimate_total_harvest_sections <- function(design, by_quo, variance_method, # n
 
       if (!is.null(by_vars)) {
         # Grouped path: delegates to existing grouped helper
-        result <- estimate_total_harvest_grouped( # nolint: object_usage_linter
-          sec_design, by_vars, variance_method, conf_level,
+        result <- estimate_total_harvest_grouped(
+          # nolint: object_usage_linter
+          sec_design,
+          by_vars,
+          variance_method,
+          conf_level,
           target = target
         )
         row_df <- tibble::add_column(result$estimates, section = sec, .before = 1)
@@ -460,7 +524,12 @@ estimate_total_harvest_sections <- function(design, by_quo, variance_method, # n
         section_rows[[sec]] <- row_df
       } else {
         # Ungrouped path: call internal helpers directly to bypass sample-size validation
-        effort_res <- estimate_effort_total(sec_design, variance_method, conf_level, target = target) # nolint: object_usage_linter
+        effort_res <- estimate_effort_total(
+          sec_design,
+          variance_method,
+          conf_level,
+          target = target
+        ) # nolint: object_usage_linter
         hpue_res <- estimate_harvest_total(sec_design, variance_method, conf_level) # nolint: object_usage_linter
         effort_est <- effort_res$estimates$estimate
         hpue_est <- hpue_res$estimates$estimate
@@ -469,7 +538,7 @@ estimate_total_harvest_sections <- function(design, by_quo, variance_method, # n
         sec_estimate <- effort_est * hpue_est
         sec_var <- (effort_est^2 * hpue_se^2) + (hpue_est^2 * effort_se^2)
         sec_se <- sqrt(sec_var)
-        sec_n  <- hpue_res$estimates$n
+        sec_n <- hpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))
         section_rows[[sec]] <- tibble::tibble(
           section = sec,
@@ -520,13 +589,14 @@ estimate_total_harvest_sections <- function(design, by_quo, variance_method, # n
     result_df <- dplyr::bind_rows(result_df, lake_row)
   }
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = result_df,
-    method          = "product-total-harvest-sections",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = result_df,
+    method = "product-total-harvest-sections",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = if (!is.null(by_vars)) c("section", by_vars) else "section",
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = if (!is.null(by_vars)) c("section", by_vars) else "section",
+    effort_target = target
   )
 }

--- a/R/creel-estimates-total-release.R
+++ b/R/creel-estimates-total-release.R
@@ -124,29 +124,37 @@ estimate_total_release <- function(
 
   if (!is.null(by_info$species_var)) {
     # Species-level total release
-    estimates_df <- estimate_total_release_species( # nolint: object_usage_linter
+    estimates_df <- estimate_total_release_species(
+      # nolint: object_usage_linter
       design,
-      species_col       = by_info$species_var,
+      species_col = by_info$species_var,
       interview_by_vars = by_info$interview_vars,
-      variance_method   = variance,
-      conf_level        = conf_level,
-      target            = target
-    )
-    return(new_creel_estimates( # nolint: object_usage_linter
-      estimates       = tibble::as_tibble(estimates_df),
-      method          = "product-total-release",
       variance_method = variance,
-      design          = design,
-      conf_level      = conf_level,
-      by_vars         = by_info$all_vars,
-      effort_target   = target
+      conf_level = conf_level,
+      target = target
+    )
+    return(new_creel_estimates(
+      # nolint: object_usage_linter
+      estimates = tibble::as_tibble(estimates_df),
+      method = "product-total-release",
+      variance_method = variance,
+      design = design,
+      conf_level = conf_level,
+      by_vars = by_info$all_vars,
+      effort_target = target
     ))
   }
 
   # Section dispatch guard (v0.7.0+ — only fires when add_sections() was called)
   if (!is.null(design[["sections"]])) {
-    return(estimate_total_release_sections( # nolint: object_usage_linter
-      design, by_quo, variance, conf_level, aggregate_sections, missing_sections,
+    return(estimate_total_release_sections(
+      # nolint: object_usage_linter
+      design,
+      by_quo,
+      variance,
+      conf_level,
+      aggregate_sections,
+      missing_sections,
       target = target
     ))
   }
@@ -201,13 +209,25 @@ rpue_for_stratum_product <- function(design, by_vars, variance_method, conf_leve
 
 #' @keywords internal
 #' @noRd
-estimate_total_release_ungrouped <- function(design, variance_method, conf_level, target = "sampled_days") { # nolint: object_length_linter
+estimate_total_release_ungrouped <- function(
+  design,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
+  # nolint: object_length_linter
   strata_cols <- design$strata_cols %||% character(0)
 
   if (length(strata_cols) == 0L) {
     effort_result <- estimate_effort_total(design, variance_method, conf_level, target = target)
   } else {
-    effort_result <- estimate_effort_grouped(design, strata_cols, variance_method, conf_level, target = target)
+    effort_result <- estimate_effort_grouped(
+      design,
+      strata_cols,
+      variance_method,
+      conf_level,
+      target = target
+    )
   }
   effort_df <- effort_result$estimates
 
@@ -216,33 +236,47 @@ estimate_total_release_ungrouped <- function(design, variance_method, conf_level
 
   warn_missing_rate_strata(effort_df, rpue_df, strata_cols, "estimate_total_release") # nolint: object_usage_linter
 
-  estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
-    effort_df         = effort_df,
-    rate_df           = rpue_df,
-    stratum_by_vars   = strata_cols,
+  estimates_df <- compute_stratum_product_sum(
+    # nolint: object_usage_linter
+    effort_df = effort_df,
+    rate_df = rpue_df,
+    stratum_by_vars = strata_cols,
     interview_by_vars = NULL,
-    conf_level        = conf_level,
-    rate_suffix       = "rpue"
+    conf_level = conf_level,
+    rate_suffix = "rpue"
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = tibble::as_tibble(estimates_df),
-    method          = "product-total-release",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = tibble::as_tibble(estimates_df),
+    method = "product-total-release",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = NULL,
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = NULL,
+    effort_target = target
   )
 }
 
 #' @keywords internal
 #' @noRd
-estimate_total_release_grouped <- function(design, by_vars, variance_method, conf_level, target = "sampled_days") {
+estimate_total_release_grouped <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, by_vars))
 
-  effort_result <- estimate_effort_grouped(design, stratum_by_vars, variance_method, conf_level, target = target)
+  effort_result <- estimate_effort_grouped(
+    design,
+    stratum_by_vars,
+    variance_method,
+    conf_level,
+    target = target
+  )
   effort_df <- effort_result$estimates
 
   rpue_result <- rpue_for_stratum_product(design, stratum_by_vars, variance_method, conf_level)
@@ -250,23 +284,25 @@ estimate_total_release_grouped <- function(design, by_vars, variance_method, con
 
   warn_missing_rate_strata(effort_df, rpue_df, stratum_by_vars, "estimate_total_release(by=)") # nolint: object_usage_linter
 
-  estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
-    effort_df         = effort_df,
-    rate_df           = rpue_df,
-    stratum_by_vars   = stratum_by_vars,
+  estimates_df <- compute_stratum_product_sum(
+    # nolint: object_usage_linter
+    effort_df = effort_df,
+    rate_df = rpue_df,
+    stratum_by_vars = stratum_by_vars,
     interview_by_vars = if (length(by_vars) > 0L) by_vars else NULL,
-    conf_level        = conf_level,
-    rate_suffix       = "rpue"
+    conf_level = conf_level,
+    rate_suffix = "rpue"
   )
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = tibble::as_tibble(estimates_df),
-    method          = "product-total-release",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = tibble::as_tibble(estimates_df),
+    method = "product-total-release",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = by_vars,
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = by_vars,
+    effort_target = target
   )
 }
 
@@ -274,32 +310,45 @@ estimate_total_release_grouped <- function(design, by_vars, variance_method, con
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_release_species <- function(design, species_col, interview_by_vars,
-                                           variance_method, conf_level,
-                                           target = "sampled_days") {
+estimate_total_release_species <- function(
+  design,
+  species_col,
+  interview_by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, interview_by_vars))
 
   # Per-stratum species release rates
   rate_by <- if (length(stratum_by_vars) > 0L) stratum_by_vars else NULL
-  all_rate_df <- estimate_release_rate_species( # nolint: object_usage_linter
+  all_rate_df <- estimate_release_rate_species(
+    # nolint: object_usage_linter
     design,
-    species_col       = species_col,
+    species_col = species_col,
     interview_by_vars = rate_by,
-    variance_method   = variance_method,
-    conf_level        = conf_level,
-    validate          = FALSE
+    variance_method = variance_method,
+    conf_level = conf_level,
+    validate = FALSE
   )
 
   # Per-stratum effort
   if (length(stratum_by_vars) == 0L) {
     effort_result <- estimate_effort_total(design, variance_method, conf_level, target = target) # nolint: object_usage_linter
   } else {
-    effort_result <- estimate_effort_grouped(design, stratum_by_vars, variance_method, conf_level, target = target) # nolint: object_usage_linter
+    effort_result <- estimate_effort_grouped(
+      design,
+      stratum_by_vars,
+      variance_method,
+      conf_level,
+      target = target
+    ) # nolint: object_usage_linter
   }
   effort_df <- effort_result$estimates
 
-  warn_missing_rate_strata( # nolint: object_usage_linter
+  warn_missing_rate_strata(
+    # nolint: object_usage_linter
     effort_df = effort_df,
     rate_df = all_rate_df[, setdiff(names(all_rate_df), species_col), drop = FALSE],
     stratum_by_vars = stratum_by_vars,
@@ -314,13 +363,14 @@ estimate_total_release_species <- function(design, species_col, interview_by_var
     rate_sp_df <- all_rate_df[all_rate_df[[species_col]] == sp, , drop = FALSE]
     rate_no_sp <- rate_sp_df[, setdiff(names(rate_sp_df), species_col), drop = FALSE]
 
-    sp_result <- compute_stratum_product_sum( # nolint: object_usage_linter
-      effort_df         = effort_df,
-      rate_df           = rate_no_sp,
-      stratum_by_vars   = stratum_by_vars,
+    sp_result <- compute_stratum_product_sum(
+      # nolint: object_usage_linter
+      effort_df = effort_df,
+      rate_df = rate_no_sp,
+      stratum_by_vars = stratum_by_vars,
       interview_by_vars = interview_by_vars,
-      conf_level        = conf_level,
-      rate_suffix       = "rpue"
+      conf_level = conf_level,
+      rate_suffix = "rpue"
     )
 
     sp_result[[species_col]] <- sp
@@ -335,10 +385,15 @@ estimate_total_release_species <- function(design, species_col, interview_by_var
 #'
 #' @keywords internal
 #' @noRd
-estimate_total_release_sections <- function(design, by_quo, variance_method, # nolint: object_length_linter
-                                            conf_level, aggregate_sections,
-                                            missing_sections,
-                                            target = "sampled_days") {
+estimate_total_release_sections <- function(
+  design,
+  by_quo,
+  variance_method, # nolint: object_length_linter
+  conf_level,
+  aggregate_sections,
+  missing_sections,
+  target = "sampled_days"
+) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
   present_count_sections <- unique(design$counts[[section_col]])
@@ -406,8 +461,12 @@ estimate_total_release_sections <- function(design, by_quo, variance_method, # n
 
       if (!is.null(by_vars)) {
         # Grouped path: delegates to existing grouped helper
-        result <- estimate_total_release_grouped( # nolint: object_usage_linter
-          sec_design, by_vars, variance_method, conf_level,
+        result <- estimate_total_release_grouped(
+          # nolint: object_usage_linter
+          sec_design,
+          by_vars,
+          variance_method,
+          conf_level,
           target = target
         )
         row_df <- tibble::add_column(result$estimates, section = sec, .before = 1)
@@ -416,7 +475,12 @@ estimate_total_release_sections <- function(design, by_quo, variance_method, # n
       } else {
         # Ungrouped path: call internal helpers directly to bypass sample-size validation.
         # Build release data inline (mirrors estimate_release_rate_sections pattern).
-        effort_res <- estimate_effort_total(sec_design, variance_method, conf_level, target = target) # nolint: object_usage_linter
+        effort_res <- estimate_effort_total(
+          sec_design,
+          variance_method,
+          conf_level,
+          target = target
+        ) # nolint: object_usage_linter
         release_data <- estimate_release_build_data(sec_design, species = NULL) # nolint: object_usage_linter
         release_data$.release_effort <- release_data[[sec_design$angler_effort_col]]
         design_rel <- sec_design
@@ -429,7 +493,8 @@ estimate_total_release_sections <- function(design, by_quo, variance_method, # n
         } else {
           NULL
         }
-        design_rel$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+        design_rel$interview_survey <- build_interview_survey(
+          # nolint: object_usage_linter
           release_data,
           strata = strata_formula
         )
@@ -441,7 +506,7 @@ estimate_total_release_sections <- function(design, by_quo, variance_method, # n
         sec_estimate <- effort_est * rpue_est
         sec_var <- (effort_est^2 * rpue_se^2) + (rpue_est^2 * effort_se^2)
         sec_se <- sqrt(sec_var)
-        sec_n  <- rpue_res$estimates$n
+        sec_n <- rpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))
         section_rows[[sec]] <- tibble::tibble(
           section = sec,
@@ -492,13 +557,14 @@ estimate_total_release_sections <- function(design, by_quo, variance_method, # n
     result_df <- dplyr::bind_rows(result_df, lake_row)
   }
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = result_df,
-    method          = "product-total-release-sections",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = result_df,
+    method = "product-total-release-sections",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = if (!is.null(by_vars)) c("section", by_vars) else "section",
-    effort_target   = target
+    design = design,
+    conf_level = conf_level,
+    by_vars = if (!is.null(by_vars)) c("section", by_vars) else "section",
+    effort_target = target
   )
 }

--- a/R/creel-estimates-total-release.R
+++ b/R/creel-estimates-total-release.R
@@ -214,6 +214,8 @@ estimate_total_release_ungrouped <- function(design, variance_method, conf_level
   rpue_result <- rpue_for_stratum_product(design, strata_cols, variance_method, conf_level)
   rpue_df <- rpue_result$estimates
 
+  warn_missing_rate_strata(effort_df, rpue_df, strata_cols, "estimate_total_release") # nolint: object_usage_linter
+
   estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
     effort_df         = effort_df,
     rate_df           = rpue_df,
@@ -245,6 +247,8 @@ estimate_total_release_grouped <- function(design, by_vars, variance_method, con
 
   rpue_result <- rpue_for_stratum_product(design, stratum_by_vars, variance_method, conf_level)
   rpue_df <- rpue_result$estimates
+
+  warn_missing_rate_strata(effort_df, rpue_df, stratum_by_vars, "estimate_total_release(by=)") # nolint: object_usage_linter
 
   estimates_df <- compute_stratum_product_sum( # nolint: object_usage_linter
     effort_df         = effort_df,

--- a/R/creel-estimates-trip-density.R
+++ b/R/creel-estimates-trip-density.R
@@ -89,7 +89,15 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
     dur_vals <- durations_all[!is.na(durations_all) & durations_all > 0]
     n_int <- length(dur_vals)
     L     <- mean(dur_vals)
-    se_L  <- stats::sd(dur_vals) / sqrt(n_int)
+    if (n_int < 2L) {
+      cli::cli_warn(c(
+        "!" = "Only {n_int} valid trip duration value{?s}; SE of mean trip length is undefined.",
+        "i" = "SE and CI will be {.val NA}. Point estimate (trips) is still returned."
+      ))
+      se_L <- NA_real_
+    } else {
+      se_L <- stats::sd(dur_vals) / sqrt(n_int)
+    }
 
     if (L <= 0) {
       cli::cli_abort(
@@ -132,10 +140,27 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   summary_df <- dplyr::summarise(
     dplyr::group_by(interview_df, dplyr::across(dplyr::all_of(effort$by_vars))),
     mean_L       = mean(.data$.duration, na.rm = TRUE),
-    se_L         = stats::sd(.data$.duration, na.rm = TRUE) / sqrt(dplyr::n()),
+    se_L         = dplyr::if_else(
+      dplyr::n() >= 2L,
+      stats::sd(.data$.duration, na.rm = TRUE) / sqrt(dplyr::n()),
+      NA_real_
+    ),
     n_interviews = dplyr::n(),
     .groups      = "drop"
   )
+
+  # Warn about single-interview strata (SD undefined → SE/CI will be NA)
+  singleton_strata <- summary_df[summary_df$n_interviews < 2L, , drop = FALSE]
+  if (nrow(singleton_strata) > 0L) {
+    stratum_labels <- apply(
+      singleton_strata[effort$by_vars],
+      1, paste, collapse = " / "
+    )
+    cli::cli_warn(c(
+      "!" = "{nrow(singleton_strata)} stratum/strata {?has/have} only 1 interview; SE of mean trip length is undefined.",
+      "i" = "SE and CI will be {.val NA} for: {.val {stratum_labels}}. Point estimates are still returned."
+    ))
+  }
 
   # Guard against zero mean trip length
   if (any(summary_df$mean_L <= 0, na.rm = TRUE)) {

--- a/R/creel-estimates-trip-density.R
+++ b/R/creel-estimates-trip-density.R
@@ -41,7 +41,6 @@
 #'
 #' @export
 estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
-
   # --- input guards ---
   if (!inherits(effort, "creel_estimates")) {
     cli::cli_abort(
@@ -88,7 +87,7 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   if (is.null(effort$by_vars)) {
     dur_vals <- durations_all[!is.na(durations_all) & durations_all > 0]
     n_int <- length(dur_vals)
-    L     <- mean(dur_vals)
+    L <- mean(dur_vals)
     if (n_int < 2L) {
       cli::cli_warn(c(
         "!" = "Only {n_int} valid trip duration value{?s}; SE of mean trip length is undefined.",
@@ -105,29 +104,29 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
       )
     }
 
-    E     <- effort$estimates$estimate
-    se_E  <- effort$estimates$se
+    E <- effort$estimates$estimate
+    se_E <- effort$estimates$se
 
     var_trips <- se_E^2 / L^2 + E^2 * se_L^2 / L^4
-    se_trips  <- sqrt(var_trips)
-    trips     <- E / L
+    se_trips <- sqrt(var_trips)
+    trips <- E / L
 
     estimates_df <- tibble::tibble(
       estimate = trips,
-      se       = se_trips,
+      se = se_trips,
       ci_lower = trips - z * se_trips,
       ci_upper = trips + z * se_trips,
-      n        = n_int
+      n = n_int
     )
 
     return(
       new_creel_estimates(
-        estimates       = estimates_df,
-        method          = "angler-trips",
+        estimates = estimates_df,
+        method = "angler-trips",
         variance_method = "delta",
-        design          = NULL,
-        conf_level      = conf_level,
-        by_vars         = NULL
+        design = NULL,
+        conf_level = conf_level,
+        by_vars = NULL
       )
     )
   }
@@ -139,14 +138,14 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   # Compute per-stratum mean trip length
   summary_df <- dplyr::summarise(
     dplyr::group_by(interview_df, dplyr::across(dplyr::all_of(effort$by_vars))),
-    mean_L       = mean(.data$.duration, na.rm = TRUE),
-    se_L         = dplyr::if_else(
+    mean_L = mean(.data$.duration, na.rm = TRUE),
+    se_L = dplyr::if_else(
       dplyr::n() >= 2L,
       stats::sd(.data$.duration, na.rm = TRUE) / sqrt(dplyr::n()),
       NA_real_
     ),
     n_interviews = dplyr::n(),
-    .groups      = "drop"
+    .groups = "drop"
   )
 
   # Warn about single-interview strata (SD undefined → SE/CI will be NA)
@@ -154,7 +153,9 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   if (nrow(singleton_strata) > 0L) {
     stratum_labels <- apply(
       singleton_strata[effort$by_vars],
-      1, paste, collapse = " / "
+      1,
+      paste,
+      collapse = " / "
     )
     cli::cli_warn(c(
       "!" = "{nrow(singleton_strata)} stratum/strata {?has/have} only 1 interview; SE of mean trip length is undefined.",
@@ -182,29 +183,29 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   }
 
   # Row-wise Delta Method
-  E         <- joined$estimate
-  se_E      <- joined$se
-  L         <- joined$mean_L
-  se_L_vec  <- joined$se_L
+  E <- joined$estimate
+  se_E <- joined$se
+  L <- joined$mean_L
+  se_L_vec <- joined$se_L
 
   var_trips <- se_E^2 / L^2 + E^2 * se_L_vec^2 / L^4
-  trips     <- E / L
-  se_trips  <- sqrt(var_trips)
+  trips <- E / L
+  se_trips <- sqrt(var_trips)
 
   # Per-stratum rows
   stratum_rows <- tibble::tibble(
     dplyr::select(joined, dplyr::all_of(effort$by_vars)),
     estimate = trips,
-    se       = se_trips,
+    se = se_trips,
     ci_lower = trips - z * se_trips,
     ci_upper = trips + z * se_trips,
-    n        = joined$n_interviews
+    n = joined$n_interviews
   )
 
   # .overall row: additive aggregate
   overall_est <- sum(trips)
   overall_var <- sum(var_trips)
-  overall_se  <- sqrt(overall_var)
+  overall_se <- sqrt(overall_var)
 
   overall_vals <- stats::setNames(
     rep(".overall", length(effort$by_vars)),
@@ -212,20 +213,20 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   )
   overall_row <- tibble::as_tibble(as.list(overall_vals))
   overall_row$estimate <- overall_est
-  overall_row$se       <- overall_se
+  overall_row$se <- overall_se
   overall_row$ci_lower <- overall_est - z * overall_se
   overall_row$ci_upper <- overall_est + z * overall_se
-  overall_row$n        <- sum(joined$n_interviews)
+  overall_row$n <- sum(joined$n_interviews)
 
   estimates_df <- dplyr::bind_rows(stratum_rows, overall_row)
 
   new_creel_estimates(
-    estimates       = estimates_df,
-    method          = "angler-trips",
+    estimates = estimates_df,
+    method = "angler-trips",
     variance_method = "delta",
-    design          = NULL,
-    conf_level      = conf_level,
-    by_vars         = effort$by_vars
+    design = NULL,
+    conf_level = conf_level,
+    by_vars = effort$by_vars
   )
 }
 
@@ -261,7 +262,6 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
 #'
 #' @export
 estimate_effort_per_acre <- function(effort, acres, ...) {
-
   # --- input guards ---
   if (!inherits(effort, "creel_estimates")) {
     cli::cli_abort(
@@ -279,20 +279,24 @@ estimate_effort_per_acre <- function(effort, acres, ...) {
   est_df <- effort$estimates
 
   est_df$estimate <- est_df$estimate / acres
-  est_df$se       <- est_df$se       / acres
+  est_df$se <- est_df$se / acres
   est_df$ci_lower <- est_df$ci_lower / acres
   est_df$ci_upper <- est_df$ci_upper / acres
 
-  if ("se_between" %in% names(est_df)) est_df$se_between <- est_df$se_between / acres
-  if ("se_within"  %in% names(est_df)) est_df$se_within  <- est_df$se_within  / acres
+  if ("se_between" %in% names(est_df)) {
+    est_df$se_between <- est_df$se_between / acres
+  }
+  if ("se_within" %in% names(est_df)) {
+    est_df$se_within <- est_df$se_within / acres
+  }
 
   # --- return ---
   new_creel_estimates(
-    estimates       = est_df,
-    method          = "effort-per-acre",
+    estimates = est_df,
+    method = "effort-per-acre",
     variance_method = effort$variance_method,
-    design          = NULL,
-    conf_level      = effort$conf_level,
-    by_vars         = effort$by_vars
+    design = NULL,
+    conf_level = effort$conf_level,
+    by_vars = effort$by_vars
   )
 }

--- a/R/creel-estimates-trip-density.R
+++ b/R/creel-estimates-trip-density.R
@@ -82,13 +82,14 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   }
 
   z <- stats::qnorm(1 - (1 - conf_level) / 2)
+  min_n_se <- 2L
 
   # --- ungrouped case ---
   if (is.null(effort$by_vars)) {
     dur_vals <- durations_all[!is.na(durations_all) & durations_all > 0]
     n_int <- length(dur_vals)
     L <- mean(dur_vals)
-    if (n_int < 2L) {
+    if (n_int < min_n_se) {
       cli::cli_warn(c(
         "!" = "Only {n_int} valid trip duration value{?s}; SE of mean trip length is undefined.",
         "i" = "SE and CI will be {.val NA}. Point estimate (trips) is still returned."
@@ -140,7 +141,7 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
     dplyr::group_by(interview_df, dplyr::across(dplyr::all_of(effort$by_vars))),
     mean_L = mean(.data$.duration, na.rm = TRUE),
     se_L = dplyr::if_else(
-      dplyr::n() >= 2L,
+      dplyr::n() >= min_n_se,
       stats::sd(.data$.duration, na.rm = TRUE) / sqrt(dplyr::n()),
       NA_real_
     ),
@@ -149,7 +150,7 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   )
 
   # Warn about single-interview strata (SD undefined → SE/CI will be NA)
-  singleton_strata <- summary_df[summary_df$n_interviews < 2L, , drop = FALSE]
+  singleton_strata <- summary_df[summary_df$n_interviews < min_n_se, , drop = FALSE]
   if (nrow(singleton_strata) > 0L) {
     stratum_labels <- apply(
       singleton_strata[effort$by_vars],

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -1673,6 +1673,35 @@ estimate_harvest_rate <- function(
     }
   }
 
+  # Detect species-level grouping
+  by_info <- resolve_species_by(by_quo, design) # nolint: object_usage_linter
+
+  # Species-level dispatch
+  if (!is.null(by_info$species_var)) {
+    if (is.null(design[["catch"]])) {
+      cli::cli_abort(c(
+        "Species-level HPUE requires catch data.",
+        "x" = "{.field species} found in {.arg by} but {.fn add_catch} has not been called.",
+        "i" = "Call {.fn add_catch} before using species grouping in {.fn estimate_harvest_rate}."
+      ))
+    }
+    estimates_df <- estimate_hpue_species( # nolint: object_usage_linter
+      design,
+      species_col       = by_info$species_var,
+      interview_by_vars = by_info$interview_vars,
+      variance_method   = variance,
+      conf_level        = conf_level
+    )
+    return(new_creel_estimates( # nolint: object_usage_linter
+      estimates       = tibble::as_tibble(estimates_df),
+      method          = "ratio-of-means-hpue-species",
+      variance_method = variance,
+      design          = design,
+      conf_level      = conf_level,
+      by_vars         = by_info$all_vars
+    ))
+  }
+
   # Route to grouped or ungrouped estimation
   if (rlang::quo_is_null(by_quo)) {
     # Ungrouped estimation

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -68,21 +68,25 @@ wrap_survey_call <- function(expr) {
 #'
 #' @keywords internal
 #' @noRd
-new_creel_estimates <- function(estimates,
-                                method = "total",
-                                variance_method = "taylor",
-                                design = NULL,
-                                conf_level = 0.95,
-                                by_vars = NULL,
-                                effort_target = NULL) {
+new_creel_estimates <- function(
+  estimates,
+  method = "total",
+  variance_method = "taylor",
+  design = NULL,
+  conf_level = 0.95,
+  by_vars = NULL,
+  effort_target = NULL
+) {
   # Input validation
   stopifnot(
     "estimates must be a data.frame" = is.data.frame(estimates),
     "method must be character" = is.character(method) && length(method) == 1,
-    "variance_method must be character" = is.character(variance_method) && length(variance_method) == 1,
+    "variance_method must be character" = is.character(variance_method) &&
+      length(variance_method) == 1,
     "conf_level must be numeric" = is.numeric(conf_level) && length(conf_level) == 1,
     "by_vars must be NULL or character" = is.null(by_vars) || is.character(by_vars),
-    "effort_target must be NULL or character" = is.null(effort_target) || is.character(effort_target)
+    "effort_target must be NULL or character" = is.null(effort_target) ||
+      is.character(effort_target)
   )
 
   structure(
@@ -115,16 +119,18 @@ new_creel_estimates <- function(estimates,
 #'
 #' @keywords internal
 #' @noRd
-new_creel_estimates_mor <- function(estimates,
-                                    method = "mean-of-ratios-cpue",
-                                    variance_method = "taylor",
-                                    design = NULL,
-                                    conf_level = 0.95,
-                                    by_vars = NULL,
-                                    n_incomplete = NULL,
-                                    n_total = NULL,
-                                    mor_truncate_at = NULL,
-                                    mor_n_truncated = NULL) {
+new_creel_estimates_mor <- function(
+  estimates,
+  method = "mean-of-ratios-cpue",
+  variance_method = "taylor",
+  design = NULL,
+  conf_level = 0.95,
+  by_vars = NULL,
+  n_incomplete = NULL,
+  n_total = NULL,
+  mor_truncate_at = NULL,
+  mor_n_truncated = NULL
+) {
   # Call parent constructor
   result <- new_creel_estimates(
     estimates = estimates,
@@ -157,7 +163,8 @@ new_creel_estimates_mor <- function(estimates,
 #' @export
 format.creel_estimates <- function(x, ...) {
   # Convert variance method to human-readable form
-  variance_display <- switch(x$variance_method, # nolint: object_usage_linter
+  variance_display <- switch(
+    x$variance_method, # nolint: object_usage_linter
     taylor = "Taylor linearization",
     bootstrap = "Bootstrap",
     jackknife = "Jackknife",
@@ -168,7 +175,8 @@ format.creel_estimates <- function(x, ...) {
   conf_pct <- paste0(round(x$conf_level * 100), "%") # nolint: object_usage_linter
 
   # Convert method to human-readable form
-  method_display <- switch(x$method, # nolint: object_usage_linter
+  method_display <- switch(
+    x$method, # nolint: object_usage_linter
     total = "Total",
     "ratio-of-means-cpue" = "Ratio-of-Means CPUE",
     "mean-of-ratios-cpue" = "Mean-of-Ratios CPUE",
@@ -185,29 +193,32 @@ format.creel_estimates <- function(x, ...) {
   # Build formatted output using cli
   output <- character()
 
-  output <- c(output, cli::cli_format_method({
-    cli::cli_h1("Creel Survey Estimates")
-    cli::cli_text("Method: {method_display}")
-    cli::cli_text("Variance: {variance_display}")
-    cli::cli_text("Confidence level: {conf_pct}")
+  output <- c(
+    output,
+    cli::cli_format_method({
+      cli::cli_h1("Creel Survey Estimates")
+      cli::cli_text("Method: {method_display}")
+      cli::cli_text("Variance: {variance_display}")
+      cli::cli_text("Confidence level: {conf_pct}")
 
-    # Show normalization note if effort was normalized by party size
-    if (endsWith(x$method, "-per-angler")) {
-      cli::cli_text("Note: Effort normalized by party size (n_anglers)")
-    }
+      # Show normalization note if effort was normalized by party size
+      if (endsWith(x$method, "-per-angler")) {
+        cli::cli_text("Note: Effort normalized by party size (n_anglers)")
+      }
 
-    # Show grouping variables if present
-    if (!is.null(x$by_vars)) {
-      by_display <- paste(x$by_vars, collapse = ", ") # nolint: object_usage_linter
-      cli::cli_text("Grouped by: {by_display}")
-    }
+      # Show grouping variables if present
+      if (!is.null(x$by_vars)) {
+        by_display <- paste(x$by_vars, collapse = ", ") # nolint: object_usage_linter
+        cli::cli_text("Grouped by: {by_display}")
+      }
 
-    if (!is.null(x$effort_target)) {
-      cli::cli_text("Effort target: {x$effort_target}")
-    }
+      if (!is.null(x$effort_target)) {
+        cli::cli_text("Effort target: {x$effort_target}")
+      }
 
-    cli::cli_text("")
-  }))
+      cli::cli_text("")
+    })
+  )
 
   # Add estimates table
   output <- c(output, utils::capture.output(print(x$estimates)))
@@ -361,10 +372,17 @@ print.creel_estimates <- function(x, ...) {
 #' result_verbose <- estimate_effort(design_with_counts, verbose = TRUE)
 #' @family "Estimation"
 #' @export
-estimate_effort <- function(design, by = NULL, variance = "taylor", conf_level = 0.95,
-                            target = c("sampled_days", "stratum_total", "period_total"),
-                            verbose = FALSE, aggregate_sections = TRUE,
-                            method = "correlated", missing_sections = "warn") {
+estimate_effort <- function(
+  design,
+  by = NULL,
+  variance = "taylor",
+  conf_level = 0.95,
+  target = c("sampled_days", "stratum_total", "period_total"),
+  verbose = FALSE,
+  aggregate_sections = TRUE,
+  method = "correlated",
+  missing_sections = "warn"
+) {
   # Capture by parameter BEFORE validation
   by_quo <- rlang::enquo(by)
   target <- match.arg(target)
@@ -446,7 +464,8 @@ estimate_effort <- function(design, by = NULL, variance = "taylor", conf_level =
       by_vars_br <- names(by_cols_br)
     }
 
-    result <- estimate_effort_br( # nolint: object_usage_linter.
+    result <- estimate_effort_br(
+      # nolint: object_usage_linter.
       design,
       by_vars_br,
       variance,
@@ -457,7 +476,8 @@ estimate_effort <- function(design, by = NULL, variance = "taylor", conf_level =
 
     # Ice-specific: rename 'estimate' column to reflect effort_type
     if (identical(design$design_type, "ice")) {
-      col_name <- switch(design$ice$effort_type,
+      col_name <- switch(
+        design$ice$effort_type,
         time_on_ice = "total_effort_hr_on_ice",
         active_fishing_time = "total_effort_hr_active",
         "estimate"
@@ -502,7 +522,8 @@ estimate_effort <- function(design, by = NULL, variance = "taylor", conf_level =
         "i" = "Use {.code target = 'sampled_days'} for now."
       ))
     }
-    return(estimate_effort_sections( # nolint: object_usage_linter
+    return(estimate_effort_sections(
+      # nolint: object_usage_linter
       design,
       variance,
       conf_level,
@@ -725,24 +746,30 @@ estimate_effort <- function(design, by = NULL, variance = "taylor", conf_level =
 #' result_mor_1h <- estimate_catch_rate(design_with_interviews, estimator = "mor", truncate_at = 1.0)
 #' @family "Estimation"
 #' @export
-estimate_catch_rate <- function(design,
-                                by = NULL,
-                                variance = "taylor",
-                                conf_level = 0.95,
-                                estimator = NULL,
-                                use_trips = NULL,
-                                truncate_at = 0.5,
-                                targeted = TRUE,
-                                missing_sections = "warn",
-                                force_origin = TRUE) {
+estimate_catch_rate <- function(
+  design,
+  by = NULL,
+  variance = "taylor",
+  conf_level = 0.95,
+  estimator = NULL,
+  use_trips = NULL,
+  truncate_at = 0.5,
+  targeted = TRUE,
+  missing_sections = "warn",
+  force_origin = TRUE
+) {
   # Capture by parameter BEFORE validation
   by_quo <- rlang::enquo(by)
 
   # Track whether use_trips / estimator were explicitly provided
-  use_trips_is_default  <- is.null(use_trips)
-  estimator_is_default  <- is.null(estimator)
-  if (is.null(use_trips))  use_trips  <- "complete"
-  if (is.null(estimator))  estimator  <- "ratio-of-means"
+  use_trips_is_default <- is.null(use_trips)
+  estimator_is_default <- is.null(estimator)
+  if (is.null(use_trips)) {
+    use_trips <- "complete"
+  }
+  if (is.null(estimator)) {
+    estimator <- "ratio-of-means"
+  }
 
   # Auto-route roving designs: when interview_type="roving" and the user has not
   # specified use_trips or estimator, default to all-trip MOR (Hoenig 1997).
@@ -1094,7 +1121,9 @@ estimate_catch_rate <- function(design,
 
       # Filter to incomplete trips and rebuild survey design
       # This lets MOR's validate_mor_availability see incomplete-only data
-      incomplete_interviews <- design$interviews[design$interviews[[trip_status_col]] == "incomplete", ]
+      incomplete_interviews <- design$interviews[
+        design$interviews[[trip_status_col]] == "incomplete",
+      ]
       design <- rebuild_interview_survey(design, incomplete_interviews) # nolint: object_usage_linter
     } else if (use_trips == "all") {
       # Roving design (or explicit use_trips="all"): use all interviews with MOR.
@@ -1128,8 +1157,8 @@ estimate_catch_rate <- function(design,
     # Determine if we already filtered via use_trips
     # Track which use_trips branch filtered the data
     use_trips_was_incomplete <- has_trip_status && use_trips == "incomplete"
-    use_trips_was_complete   <- has_trip_status && use_trips == "complete"
-    use_trips_was_all        <- has_trip_status && use_trips == "all"
+    use_trips_was_complete <- has_trip_status && use_trips == "complete"
+    use_trips_was_all <- has_trip_status && use_trips == "all"
 
     # Non-standard case: use_trips='complete' + estimator='mor'
     # Warn but allow (valid but unusual choice)
@@ -1168,7 +1197,9 @@ estimate_catch_rate <- function(design,
       # Old behavior: no use_trips filtering, filter to incomplete now
       n_total <- nrow(design$interviews)
       n_incomplete <- sum(design$interviews[[design$trip_status_col]] == "incomplete", na.rm = TRUE)
-      incomplete_interviews <- design$interviews[design$interviews[[design$trip_status_col]] == "incomplete", ]
+      incomplete_interviews <- design$interviews[
+        design$interviews[[design$trip_status_col]] == "incomplete",
+      ]
     }
 
     # Issue MOR assumptions warning, except:
@@ -1274,7 +1305,8 @@ estimate_catch_rate <- function(design,
     } else {
       NULL
     }
-    design_incomplete$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+    design_incomplete$interview_survey <- build_interview_survey(
+      # nolint: object_usage_linter
       incomplete_interviews,
       strata = strata_formula
     )
@@ -1285,8 +1317,14 @@ estimate_catch_rate <- function(design,
 
   # Section dispatch guard — fires AFTER trip filtering, BEFORE standard dispatch
   if (!is.null(design[["sections"]])) {
-    return(estimate_catch_rate_sections( # nolint: object_usage_linter
-      design, by_quo, variance, conf_level, missing_sections, estimator
+    return(estimate_catch_rate_sections(
+      # nolint: object_usage_linter
+      design,
+      by_quo,
+      variance,
+      conf_level,
+      missing_sections,
+      estimator
     ))
   }
 
@@ -1304,13 +1342,14 @@ estimate_catch_rate <- function(design,
       ))
     }
 
-    estimates_df <- estimate_cpue_species( # nolint: object_usage_linter
+    estimates_df <- estimate_cpue_species(
+      # nolint: object_usage_linter
       design,
-      species_col       = by_info$species_var,
+      species_col = by_info$species_var,
       interview_by_vars = by_info$interview_vars,
-      variance_method   = variance,
-      conf_level        = conf_level,
-      estimator         = estimator
+      variance_method = variance,
+      conf_level = conf_level,
+      estimator = estimator
     )
 
     method_label <- if (estimator == "mor") {
@@ -1320,35 +1359,40 @@ estimate_catch_rate <- function(design,
     }
 
     if (estimator == "mor") {
-      return(new_creel_estimates_mor( # nolint: object_usage_linter
-        estimates       = tibble::as_tibble(estimates_df),
-        method          = method_label,
+      return(new_creel_estimates_mor(
+        # nolint: object_usage_linter
+        estimates = tibble::as_tibble(estimates_df),
+        method = method_label,
         variance_method = variance,
-        design          = design,
-        conf_level      = conf_level,
-        by_vars         = by_info$all_vars,
-        n_incomplete    = design$mor_n_incomplete,
-        n_total         = design$mor_n_total,
+        design = design,
+        conf_level = conf_level,
+        by_vars = by_info$all_vars,
+        n_incomplete = design$mor_n_incomplete,
+        n_total = design$mor_n_total,
         mor_truncate_at = design$mor_truncate_at,
         mor_n_truncated = design$mor_n_truncated
       ))
     }
 
-    return(new_creel_estimates( # nolint: object_usage_linter
-      estimates       = tibble::as_tibble(estimates_df),
-      method          = method_label,
+    return(new_creel_estimates(
+      # nolint: object_usage_linter
+      estimates = tibble::as_tibble(estimates_df),
+      method = method_label,
       variance_method = variance,
-      design          = design,
-      conf_level      = conf_level,
-      by_vars         = by_info$all_vars
+      design = design,
+      conf_level = conf_level,
+      by_vars = by_info$all_vars
     ))
   }
 
   # Regression (CPUE3) path — route before standard dispatch
   if (estimator == "regression") {
     if (rlang::quo_is_null(by_quo)) {
-      return(estimate_cpue_regression_total( # nolint: object_usage_linter
-        design, conf_level, force_origin
+      return(estimate_cpue_regression_total(
+        # nolint: object_usage_linter
+        design,
+        conf_level,
+        force_origin
       ))
     } else {
       by_cols <- tidyselect::eval_select(
@@ -1359,8 +1403,12 @@ estimate_catch_rate <- function(design,
         error_call = rlang::caller_env()
       )
       by_vars <- names(by_cols)
-      return(estimate_cpue_reg_grouped( # nolint: object_usage_linter
-        design, by_vars, conf_level, force_origin
+      return(estimate_cpue_reg_grouped(
+        # nolint: object_usage_linter
+        design,
+        by_vars,
+        conf_level,
+        force_origin
       ))
     }
   }
@@ -1381,8 +1429,13 @@ estimate_catch_rate <- function(design,
     )
     by_vars <- names(by_cols)
     validate_ratio_sample_size(design, by_vars, type = "cpue") # nolint: object_usage_linter
-    return(estimate_cpue_grouped( # nolint: object_usage_linter
-      design, by_vars, variance, conf_level, dispatch_estimator
+    return(estimate_cpue_grouped(
+      # nolint: object_usage_linter
+      design,
+      by_vars,
+      variance,
+      conf_level,
+      dispatch_estimator
     ))
   }
 }
@@ -1586,9 +1639,14 @@ estimate_harvest_rate <- function(
       by_vars_br <- names(by_cols_br)
     }
     use_trips_br <- if (is.null(use_trips)) "complete" else use_trips
-    return(estimate_harvest_br( # nolint: object_usage_linter
-      design, by_vars_br, variance, conf_level,
-      verbose = FALSE, use_trips = use_trips_br
+    return(estimate_harvest_br(
+      # nolint: object_usage_linter
+      design,
+      by_vars_br,
+      variance,
+      conf_level,
+      verbose = FALSE,
+      use_trips = use_trips_br
     ))
   }
 
@@ -1616,14 +1674,21 @@ estimate_harvest_rate <- function(
 
   # Section dispatch guard — fires AFTER validation, BEFORE standard dispatch
   if (!is.null(design[["sections"]])) {
-    return(estimate_harvest_rate_sections( # nolint: object_usage_linter
-      design, by_quo, variance, conf_level, missing_sections
+    return(estimate_harvest_rate_sections(
+      # nolint: object_usage_linter
+      design,
+      by_quo,
+      variance,
+      conf_level,
+      missing_sections
     ))
   }
 
   # Handle use_trips for standard (non-bus-route, non-sectioned) path
   use_trips_is_default <- is.null(use_trips)
-  if (is.null(use_trips)) use_trips <- "complete"
+  if (is.null(use_trips)) {
+    use_trips <- "complete"
+  }
   valid_use_trips_std <- c("all", "complete")
   if (!use_trips %in% valid_use_trips_std) {
     cli::cli_abort(c(
@@ -1685,20 +1750,22 @@ estimate_harvest_rate <- function(
         "i" = "Call {.fn add_catch} before using species grouping in {.fn estimate_harvest_rate}."
       ))
     }
-    estimates_df <- estimate_hpue_species( # nolint: object_usage_linter
+    estimates_df <- estimate_hpue_species(
+      # nolint: object_usage_linter
       design,
-      species_col       = by_info$species_var,
+      species_col = by_info$species_var,
       interview_by_vars = by_info$interview_vars,
-      variance_method   = variance,
-      conf_level        = conf_level
-    )
-    return(new_creel_estimates( # nolint: object_usage_linter
-      estimates       = tibble::as_tibble(estimates_df),
-      method          = "ratio-of-means-hpue-species",
       variance_method = variance,
-      design          = design,
-      conf_level      = conf_level,
-      by_vars         = by_info$all_vars
+      conf_level = conf_level
+    )
+    return(new_creel_estimates(
+      # nolint: object_usage_linter
+      estimates = tibble::as_tibble(estimates_df),
+      method = "ratio-of-means-hpue-species",
+      variance_method = variance,
+      design = design,
+      conf_level = conf_level,
+      by_vars = by_info$all_vars
     ))
   }
 
@@ -1861,14 +1928,21 @@ estimate_release_rate <- function(
 
   # Section dispatch guard — fires AFTER validation, BEFORE standard dispatch
   if (!is.null(design[["sections"]])) {
-    return(estimate_release_rate_sections( # nolint: object_usage_linter
-      design, by_quo, variance, conf_level, missing_sections
+    return(estimate_release_rate_sections(
+      # nolint: object_usage_linter
+      design,
+      by_quo,
+      variance,
+      conf_level,
+      missing_sections
     ))
   }
 
   # Handle use_trips for standard (non-sectioned) path
   use_trips_is_default <- is.null(use_trips)
-  if (is.null(use_trips)) use_trips <- "complete"
+  if (is.null(use_trips)) {
+    use_trips <- "complete"
+  }
   valid_use_trips_std <- c("all", "complete")
   if (!use_trips %in% valid_use_trips_std) {
     cli::cli_abort(c(
@@ -1923,20 +1997,22 @@ estimate_release_rate <- function(
 
   if (!is.null(by_info$species_var)) {
     # Species-level release rate: loop over species
-    estimates_df <- estimate_release_rate_species( # nolint: object_usage_linter
+    estimates_df <- estimate_release_rate_species(
+      # nolint: object_usage_linter
       design,
       species_col = by_info$species_var,
       interview_by_vars = by_info$interview_vars,
       variance_method = variance,
       conf_level = conf_level
     )
-    return(new_creel_estimates( # nolint: object_usage_linter
-      estimates       = tibble::as_tibble(estimates_df),
-      method          = "ratio-of-means-rpue",
+    return(new_creel_estimates(
+      # nolint: object_usage_linter
+      estimates = tibble::as_tibble(estimates_df),
+      method = "ratio-of-means-rpue",
       variance_method = variance,
-      design          = design,
-      conf_level      = conf_level,
-      by_vars         = by_info$all_vars
+      design = design,
+      conf_level = conf_level,
+      by_vars = by_info$all_vars
     ))
   }
 
@@ -1957,7 +2033,8 @@ estimate_release_rate <- function(
   } else {
     NULL
   }
-  design_rel$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+  design_rel$interview_survey <- build_interview_survey(
+    # nolint: object_usage_linter
     release_data,
     strata = strata_formula
   )
@@ -2008,7 +2085,8 @@ rebuild_interview_survey <- function(design, filtered_interviews) {
   } else {
     NULL
   }
-  design_new$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+  design_new$interview_survey <- build_interview_survey(
+    # nolint: object_usage_linter
     filtered_interviews,
     strata = strata_formula
   )
@@ -2061,31 +2139,31 @@ aggregate_section_totals <- function(by_formula, full_design_svy, count_formula,
   if (method == "correlated") {
     by_result <- survey::svyby(
       formula = count_formula,
-      by      = by_formula,
-      design  = full_design_svy,
-      FUN     = survey::svytotal,
-      covmat  = TRUE
+      by = by_formula,
+      design = full_design_svy,
+      FUN = survey::svytotal,
+      covmat = TRUE
     )
     contrast_vec <- setNames(rep(1, nrow(by_result)), rownames(vcov(by_result)))
     lake_contrast <- survey::svycontrast(by_result, list(lake_total = contrast_vec))
     list(
       estimate = as.numeric(coef(lake_contrast)),
-      se       = as.numeric(survey::SE(lake_contrast))
+      se = as.numeric(survey::SE(lake_contrast))
     )
   } else {
     # Cochran 5.2 — documented approximation for independent section designs
     by_result_ind <- survey::svyby(
       formula = count_formula,
-      by      = by_formula,
-      design  = full_design_svy,
-      FUN     = survey::svytotal,
-      covmat  = FALSE
+      by = by_formula,
+      design = full_design_svy,
+      FUN = survey::svytotal,
+      covmat = FALSE
     )
     section_ests <- as.numeric(coef(by_result_ind))
     section_ses <- as.numeric(survey::SE(by_result_ind))
     list(
       estimate = sum(section_ests),
-      se       = sqrt(sum(section_ses^2))
+      se = sqrt(sum(section_ses^2))
     )
   }
 }
@@ -2148,7 +2226,9 @@ resolve_species_by <- function(by_quo, design) {
   # Split: species_var vs interview_vars
   species_var <- if (species_col_name %in% all_vars) species_col_name else NULL
   interview_vars <- setdiff(all_vars, species_col_name)
-  if (length(interview_vars) == 0L) interview_vars <- NULL
+  if (length(interview_vars) == 0L) {
+    interview_vars <- NULL
+  }
 
   list(
     all_vars = all_vars,
@@ -2174,7 +2254,8 @@ resolve_species_by <- function(by_quo, design) {
 #'
 #' @keywords internal
 #' @noRd
-make_species_catch_for_interviews <- function(design, species_val, catch_type_val) { # nolint: object_length_linter
+make_species_catch_for_interviews <- function(design, species_val, catch_type_val) {
+  # nolint: object_length_linter
   catch_df <- design[["catch"]]
   interviews <- design$interviews
 
@@ -2193,13 +2274,17 @@ make_species_catch_for_interviews <- function(design, species_val, catch_type_va
       species_catch <- caught_only[, c(uid_col, count_col), drop = FALSE]
     } else {
       sub_rows <- species_rows[
-        species_rows[[type_col]] %in% c("harvested", "released"), , drop = FALSE
+        species_rows[[type_col]] %in% c("harvested", "released"),
+        ,
+        drop = FALSE
       ]
       species_catch <- sub_rows[, c(uid_col, count_col), drop = FALSE]
     }
   } else {
     species_catch <- species_rows[
-      species_rows[[type_col]] == catch_type_val, c(uid_col, count_col), drop = FALSE
+      species_rows[[type_col]] == catch_type_val,
+      c(uid_col, count_col),
+      drop = FALSE
     ]
   }
 
@@ -2305,8 +2390,11 @@ estimate_release_build_data <- function(design, species = NULL) {
 #'
 #' @keywords internal
 #' @noRd
-compute_within_day_var_contribution <- function(design, by_vars = NULL, # nolint: object_length_linter
-                                               target = "stratum_total") {
+compute_within_day_var_contribution <- function(
+  design,
+  by_vars = NULL, # nolint: object_length_linter
+  target = "stratum_total"
+) {
   wdv <- design$within_day_var
   if (is.null(wdv)) {
     return(0)
@@ -2365,7 +2453,9 @@ compute_within_day_var_contribution <- function(design, by_vars = NULL, # nolint
       k_d <- combined$k_d[rows]
       ss_d <- combined$ss_d[rows]
       k_bar <- mean(k_d)
-      if (k_bar <= 1) next # no within-day component when k_bar = 1
+      if (k_bar <= 1) {
+        next
+      } # no within-day component when k_bar = 1
       s2_within <- sum(ss_d) / (n_sampled * (k_bar - 1))
       # For sampled_days target the between-day variance is on the sampled-day
       # scale (no expansion weights), so the within-day component must match:
@@ -2385,7 +2475,8 @@ compute_within_day_var_contribution <- function(design, by_vars = NULL, # nolint
     }
     group_keys <- unique(combined$.group_key)
     v_within_by_group <- stats::setNames(
-      numeric(length(group_keys)), group_keys
+      numeric(length(group_keys)),
+      group_keys
     )
     for (gk in group_keys) {
       g_rows <- combined$.group_key == gk
@@ -2399,7 +2490,9 @@ compute_within_day_var_contribution <- function(design, by_vars = NULL, # nolint
         k_d <- g_data$k_d[s_rows]
         ss_d <- g_data$ss_d[s_rows]
         k_bar <- mean(k_d)
-        if (k_bar <= 1) next
+        if (k_bar <= 1) {
+          next
+        }
         s2_within <- sum(ss_d) / (n_sampled * (k_bar - 1))
         scale_n <- if (identical(target, "sampled_days")) n_sampled else n_avail
         v_within <- (scale_n / k_bar) * s2_within
@@ -2437,8 +2530,16 @@ get_effort_target_design <- function(design, target) {
     ))
   }
 
-  available_by_strata <- dplyr::count(calendar, dplyr::across(dplyr::all_of(strata_cols)), name = ".N_avail")
-  sampled_by_strata <- dplyr::count(counts_data, dplyr::across(dplyr::all_of(strata_cols)), name = ".n_sampled")
+  available_by_strata <- dplyr::count(
+    calendar,
+    dplyr::across(dplyr::all_of(strata_cols)),
+    name = ".N_avail"
+  )
+  sampled_by_strata <- dplyr::count(
+    counts_data,
+    dplyr::across(dplyr::all_of(strata_cols)),
+    name = ".n_sampled"
+  )
 
   expanded_counts <- counts_data |>
     dplyr::left_join(available_by_strata, by = strata_cols) |>
@@ -2489,9 +2590,15 @@ get_effort_target_design <- function(design, target) {
 #'
 #' @keywords internal
 #' @noRd
-estimate_effort_sections <- function(design, variance_method, conf_level,
-                                     aggregate_sections, method, missing_sections,
-                                     target = "sampled_days") {
+estimate_effort_sections <- function(
+  design,
+  variance_method,
+  conf_level,
+  aggregate_sections,
+  method,
+  missing_sections,
+  target = "sampled_days"
+) {
   # NULL guard (defensive; dispatch should prevent this firing)
   if (is.null(design[["sections"]])) {
     stop("sections dispatch called on non-section design")
@@ -2591,11 +2698,12 @@ estimate_effort_sections <- function(design, variance_method, conf_level,
     # Use only present sections for aggregation
     present_design_svy <- full_svy_design
     # Filter to present sections only for the section formula (absent sections skipped)
-    agg <- suppressWarnings(aggregate_section_totals( # nolint: object_usage_linter
-      by_formula      = section_formula,
+    agg <- suppressWarnings(aggregate_section_totals(
+      # nolint: object_usage_linter
+      by_formula = section_formula,
       full_design_svy = present_design_svy,
-      count_formula   = count_formula,
-      method          = method
+      count_formula = count_formula,
+      method = method
     ))
     lake_est <- agg$estimate
     lake_se <- agg$se
@@ -2623,7 +2731,8 @@ estimate_effort_sections <- function(design, variance_method, conf_level,
   }
 
   # Return creel_estimates object
-  new_creel_estimates( # nolint: object_usage_linter
+  new_creel_estimates(
+    # nolint: object_usage_linter
     estimates = result_df,
     method = "total-sections",
     variance_method = variance_method,
@@ -2735,7 +2844,8 @@ estimate_effort_total <- function(design, variance_method, conf_level, target = 
   )
 
   # Return creel_estimates object
-  new_creel_estimates( # nolint: object_usage_linter
+  new_creel_estimates(
+    # nolint: object_usage_linter
     estimates = estimates_df,
     method = "total",
     variance_method = variance_method,
@@ -2750,7 +2860,13 @@ estimate_effort_total <- function(design, variance_method, conf_level, target = 
 #'
 #' @keywords internal
 #' @noRd
-estimate_effort_grouped <- function(design, by_vars, variance_method, conf_level, target = "sampled_days") {
+estimate_effort_grouped <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  target = "sampled_days"
+) {
   counts_data <- design$counts
 
   # Tier 2 validation for groups
@@ -2801,7 +2917,11 @@ estimate_effort_grouped <- function(design, by_vars, variance_method, conf_level
   var_between_vec <- se_between_vec^2
 
   # Within-day variance per group (Rasmussen 1998; named vector keyed by group)
-  var_within_named <- compute_within_day_var_contribution(design, by_vars = by_vars, target = target) # nolint: object_usage_linter
+  var_within_named <- compute_within_day_var_contribution(
+    design,
+    by_vars = by_vars,
+    target = target
+  ) # nolint: object_usage_linter
 
   # Build group keys for the svyby result rows to match var_within_named names
   if (length(by_vars) == 1) {
@@ -2861,7 +2981,8 @@ estimate_effort_grouped <- function(design, by_vars, variance_method, conf_level
   estimates_df <- estimates_df[col_order]
 
   # Return creel_estimates object
-  new_creel_estimates( # nolint: object_usage_linter
+  new_creel_estimates(
+    # nolint: object_usage_linter
     estimates = estimates_df,
     method = "total",
     variance_method = variance_method,
@@ -2876,8 +2997,7 @@ estimate_effort_grouped <- function(design, by_vars, variance_method, conf_level
 #'
 #' @keywords internal
 #' @noRd
-estimate_cpue_total <- function(design, variance_method, conf_level,
-                                estimator = "ratio-of-means") {
+estimate_cpue_total <- function(design, variance_method, conf_level, estimator = "ratio-of-means") {
   interviews_data <- design$interviews
   catch_col <- design$catch_col
   effort_col <- design$angler_effort_col
@@ -2969,7 +3089,8 @@ estimate_cpue_total <- function(design, variance_method, conf_level,
   # Return appropriate creel_estimates object (MOR or standard)
   if (estimator %in% c("mor", "mortr")) {
     # Get trip counts and truncation metadata stored during MOR filtering
-    new_creel_estimates_mor( # nolint: object_usage_linter
+    new_creel_estimates_mor(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = method_name,
       variance_method = variance_method,
@@ -2982,7 +3103,8 @@ estimate_cpue_total <- function(design, variance_method, conf_level,
       mor_n_truncated = design$mor_n_truncated
     )
   } else {
-    new_creel_estimates( # nolint: object_usage_linter
+    new_creel_estimates(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = method_name,
       variance_method = variance_method,
@@ -2997,8 +3119,13 @@ estimate_cpue_total <- function(design, variance_method, conf_level,
 #'
 #' @keywords internal
 #' @noRd
-estimate_cpue_grouped <- function(design, by_vars, variance_method, conf_level,
-                                  estimator = "ratio-of-means") {
+estimate_cpue_grouped <- function(
+  design,
+  by_vars,
+  variance_method,
+  conf_level,
+  estimator = "ratio-of-means"
+) {
   interviews_data <- design$interviews
   catch_col <- design$catch_col
   effort_col <- design$angler_effort_col
@@ -3121,7 +3248,8 @@ estimate_cpue_grouped <- function(design, by_vars, variance_method, conf_level,
   # Return appropriate creel_estimates object (MOR or standard)
   if (estimator %in% c("mor", "mortr")) {
     # Get trip counts and truncation metadata stored during MOR filtering
-    new_creel_estimates_mor( # nolint: object_usage_linter
+    new_creel_estimates_mor(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = method_name,
       variance_method = variance_method,
@@ -3134,7 +3262,8 @@ estimate_cpue_grouped <- function(design, by_vars, variance_method, conf_level,
       mor_n_truncated = design$mor_n_truncated
     )
   } else {
-    new_creel_estimates( # nolint: object_usage_linter
+    new_creel_estimates(
+      # nolint: object_usage_linter
       estimates = estimates_df,
       method = method_name,
       variance_method = variance_method,
@@ -3219,9 +3348,14 @@ warn_missing_rate_strata <- function(effort_df, rate_df, stratum_by_vars, contex
 #'
 #' @keywords internal
 #' @noRd
-compute_stratum_product_sum <- function(effort_df, rate_df, stratum_by_vars,
-                                        interview_by_vars, conf_level,
-                                        rate_suffix = "rate") {
+compute_stratum_product_sum <- function(
+  effort_df,
+  rate_df,
+  stratum_by_vars,
+  interview_by_vars,
+  conf_level,
+  rate_suffix = "rate"
+) {
   # t-distribution df: total interviews minus number of strata (conservative)
   n_strata_ci <- if (length(stratum_by_vars) == 0L) 1L else max(1L, nrow(rate_df))
   df_ci <- max(1L, sum(rate_df$n, na.rm = TRUE) - n_strata_ci)
@@ -3236,15 +3370,19 @@ compute_stratum_product_sum <- function(effort_df, rate_df, stratum_by_vars,
     est <- e_est * r_est
     pv <- (e_est^2 * r_se^2) + (r_est^2 * e_se^2)
     return(data.frame(
-      estimate = est, se = sqrt(pv),
-      ci_lower = est - z * sqrt(pv), ci_upper = est + z * sqrt(pv),
-      n = rate_df$n, stringsAsFactors = FALSE
+      estimate = est,
+      se = sqrt(pv),
+      ci_lower = est - z * sqrt(pv),
+      ci_upper = est + z * sqrt(pv),
+      n = rate_df$n,
+      stringsAsFactors = FALSE
     ))
   }
 
   # Merge per-stratum effort and rate on stratum_by_vars
   merged <- merge(
-    effort_df, rate_df,
+    effort_df,
+    rate_df,
     by = stratum_by_vars,
     suffixes = c("_effort", paste0("_", rate_suffix)),
     sort = FALSE
@@ -3268,16 +3406,19 @@ compute_stratum_product_sum <- function(effort_df, rate_df, stratum_by_vars,
     pv <- sum(merged$.var_sh)
     n <- sum(merged$.n_sh)
     data.frame(
-      estimate = est, se = sqrt(pv),
-      ci_lower = est - z * sqrt(pv), ci_upper = est + z * sqrt(pv),
-      n = as.integer(n), stringsAsFactors = FALSE
+      estimate = est,
+      se = sqrt(pv),
+      ci_lower = est - z * sqrt(pv),
+      ci_upper = est + z * sqrt(pv),
+      n = as.integer(n),
+      stringsAsFactors = FALSE
     )
   } else {
     # Sum strata within each interview_by_vars group
     agg <- stats::aggregate(
       cbind(.est_sh, .var_sh, .n_sh) ~ .,
       data = merged[c(interview_by_vars, ".est_sh", ".var_sh", ".n_sh")],
-      FUN  = sum
+      FUN = sum
     )
     sp_result <- tibble::as_tibble(agg[interview_by_vars])
     sp_result$estimate <- agg$.est_sh
@@ -3302,10 +3443,15 @@ compute_stratum_product_sum <- function(effort_df, rate_df, stratum_by_vars,
 #'
 #' @keywords internal
 #' @noRd
-estimate_cpue_species <- function(design, species_col, interview_by_vars,
-                                  variance_method, conf_level,
-                                  estimator = "ratio-of-means",
-                                  validate = TRUE) {
+estimate_cpue_species <- function(
+  design,
+  species_col,
+  interview_by_vars,
+  variance_method,
+  conf_level,
+  estimator = "ratio-of-means",
+  validate = TRUE
+) {
   all_species <- sort(unique(design[["catch"]][[species_col]]))
 
   results_list <- vector("list", length(all_species))
@@ -3328,7 +3474,8 @@ estimate_cpue_species <- function(design, species_col, interview_by_vars,
     } else {
       NULL
     }
-    design_sp$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+    design_sp$interview_survey <- build_interview_survey(
+      # nolint: object_usage_linter
       sp_data,
       strata = strata_formula
     )
@@ -3340,7 +3487,13 @@ estimate_cpue_species <- function(design, species_col, interview_by_vars,
     if (is.null(interview_by_vars)) {
       result <- estimate_cpue_total(design_sp, variance_method, conf_level, estimator) # nolint: object_usage_linter
     } else {
-      result <- estimate_cpue_grouped(design_sp, interview_by_vars, variance_method, conf_level, estimator) # nolint: object_usage_linter
+      result <- estimate_cpue_grouped(
+        design_sp,
+        interview_by_vars,
+        variance_method,
+        conf_level,
+        estimator
+      ) # nolint: object_usage_linter
     }
 
     sp_df <- result$estimates
@@ -3357,9 +3510,14 @@ estimate_cpue_species <- function(design, species_col, interview_by_vars,
 #'
 #' @keywords internal
 #' @noRd
-estimate_release_rate_species <- function(design, species_col, interview_by_vars,
-                                          variance_method, conf_level,
-                                          validate = TRUE) {
+estimate_release_rate_species <- function(
+  design,
+  species_col,
+  interview_by_vars,
+  variance_method,
+  conf_level,
+  validate = TRUE
+) {
   all_species <- sort(unique(design[["catch"]][[species_col]]))
 
   results_list <- vector("list", length(all_species))
@@ -3383,7 +3541,8 @@ estimate_release_rate_species <- function(design, species_col, interview_by_vars
     } else {
       NULL
     }
-    design_sp$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+    design_sp$interview_survey <- build_interview_survey(
+      # nolint: object_usage_linter
       sp_data,
       strata = strata_formula
     )
@@ -3412,9 +3571,14 @@ estimate_release_rate_species <- function(design, species_col, interview_by_vars
 #'
 #' @keywords internal
 #' @noRd
-estimate_hpue_species <- function(design, species_col, interview_by_vars,
-                                  variance_method, conf_level,
-                                  validate = TRUE) {
+estimate_hpue_species <- function(
+  design,
+  species_col,
+  interview_by_vars,
+  variance_method,
+  conf_level,
+  validate = TRUE
+) {
   all_species <- sort(unique(design[["catch"]][[species_col]]))
   results_list <- vector("list", length(all_species))
 
@@ -3435,7 +3599,8 @@ estimate_hpue_species <- function(design, species_col, interview_by_vars,
     } else {
       NULL
     }
-    design_sp$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+    design_sp$interview_survey <- build_interview_survey(
+      # nolint: object_usage_linter
       sp_data,
       strata = strata_formula
     )
@@ -3542,7 +3707,8 @@ estimate_harvest_total <- function(design, variance_method, conf_level) {
   )
 
   # Return creel_estimates object
-  new_creel_estimates( # nolint: object_usage_linter
+  new_creel_estimates(
+    # nolint: object_usage_linter
     estimates = estimates_df,
     method = "ratio-of-means-hpue",
     variance_method = variance_method,
@@ -3661,7 +3827,8 @@ estimate_harvest_grouped <- function(design, by_vars, variance_method, conf_leve
   estimates_df <- estimates_df[col_order]
 
   # Return creel_estimates object
-  new_creel_estimates( # nolint: object_usage_linter
+  new_creel_estimates(
+    # nolint: object_usage_linter
     estimates = estimates_df,
     method = "ratio-of-means-hpue",
     variance_method = variance_method,
@@ -3677,9 +3844,14 @@ estimate_harvest_grouped <- function(design, by_vars, variance_method, conf_leve
 #'
 #' @keywords internal
 #' @noRd
-estimate_catch_rate_sections <- function(design, by_quo, variance_method, # nolint: object_length_linter
-                                         conf_level, missing_sections,
-                                         estimator) {
+estimate_catch_rate_sections <- function(
+  design,
+  by_quo,
+  variance_method, # nolint: object_length_linter
+  conf_level,
+  missing_sections,
+  estimator
+) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
   present_sections <- unique(design$interviews[[section_col]])
@@ -3713,12 +3885,12 @@ estimate_catch_rate_sections <- function(design, by_quo, variance_method, # noli
     if (sec %in% absent_sections) {
       # Build NA row — include by= columns set to NA if present
       na_row <- tibble::tibble(
-        section        = sec,
-        estimate       = NA_real_,
-        se             = NA_real_,
-        ci_lower       = NA_real_,
-        ci_upper       = NA_real_,
-        n              = 0L,
+        section = sec,
+        estimate = NA_real_,
+        se = NA_real_,
+        ci_lower = NA_real_,
+        ci_upper = NA_real_,
+        n = 0L,
         data_available = FALSE
       )
       if (!is.null(by_info$all_vars)) {
@@ -3734,42 +3906,48 @@ estimate_catch_rate_sections <- function(design, by_quo, variance_method, # noli
 
       if (!is.null(by_info$species_var)) {
         # Species by= path
-        sp_df <- estimate_cpue_species( # nolint: object_usage_linter
+        sp_df <- estimate_cpue_species(
+          # nolint: object_usage_linter
           sec_design,
-          species_col       = by_info$species_var,
+          species_col = by_info$species_var,
           interview_by_vars = by_info$interview_vars,
-          variance_method   = variance_method,
-          conf_level        = conf_level,
-          estimator         = estimator
+          variance_method = variance_method,
+          conf_level = conf_level,
+          estimator = estimator
         )
         sp_df <- tibble::add_column(tibble::as_tibble(sp_df), section = sec, .before = 1)
         sp_df$data_available <- TRUE
         section_rows[[sec]] <- sp_df
       } else if (!is.null(by_info$interview_vars)) {
         # Grouped (non-species) by= path
-        result <- estimate_cpue_grouped( # nolint: object_usage_linter
+        result <- estimate_cpue_grouped(
+          # nolint: object_usage_linter
           sec_design,
-          by_vars         = by_info$interview_vars,
+          by_vars = by_info$interview_vars,
           variance_method = variance_method,
-          conf_level      = conf_level,
-          estimator       = estimator
+          conf_level = conf_level,
+          estimator = estimator
         )
         row_df <- tibble::add_column(result$estimates, section = sec, .before = 1)
         row_df$data_available <- TRUE
         section_rows[[sec]] <- row_df
       } else {
         # Ungrouped (total) path
-        result <- estimate_cpue_total( # nolint: object_usage_linter
-          sec_design, variance_method, conf_level, estimator
+        result <- estimate_cpue_total(
+          # nolint: object_usage_linter
+          sec_design,
+          variance_method,
+          conf_level,
+          estimator
         )
         row <- result$estimates
         section_rows[[sec]] <- tibble::tibble(
-          section        = sec,
-          estimate       = row$estimate,
-          se             = row$se,
-          ci_lower       = row$ci_lower,
-          ci_upper       = row$ci_upper,
-          n              = row$n,
+          section = sec,
+          estimate = row$estimate,
+          se = row$se,
+          ci_lower = row$ci_lower,
+          ci_upper = row$ci_upper,
+          n = row$n,
           data_available = TRUE
         )
       }
@@ -3778,13 +3956,14 @@ estimate_catch_rate_sections <- function(design, by_quo, variance_method, # noli
 
   result_df <- dplyr::bind_rows(section_rows)
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = result_df,
-    method          = "ratio-of-means-cpue-sections",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = result_df,
+    method = "ratio-of-means-cpue-sections",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = if (!is.null(by_info$all_vars)) c("section", by_info$all_vars) else "section"
+    design = design,
+    conf_level = conf_level,
+    by_vars = if (!is.null(by_info$all_vars)) c("section", by_info$all_vars) else "section"
   )
 }
 
@@ -3792,8 +3971,13 @@ estimate_catch_rate_sections <- function(design, by_quo, variance_method, # noli
 #'
 #' @keywords internal
 #' @noRd
-estimate_harvest_rate_sections <- function(design, by_quo, variance_method, # nolint: object_length_linter
-                                           conf_level, missing_sections) {
+estimate_harvest_rate_sections <- function(
+  design,
+  by_quo,
+  variance_method, # nolint: object_length_linter
+  conf_level,
+  missing_sections
+) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
   present_sections <- unique(design$interviews[[section_col]])
@@ -3837,12 +4021,12 @@ estimate_harvest_rate_sections <- function(design, by_quo, variance_method, # no
   for (sec in registered_sections) {
     if (sec %in% absent_sections) {
       na_row <- tibble::tibble(
-        section        = sec,
-        estimate       = NA_real_,
-        se             = NA_real_,
-        ci_lower       = NA_real_,
-        ci_upper       = NA_real_,
-        n              = 0L,
+        section = sec,
+        estimate = NA_real_,
+        se = NA_real_,
+        ci_lower = NA_real_,
+        ci_upper = NA_real_,
+        n = 0L,
         data_available = FALSE
       )
       if (!is.null(by_vars)) {
@@ -3856,24 +4040,31 @@ estimate_harvest_rate_sections <- function(design, by_quo, variance_method, # no
       sec_design <- rebuild_interview_survey(design, filtered) # nolint: object_usage_linter
 
       if (!is.null(by_vars)) {
-        result <- estimate_harvest_grouped( # nolint: object_usage_linter
-          sec_design, by_vars, variance_method, conf_level
+        result <- estimate_harvest_grouped(
+          # nolint: object_usage_linter
+          sec_design,
+          by_vars,
+          variance_method,
+          conf_level
         )
         row_df <- tibble::add_column(result$estimates, section = sec, .before = 1)
         row_df$data_available <- TRUE
         section_rows[[sec]] <- row_df
       } else {
-        result <- estimate_harvest_total( # nolint: object_usage_linter
-          sec_design, variance_method, conf_level
+        result <- estimate_harvest_total(
+          # nolint: object_usage_linter
+          sec_design,
+          variance_method,
+          conf_level
         )
         row <- result$estimates
         section_rows[[sec]] <- tibble::tibble(
-          section        = sec,
-          estimate       = row$estimate,
-          se             = row$se,
-          ci_lower       = row$ci_lower,
-          ci_upper       = row$ci_upper,
-          n              = row$n,
+          section = sec,
+          estimate = row$estimate,
+          se = row$se,
+          ci_lower = row$ci_lower,
+          ci_upper = row$ci_upper,
+          n = row$n,
           data_available = TRUE
         )
       }
@@ -3882,13 +4073,14 @@ estimate_harvest_rate_sections <- function(design, by_quo, variance_method, # no
 
   result_df <- dplyr::bind_rows(section_rows)
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = result_df,
-    method          = "ratio-of-means-hpue-sections",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = result_df,
+    method = "ratio-of-means-hpue-sections",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = if (!is.null(by_vars)) c("section", by_vars) else "section"
+    design = design,
+    conf_level = conf_level,
+    by_vars = if (!is.null(by_vars)) c("section", by_vars) else "section"
   )
 }
 
@@ -3896,8 +4088,13 @@ estimate_harvest_rate_sections <- function(design, by_quo, variance_method, # no
 #'
 #' @keywords internal
 #' @noRd
-estimate_release_rate_sections <- function(design, by_quo, variance_method, # nolint: object_length_linter
-                                           conf_level, missing_sections) {
+estimate_release_rate_sections <- function(
+  design,
+  by_quo,
+  variance_method, # nolint: object_length_linter
+  conf_level,
+  missing_sections
+) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
   present_sections <- unique(design$interviews[[section_col]])
@@ -3941,12 +4138,12 @@ estimate_release_rate_sections <- function(design, by_quo, variance_method, # no
   for (sec in registered_sections) {
     if (sec %in% absent_sections) {
       na_row <- tibble::tibble(
-        section        = sec,
-        estimate       = NA_real_,
-        se             = NA_real_,
-        ci_lower       = NA_real_,
-        ci_upper       = NA_real_,
-        n              = 0L,
+        section = sec,
+        estimate = NA_real_,
+        se = NA_real_,
+        ci_lower = NA_real_,
+        ci_upper = NA_real_,
+        n = 0L,
         data_available = FALSE
       )
       if (!is.null(by_vars)) {
@@ -3974,14 +4171,19 @@ estimate_release_rate_sections <- function(design, by_quo, variance_method, # no
       } else {
         NULL
       }
-      design_rel$interview_survey <- build_interview_survey( # nolint: object_usage_linter
+      design_rel$interview_survey <- build_interview_survey(
+        # nolint: object_usage_linter
         release_data,
         strata = strata_formula
       )
 
       if (!is.null(by_vars)) {
-        result <- estimate_cpue_grouped( # nolint: object_usage_linter
-          design_rel, by_vars, variance_method, conf_level
+        result <- estimate_cpue_grouped(
+          # nolint: object_usage_linter
+          design_rel,
+          by_vars,
+          variance_method,
+          conf_level
         )
         row_df <- tibble::add_column(result$estimates, section = sec, .before = 1)
         row_df$data_available <- TRUE
@@ -3990,12 +4192,12 @@ estimate_release_rate_sections <- function(design, by_quo, variance_method, # no
         result <- estimate_cpue_total(design_rel, variance_method, conf_level) # nolint: object_usage_linter
         row <- result$estimates
         section_rows[[sec]] <- tibble::tibble(
-          section        = sec,
-          estimate       = row$estimate,
-          se             = row$se,
-          ci_lower       = row$ci_lower,
-          ci_upper       = row$ci_upper,
-          n              = row$n,
+          section = sec,
+          estimate = row$estimate,
+          se = row$se,
+          ci_lower = row$ci_lower,
+          ci_upper = row$ci_upper,
+          n = row$n,
           data_available = TRUE
         )
       }
@@ -4004,12 +4206,13 @@ estimate_release_rate_sections <- function(design, by_quo, variance_method, # no
 
   result_df <- dplyr::bind_rows(section_rows)
 
-  new_creel_estimates( # nolint: object_usage_linter
-    estimates       = result_df,
-    method          = "ratio-of-means-rpue-sections",
+  new_creel_estimates(
+    # nolint: object_usage_linter
+    estimates = result_df,
+    method = "ratio-of-means-rpue-sections",
     variance_method = variance_method,
-    design          = design,
-    conf_level      = conf_level,
-    by_vars         = if (!is.null(by_vars)) c("section", by_vars) else "section"
+    design = design,
+    conf_level = conf_level,
+    by_vars = if (!is.null(by_vars)) c("section", by_vars) else "section"
   )
 }

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -2436,6 +2436,7 @@ get_effort_target_design <- function(design, target) {
     ids = stats::reformulate(design$psu_col),
     strata = stats::reformulate(strata_cols),
     weights = ~.expansion_weight,
+    fpc = ~.N_avail,
     data = expanded_counts,
     nest = TRUE
   )

--- a/R/creel-schema.R
+++ b/R/creel-schema.R
@@ -1,23 +1,24 @@
 # Internal canonical column requirements per survey type — not exported
 # Keys: survey type -> table name -> character vector of required canonical col names
-CANONICAL_COLUMNS <- list( # nolint: object_name_linter
+CANONICAL_COLUMNS <- list(
+  # nolint: object_name_linter
   instantaneous = list(
     interviews = c("date", "catch", "effort", "trip_status"),
-    counts     = c("date", "count"),
-    catch      = c("catch_uid", "interview_uid", "species", "catch_count", "catch_type"),
-    lengths    = c("length_uid", "interview_uid", "species", "length_mm", "length_type")
+    counts = c("date", "count"),
+    catch = c("catch_uid", "interview_uid", "species", "catch_count", "catch_type"),
+    lengths = c("length_uid", "interview_uid", "species", "length_mm", "length_type")
   ),
   bus_route = list(
     interviews = c("date", "catch", "effort", "trip_status"),
-    counts     = c("date", "count"),
-    catch      = c("catch_uid", "interview_uid", "species", "catch_count", "catch_type"),
-    lengths    = c("length_uid", "interview_uid", "species", "length_mm", "length_type")
+    counts = c("date", "count"),
+    catch = c("catch_uid", "interview_uid", "species", "catch_count", "catch_type"),
+    lengths = c("length_uid", "interview_uid", "species", "length_mm", "length_type")
   ),
   ice = list(
     interviews = c("date", "catch", "effort", "trip_status"),
-    counts     = c("date", "count"),
-    catch      = c("catch_uid", "interview_uid", "species", "catch_count", "catch_type"),
-    lengths    = c("length_uid", "interview_uid", "species", "length_mm", "length_type")
+    counts = c("date", "count"),
+    catch = c("catch_uid", "interview_uid", "species", "catch_count", "catch_type"),
+    lengths = c("length_uid", "interview_uid", "species", "length_mm", "length_type")
   ),
   camera = list(
     counts = c("date", "count")
@@ -29,23 +30,42 @@ CANONICAL_COLUMNS <- list( # nolint: object_name_linter
 
 # Column-to-table mapping for print grouping (internal)
 # nolint: object_name_linter
-COL_TO_TABLE <- list( # nolint: object_name_linter
+COL_TO_TABLE <- list(
+  # nolint: object_name_linter
   interviews = c(
-    "date_col", "catch_col", "effort_col", "trip_status_col",
-    "harvest_col", "trip_duration_col", "trip_start_col",
-    "interview_time_col", "n_anglers_col", "n_interviewed_col",
-    "angler_type_col", "angler_method_col", "species_sought_col",
-    "refused_col", "interview_uid_col"
+    "date_col",
+    "catch_col",
+    "effort_col",
+    "trip_status_col",
+    "harvest_col",
+    "trip_duration_col",
+    "trip_start_col",
+    "interview_time_col",
+    "n_anglers_col",
+    "n_interviewed_col",
+    "angler_type_col",
+    "angler_method_col",
+    "species_sought_col",
+    "refused_col",
+    "interview_uid_col"
   ),
   counts = c(
-    "count_col", "n_counted_col",
-    "bank_anglers_col", "angler_boats_col", "non_ang_boats_col"
+    "count_col",
+    "n_counted_col",
+    "bank_anglers_col",
+    "angler_boats_col",
+    "non_ang_boats_col"
   ),
   catch = c(
-    "catch_uid_col", "species_col", "catch_count_col", "catch_type_col"
+    "catch_uid_col",
+    "species_col",
+    "catch_count_col",
+    "catch_type_col"
   ),
   lengths = c(
-    "length_uid_col", "length_mm_col", "length_type_col"
+    "length_uid_col",
+    "length_mm_col",
+    "length_type_col"
   )
 )
 
@@ -156,39 +176,42 @@ creel_schema <- function(
   refused_col = NULL
 ) {
   survey_type <- match.arg(survey_type)
-  new_creel_schema(survey_type, list(
-    interviews_table   = interviews_table,
-    counts_table       = counts_table,
-    catch_table        = catch_table,
-    lengths_table      = lengths_table,
-    date_col           = date_col,
-    catch_col          = catch_col,
-    effort_col         = effort_col,
-    trip_status_col    = trip_status_col,
-    count_col          = count_col,
-    catch_uid_col      = catch_uid_col,
-    interview_uid_col  = interview_uid_col,
-    species_col        = species_col,
-    catch_count_col    = catch_count_col,
-    catch_type_col     = catch_type_col,
-    length_uid_col     = length_uid_col,
-    length_mm_col      = length_mm_col,
-    length_type_col    = length_type_col,
-    harvest_col        = harvest_col,
-    trip_duration_col  = trip_duration_col,
-    trip_start_col     = trip_start_col,
-    interview_time_col = interview_time_col,
-    n_anglers_col      = n_anglers_col,
-    n_counted_col      = n_counted_col,
-    n_interviewed_col  = n_interviewed_col,
-    bank_anglers_col   = bank_anglers_col,
-    angler_boats_col   = angler_boats_col,
-    non_ang_boats_col  = non_ang_boats_col,
-    angler_type_col    = angler_type_col,
-    angler_method_col  = angler_method_col,
-    species_sought_col = species_sought_col,
-    refused_col        = refused_col
-  ))
+  new_creel_schema(
+    survey_type,
+    list(
+      interviews_table = interviews_table,
+      counts_table = counts_table,
+      catch_table = catch_table,
+      lengths_table = lengths_table,
+      date_col = date_col,
+      catch_col = catch_col,
+      effort_col = effort_col,
+      trip_status_col = trip_status_col,
+      count_col = count_col,
+      catch_uid_col = catch_uid_col,
+      interview_uid_col = interview_uid_col,
+      species_col = species_col,
+      catch_count_col = catch_count_col,
+      catch_type_col = catch_type_col,
+      length_uid_col = length_uid_col,
+      length_mm_col = length_mm_col,
+      length_type_col = length_type_col,
+      harvest_col = harvest_col,
+      trip_duration_col = trip_duration_col,
+      trip_start_col = trip_start_col,
+      interview_time_col = interview_time_col,
+      n_anglers_col = n_anglers_col,
+      n_counted_col = n_counted_col,
+      n_interviewed_col = n_interviewed_col,
+      bank_anglers_col = bank_anglers_col,
+      angler_boats_col = angler_boats_col,
+      non_ang_boats_col = non_ang_boats_col,
+      angler_type_col = angler_type_col,
+      angler_method_col = angler_method_col,
+      species_sought_col = species_sought_col,
+      refused_col = refused_col
+    )
+  )
 }
 
 
@@ -259,9 +282,9 @@ format.creel_schema <- function(x, ...) {
 
     table_fields <- c(
       interviews_table = "interviews",
-      counts_table     = "counts",
-      catch_table      = "catch",
-      lengths_table    = "lengths"
+      counts_table = "counts",
+      catch_table = "catch",
+      lengths_table = "lengths"
     )
 
     for (tbl_field in names(table_fields)) {

--- a/R/creel-summaries.R
+++ b/R/creel-summaries.R
@@ -4,7 +4,6 @@
 # All percent values are rounded to 1 decimal; N columns are integer.
 # Base R only: table(), aggregate(), merge(), cut(), format(). No dplyr.
 
-
 #' Tabulate refused vs accepted interviews by month
 #'
 #' Counts the number of refused and accepted interviews in each calendar
@@ -79,14 +78,16 @@ summarize_refusals <- function(design) {
   counts$N <- as.integer(counts$N)
 
   sort_map <- unique(data.frame(
-    month = month_chr, sort = month_num,
+    month = month_chr,
+    sort = month_num,
     stringsAsFactors = FALSE
   ))
   counts <- merge(counts, sort_map, by = "month")
 
   month_totals <- stats::aggregate(
     counts$N,
-    by = list(month = counts$month), FUN = sum
+    by = list(month = counts$month),
+    FUN = sum
   )
   names(month_totals)[2] <- "month_total"
   counts <- merge(counts, month_totals, by = "month")
@@ -168,14 +169,16 @@ summarize_by_day_type <- function(design) {
   counts$N <- as.integer(counts$N)
 
   sort_map <- unique(data.frame(
-    month = month_chr, sort = month_num,
+    month = month_chr,
+    sort = month_num,
     stringsAsFactors = FALSE
   ))
   counts <- merge(counts, sort_map, by = "month")
 
   month_totals <- stats::aggregate(
     counts$N,
-    by = list(month = counts$month), FUN = sum
+    by = list(month = counts$month),
+    FUN = sum
   )
   names(month_totals)[2] <- "month_total"
   counts <- merge(counts, month_totals, by = "month")
@@ -263,14 +266,16 @@ summarize_by_angler_type <- function(design) {
   counts$N <- as.integer(counts$N)
 
   sort_map <- unique(data.frame(
-    month = month_chr, sort = month_num,
+    month = month_chr,
+    sort = month_num,
     stringsAsFactors = FALSE
   ))
   counts <- merge(counts, sort_map, by = "month")
 
   month_totals <- stats::aggregate(
     counts$N,
-    by = list(month = counts$month), FUN = sum
+    by = list(month = counts$month),
+    FUN = sum
   )
   names(month_totals)[2] <- "month_total"
   counts <- merge(counts, month_totals, by = "month")
@@ -359,14 +364,16 @@ summarize_by_method <- function(design) {
   counts$N <- as.integer(counts$N)
 
   sort_map <- unique(data.frame(
-    month = month_chr, sort = month_num,
+    month = month_chr,
+    sort = month_num,
     stringsAsFactors = FALSE
   ))
   counts <- merge(counts, sort_map, by = "month")
 
   month_totals <- stats::aggregate(
     counts$N,
-    by = list(month = counts$month), FUN = sum
+    by = list(month = counts$month),
+    FUN = sum
   )
   names(month_totals)[2] <- "month_total"
   counts <- merge(counts, month_totals, by = "month")
@@ -455,14 +462,16 @@ summarize_by_species_sought <- function(design) {
   counts$N <- as.integer(counts$N)
 
   sort_map <- unique(data.frame(
-    month = month_chr, sort = month_num,
+    month = month_chr,
+    sort = month_num,
     stringsAsFactors = FALSE
   ))
   counts <- merge(counts, sort_map, by = "month")
 
   month_totals <- stats::aggregate(
     counts$N,
-    by = list(month = counts$month), FUN = sum
+    by = list(month = counts$month),
+    FUN = sum
   )
   names(month_totals)[2] <- "month_total"
   counts <- merge(counts, month_totals, by = "month")
@@ -573,8 +582,11 @@ summarize_successful_parties <- function(design) {
 
   sought_map <- interviews[, c(iuid_col, ss_col, at_col), drop = FALSE]
   catch_merged <- merge(
-    catch_data, sought_map,
-    by.x = uid_col, by.y = iuid_col, all.x = FALSE
+    catch_data,
+    sought_map,
+    by.x = uid_col,
+    by.y = iuid_col,
+    all.x = FALSE
   )
   caught_rows <- catch_merged[
     catch_merged[[type_col]] == "caught" &
@@ -587,7 +599,7 @@ summarize_successful_parties <- function(design) {
   totals <- stats::aggregate(
     interviews[[iuid_col]],
     by = list(
-      angler_type    = interviews[[at_col]],
+      angler_type = interviews[[at_col]],
       species_sought = interviews[[ss_col]]
     ),
     FUN = length
@@ -599,15 +611,13 @@ summarize_successful_parties <- function(design) {
     successes <- stats::aggregate(
       success_sub[[iuid_col]],
       by = list(
-        angler_type    = success_sub[[at_col]],
+        angler_type = success_sub[[at_col]],
         species_sought = success_sub[[ss_col]]
       ),
       FUN = length
     )
     names(successes)[3] <- "N_successful"
-    result <- merge(totals, successes,
-      by = c("angler_type", "species_sought"), all.x = TRUE
-    )
+    result <- merge(totals, successes, by = c("angler_type", "species_sought"), all.x = TRUE)
   } else {
     result <- totals
     result$N_successful <- 0L
@@ -686,15 +696,21 @@ summarize_by_trip_length <- function(design) {
 
   breaks <- c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, Inf)
   labels <- c(
-    "[0,1)", "[1,2)", "[2,3)", "[3,4)", "[4,5)",
-    "[5,6)", "[6,7)", "[7,8)", "[8,9)", "[9,10)", "10+"
+    "[0,1)",
+    "[1,2)",
+    "[2,3)",
+    "[3,4)",
+    "[4,5)",
+    "[5,6)",
+    "[6,7)",
+    "[7,8)",
+    "[8,9)",
+    "[9,10)",
+    "10+"
   )
 
   durations <- design$interviews[[design$trip_duration_col]]
-  bins <- cut(durations,
-    breaks = breaks, labels = labels,
-    right = FALSE, include.lowest = TRUE
-  )
+  bins <- cut(durations, breaks = breaks, labels = labels, right = FALSE, include.lowest = TRUE)
 
   counts <- as.data.frame(table(trip_length_bin = bins), stringsAsFactors = FALSE)
   names(counts)[names(counts) == "Freq"] <- "N"
@@ -822,7 +838,8 @@ summarize_cws_rates <- function(design, by = NULL, conf_level = 0.95) {
 
   # Step 1: Resolve by columns from interviews
   if (!rlang::quo_is_null(by_quo)) {
-    by_cols <- tidyselect::eval_select( # nolint: object_usage_linter
+    by_cols <- tidyselect::eval_select(
+      # nolint: object_usage_linter
       by_quo,
       data = interviews,
       allow_rename = FALSE,
@@ -840,14 +857,18 @@ summarize_cws_rates <- function(design, by = NULL, conf_level = 0.95) {
   # Merge to get species_sought on each catch row
   sought_map <- interviews[, c(uid_col, ss_col), drop = FALSE]
   catch_merged <- merge(
-    target_catch, sought_map,
-    by.x = uid_col, by.y = uid_col, all.x = FALSE
+    target_catch,
+    sought_map,
+    by.x = uid_col,
+    by.y = uid_col,
+    all.x = FALSE
   )
 
   # Filter to rows where catch species == species_sought
   target_rows <- catch_merged[
     !is.na(catch_merged[[species_col]]) &
-      catch_merged[[species_col]] == catch_merged[[ss_col]], ,
+      catch_merged[[species_col]] == catch_merged[[ss_col]],
+    ,
     drop = FALSE
   ]
 
@@ -866,8 +887,11 @@ summarize_cws_rates <- function(design, by = NULL, conf_level = 0.95) {
   # Step 3: Join back to ALL interviews to preserve zeros
   interview_base <- interviews[, unique(c(uid_col, ss_col, ae_col, by_vars)), drop = FALSE]
   interview_base <- merge(
-    interview_base, agg,
-    by.x = uid_col, by.y = ".uid", all.x = TRUE
+    interview_base,
+    agg,
+    by.x = uid_col,
+    by.y = ".uid",
+    all.x = TRUE
   )
   interview_base$.target_count[is.na(interview_base$.target_count)] <- 0
 
@@ -908,7 +932,9 @@ summarize_cws_rates <- function(design, by = NULL, conf_level = 0.95) {
   result$sd_rate <- NULL
 
   # Drop .group column when no by variables
-  if (length(by_vars) == 0) result$.group <- NULL
+  if (length(by_vars) == 0) {
+    result$.group <- NULL
+  }
 
   result$N <- as.integer(result$N)
   row.names(result) <- NULL
@@ -1033,7 +1059,8 @@ summarize_hws_rates <- function(design, by = NULL, conf_level = 0.95) {
 
   # Step 1: Resolve by columns from interviews
   if (!rlang::quo_is_null(by_quo)) {
-    by_cols <- tidyselect::eval_select( # nolint: object_usage_linter
+    by_cols <- tidyselect::eval_select(
+      # nolint: object_usage_linter
       by_quo,
       data = interviews,
       allow_rename = FALSE,
@@ -1051,14 +1078,18 @@ summarize_hws_rates <- function(design, by = NULL, conf_level = 0.95) {
   # Merge to get species_sought on each catch row
   sought_map <- interviews[, c(uid_col, ss_col), drop = FALSE]
   catch_merged <- merge(
-    target_catch, sought_map,
-    by.x = uid_col, by.y = uid_col, all.x = FALSE
+    target_catch,
+    sought_map,
+    by.x = uid_col,
+    by.y = uid_col,
+    all.x = FALSE
   )
 
   # Filter to rows where catch species == species_sought
   target_rows <- catch_merged[
     !is.na(catch_merged[[species_col]]) &
-      catch_merged[[species_col]] == catch_merged[[ss_col]], ,
+      catch_merged[[species_col]] == catch_merged[[ss_col]],
+    ,
     drop = FALSE
   ]
 
@@ -1077,8 +1108,11 @@ summarize_hws_rates <- function(design, by = NULL, conf_level = 0.95) {
   # Step 3: Join back to ALL interviews to preserve zeros
   interview_base <- interviews[, unique(c(uid_col, ss_col, ae_col, by_vars)), drop = FALSE]
   interview_base <- merge(
-    interview_base, agg,
-    by.x = uid_col, by.y = ".uid", all.x = TRUE
+    interview_base,
+    agg,
+    by.x = uid_col,
+    by.y = ".uid",
+    all.x = TRUE
   )
   interview_base$.target_count[is.na(interview_base$.target_count)] <- 0
 
@@ -1119,7 +1153,9 @@ summarize_hws_rates <- function(design, by = NULL, conf_level = 0.95) {
   result$sd_rate <- NULL
 
   # Drop .group column when no by variables
-  if (length(by_vars) == 0) result$.group <- NULL
+  if (length(by_vars) == 0) {
+    result$.group <- NULL
+  }
 
   result$N <- as.integer(result$N)
   row.names(result) <- NULL
@@ -1238,7 +1274,8 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
     by_cols <- tidyselect::eval_select(
       by_quo,
       data = lengths_data,
-      allow_rename = FALSE, allow_empty = FALSE,
+      allow_rename = FALSE,
+      allow_empty = FALSE,
       error_call = rlang::caller_env()
     )
     by_vars <- names(by_cols)
@@ -1272,7 +1309,9 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
         lengths = numeric(0),
         weights = integer(0)
       )
-      for (v in by_vars) out[[v]] <- character(0)
+      for (v in by_vars) {
+        out[[v]] <- character(0)
+      }
       return(out)
     }
 
@@ -1299,13 +1338,17 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
       lengths <- rep(midpoints, times = counts)
       weights <- rep(1L, times = length(lengths))
       out <- list(lengths = lengths, weights = weights)
-      for (v in by_vars) out[[v]] <- rep(rows[[v]], times = counts)
+      for (v in by_vars) {
+        out[[v]] <- rep(rows[[v]], times = counts)
+      }
     } else {
       # Individual format: one fish per row, weight = 1
       lengths <- as.numeric(rows[[length_col]])
       weights <- rep(1L, times = length(lengths))
       out <- list(lengths = lengths, weights = weights)
-      for (v in by_vars) out[[v]] <- rows[[v]]
+      for (v in by_vars) {
+        out[[v]] <- rows[[v]]
+      }
     }
     out
   }
@@ -1336,10 +1379,7 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
   max_len <- ceiling(max(all_lengths) / bin_width) * bin_width
   breaks <- seq(0, max_len + bin_width, by = bin_width)
   labels <- paste0("[", breaks[-length(breaks)], ",", breaks[-1], ")")
-  bins <- cut(all_lengths,
-    breaks = breaks, labels = labels,
-    right = FALSE, include.lowest = TRUE
-  )
+  bins <- cut(all_lengths, breaks = breaks, labels = labels, right = FALSE, include.lowest = TRUE)
 
   # Build a data frame of all records
   records_df <- data.frame(
@@ -1348,7 +1388,9 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
     .weight = all_weights,
     stringsAsFactors = FALSE
   )
-  for (v in by_vars) records_df[[v]] <- group_lists[[v]]
+  for (v in by_vars) {
+    records_df[[v]] <- group_lists[[v]]
+  }
 
   # Aggregate: N = sum(weight) per (by_vars + .length_bin)
   agg_by <- c(by_vars, ".length_bin", ".lower")
@@ -1371,10 +1413,7 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
   lower_map <- unique(n_agg[, c(".length_bin", ".lower"), drop = FALSE])
   lower_map <- lower_map[order(lower_map$.lower), ]
   ordered_labs <- lower_map$.length_bin[lower_map$.length_bin %in% occupied_labels]
-  n_agg$.length_bin <- factor(n_agg$.length_bin,
-    levels = ordered_labs,
-    ordered = TRUE
-  )
+  n_agg$.length_bin <- factor(n_agg$.length_bin, levels = ordered_labs, ordered = TRUE)
 
   # Compute percent and cumulative_percent within each group
   if (length(by_vars) > 0) {
@@ -1398,9 +1437,7 @@ summarize_length_freq <- function(design, type = "catch", by = NULL, bin_width =
   n_agg$.lower <- NULL
 
   # Final column order: by_vars, length_bin, N, percent, cumulative_percent
-  result <- n_agg[, c(by_vars, "length_bin", "N", "percent", "cumulative_percent"),
-    drop = FALSE
-  ]
+  result <- n_agg[, c(by_vars, "length_bin", "N", "percent", "cumulative_percent"), drop = FALSE]
   result$N <- as.integer(result$N)
   row.names(result) <- NULL
 
@@ -1448,8 +1485,13 @@ summary.creel_estimates <- function(object, digits = 4L, ...) {
 
   # Identify group columns (everything except the estimate columns)
   est_cols <- c(
-    "estimate", "se", "ci_lower", "ci_upper", "n",
-    "se_between", "se_within"
+    "estimate",
+    "se",
+    "ci_lower",
+    "ci_upper",
+    "n",
+    "se_between",
+    "se_within"
   )
   group_cols <- setdiff(names(est), est_cols)
 
@@ -1481,10 +1523,10 @@ summary.creel_estimates <- function(object, digits = 4L, ...) {
 new_creel_summary <- function(table, method, variance_method, conf_level) {
   structure(
     list(
-      table           = table,
-      method          = method,
+      table = table,
+      method = method,
       variance_method = variance_method,
-      conf_level      = conf_level
+      conf_level = conf_level
     ),
     class = "creel_summary"
   )
@@ -1583,46 +1625,46 @@ summarize_boat_composition <- function(design, schema) {
   counts <- design$counts
 
   # Extract dates and compute month labels
-  dates     <- counts[[design$date_col]]
+  dates <- counts[[design$date_col]]
   month_chr <- format(dates, "%B")
   month_num <- format(dates, "%m")
 
   # Extract day_type from first strata column
   strata_col <- design$strata_cols[1]
-  day_type   <- counts[[strata_col]]
+  day_type <- counts[[strata_col]]
 
   ab <- counts[[ab_col]]
   nb <- counts[[nb_col]]
 
   # Exclude rows where total boats == 0 (undefined ratio)
   keep <- (ab + nb) > 0
-  ab        <- ab[keep]
-  nb        <- nb[keep]
+  ab <- ab[keep]
+  nb <- nb[keep]
   month_chr <- month_chr[keep]
   month_num <- month_num[keep]
-  day_type  <- day_type[keep]
+  day_type <- day_type[keep]
 
   ratio <- ab / (ab + nb)
 
   working <- data.frame(
-    month     = month_chr,
+    month = month_chr,
     month_num = month_num,
-    day_type  = day_type,
-    ratio     = ratio,
+    day_type = day_type,
+    ratio = ratio,
     stringsAsFactors = FALSE
   )
 
   # Aggregate: mean ratio and count of events per month x day_type
   agg_mean <- stats::aggregate(
     working$ratio,
-    by  = list(month = working$month, day_type = working$day_type),
+    by = list(month = working$month, day_type = working$day_type),
     FUN = mean
   )
   names(agg_mean)[names(agg_mean) == "x"] <- "mean_ratio"
 
   agg_n <- stats::aggregate(
     working$ratio,
-    by  = list(month = working$month, day_type = working$day_type),
+    by = list(month = working$month, day_type = working$day_type),
     FUN = length
   )
   names(agg_n)[names(agg_n) == "x"] <- "n_events"
@@ -1631,12 +1673,12 @@ summarize_boat_composition <- function(design, schema) {
 
   # Convert to percent, round to 1 decimal
   result$pct_angler_boats <- round(result$mean_ratio * 100, 1)
-  result$n_events         <- as.integer(result$n_events)
-  result$mean_ratio       <- NULL
+  result$n_events <- as.integer(result$n_events)
+  result$mean_ratio <- NULL
 
   # Merge sort key and order by month then day_type
   sort_map <- unique(data.frame(
-    month     = working$month,
+    month = working$month,
     month_num = working$month_num,
     stringsAsFactors = FALSE
   ))
@@ -1722,20 +1764,20 @@ summarize_by_zip <- function(design) {
   }
 
   zip_vals <- design$interviews[["ii_ZipCode"]]
-  total_n  <- length(zip_vals)
+  total_n <- length(zip_vals)
 
   # Replace NA with "Unknown" before tabulating
   zip_vals[is.na(zip_vals)] <- "Unknown"
 
   counts_tbl <- as.data.frame(table(zip_code = zip_vals), stringsAsFactors = FALSE)
   names(counts_tbl)[names(counts_tbl) == "Freq"] <- "n"
-  counts_tbl$n   <- as.integer(counts_tbl$n)
+  counts_tbl$n <- as.integer(counts_tbl$n)
   counts_tbl$pct <- round(100 * counts_tbl$n / total_n, 1)
 
   # Sort: Unknown last, remaining rows by n descending
-  known   <- counts_tbl[counts_tbl$zip_code != "Unknown", ]
+  known <- counts_tbl[counts_tbl$zip_code != "Unknown", ]
   unknown <- counts_tbl[counts_tbl$zip_code == "Unknown", ]
-  known   <- known[order(-known$n), ]
+  known <- known[order(-known$n), ]
   counts_tbl <- rbind(known, unknown)
   row.names(counts_tbl) <- NULL
 
@@ -1826,15 +1868,18 @@ summarize_by_county <- function(design) {
     ))
   }
 
-  zip_vals  <- design$interviews[["ii_ZipCode"]]
-  total_n   <- length(zip_vals)
+  zip_vals <- design$interviews[["ii_ZipCode"]]
+  total_n <- length(zip_vals)
   valid_zips <- zip_vals[!is.na(zip_vals)]
   unique_zips <- unique(valid_zips)
 
   # Build county lookup from zipcodeR's zip_code_db dataset
   zip_db <- zipcodeR::zip_code_db
-  county_map <- zip_db[zip_db$zipcode %in% as.character(unique_zips),
-                       c("zipcode", "county"), drop = FALSE]
+  county_map <- zip_db[
+    zip_db$zipcode %in% as.character(unique_zips),
+    c("zipcode", "county"),
+    drop = FALSE
+  ]
 
   # Determine actual county column name returned by the lookup
   county_col <- if ("county" %in% names(county_map)) {
@@ -1871,13 +1916,13 @@ summarize_by_county <- function(design) {
 
   counts_tbl <- as.data.frame(table(county = county_vals), stringsAsFactors = FALSE)
   names(counts_tbl)[names(counts_tbl) == "Freq"] <- "n"
-  counts_tbl$n   <- as.integer(counts_tbl$n)
+  counts_tbl$n <- as.integer(counts_tbl$n)
   counts_tbl$pct <- round(100 * counts_tbl$n / total_n, 1)
 
   # Sort: Unknown last, remaining rows by n descending
-  known   <- counts_tbl[counts_tbl$county != "Unknown", ]
+  known <- counts_tbl[counts_tbl$county != "Unknown", ]
   unknown <- counts_tbl[counts_tbl$county == "Unknown", ]
-  known   <- known[order(-known$n), ]
+  known <- known[order(-known$n), ]
   counts_tbl <- rbind(known, unknown)
   row.names(counts_tbl) <- NULL
 

--- a/R/creel-validation.R
+++ b/R/creel-validation.R
@@ -55,36 +55,39 @@ format.creel_validation <- function(x, ...) {
   # Build formatted output using cli
   output <- character()
 
-  output <- c(output, cli::cli_format_method({
-    cli::cli_h1("Validation Results")
-    cli::cli_text("Context: {x$context}")
-    cli::cli_text("Tier: {x$tier}")
+  output <- c(
+    output,
+    cli::cli_format_method({
+      cli::cli_h1("Validation Results")
+      cli::cli_text("Context: {x$context}")
+      cli::cli_text("Tier: {x$tier}")
 
-    # Status with styling
-    if (x$passed) {
-      cli::cli_text("Status: {.emph PASSED}")
-    } else {
-      cli::cli_text("Status: {.emph FAILED}")
-    }
-
-    cli::cli_text("")
-    cli::cli_text("Checks:")
-
-    # List individual checks with status indicators
-    for (i in seq_len(nrow(x$results))) {
-      check_name <- x$results$check[i] # nolint: object_usage_linter
-      check_status <- x$results$status[i]
-      check_msg <- x$results$message[i] # nolint: object_usage_linter
-
-      if (check_status == "pass") {
-        cli::cli_alert_success("{check_name}: {check_msg}")
-      } else if (check_status == "fail") {
-        cli::cli_alert_danger("{check_name}: {check_msg}")
-      } else if (check_status == "warn") {
-        cli::cli_alert_warning("{check_name}: {check_msg}")
+      # Status with styling
+      if (x$passed) {
+        cli::cli_text("Status: {.emph PASSED}")
+      } else {
+        cli::cli_text("Status: {.emph FAILED}")
       }
-    }
-  }))
+
+      cli::cli_text("")
+      cli::cli_text("Checks:")
+
+      # List individual checks with status indicators
+      for (i in seq_len(nrow(x$results))) {
+        check_name <- x$results$check[i] # nolint: object_usage_linter
+        check_status <- x$results$status[i]
+        check_msg <- x$results$message[i] # nolint: object_usage_linter
+
+        if (check_status == "pass") {
+          cli::cli_alert_success("{check_name}: {check_msg}")
+        } else if (check_status == "fail") {
+          cli::cli_alert_danger("{check_name}: {check_msg}")
+        } else if (check_status == "warn") {
+          cli::cli_alert_warning("{check_name}: {check_msg}")
+        }
+      }
+    })
+  )
 
   output
 }

--- a/R/creel-validation.R
+++ b/R/creel-validation.R
@@ -29,7 +29,8 @@ new_creel_validation <- function(results, tier, context) {
   )
 
   # Compute passed flag - only "pass" status counts as passed
-  passed <- all(results$status == "pass")
+  # Guard: all(logical(0)) == TRUE, so an empty results df would silently pass
+  passed <- nrow(results) > 0L && all(results$status == "pass")
 
   structure(
     list(

--- a/R/data.R
+++ b/R/data.R
@@ -446,7 +446,7 @@
 #' 2024. Anglers fish from both open-air setups and enclosed dark-house shelters,
 #' targeting walleye and yellow perch. Dates match [example_ice_sampling_frame].
 #'
-#' @format A data frame with 72 rows and 10 columns:
+#' @format A data frame with 72 rows and 11 columns:
 #' \describe{
 #'   \item{date}{Interview date (Date class), matching [example_ice_sampling_frame]}
 #'   \item{n_counted}{Integer total number of angler parties counted at the

--- a/R/design-validator.R
+++ b/R/design-validator.R
@@ -42,9 +42,15 @@ new_creel_design_report <- function(results, passed, survey_type) {
 #' @export
 validate_design <- function(
   # nolint: object_name_linter
-  N_h, ybar_h, s2_h, n_proposed, cv_target, # nolint: object_name_linter
+  N_h,
+  ybar_h,
+  s2_h,
+  n_proposed,
+  cv_target, # nolint: object_name_linter
   type = c("effort", "cpue"),
-  cv_catch = NULL, cv_effort = NULL, rho = 0
+  cv_catch = NULL,
+  cv_effort = NULL,
+  rho = 0
 ) {
   type <- match.arg(type)
 
@@ -66,33 +72,56 @@ validate_design <- function(
 
   # Re-key ybar_h, s2_h, n_proposed to N_h's stratum order so positional
   # indexing below is correct even if the caller supplied named-but-reordered vectors.
-  if (!is.null(names(ybar_h))) ybar_h <- ybar_h[strata_names]
-  if (!is.null(names(s2_h))) s2_h <- s2_h[strata_names]
-  if (!is.null(names(n_proposed))) n_proposed <- n_proposed[strata_names]
+  if (!is.null(names(ybar_h))) {
+    ybar_h <- ybar_h[strata_names]
+  }
+  if (!is.null(names(s2_h))) {
+    s2_h <- s2_h[strata_names]
+  }
+  if (!is.null(names(n_proposed))) {
+    n_proposed <- n_proposed[strata_names]
+  }
 
   # Per-stratum calculations -- delegate entirely to Phase 49 functions
   if (type == "effort") {
-    n_req_all <- creel_n_effort( # nolint: object_usage_linter
+    n_req_all <- creel_n_effort(
+      # nolint: object_usage_linter
       cv_target = cv_target, # nolint: object_name_linter
-      N_h = N_h, ybar_h = ybar_h, s2_h = s2_h
+      N_h = N_h,
+      ybar_h = ybar_h,
+      s2_h = s2_h
     )
     n_required_vec <- n_req_all[strata_names]
-    cv_actual_vec <- vapply(seq_along(N_h), function(i) {
-      cv_from_n("effort", # nolint: object_usage_linter
-        n = n_proposed[[i]],
-        N_h = N_h[i], ybar_h = ybar_h[i], s2_h = s2_h[i]
-      )
-    }, numeric(1))
+    cv_actual_vec <- vapply(
+      seq_along(N_h),
+      function(i) {
+        cv_from_n(
+          "effort", # nolint: object_usage_linter
+          n = n_proposed[[i]],
+          N_h = N_h[i],
+          ybar_h = ybar_h[i],
+          s2_h = s2_h[i]
+        )
+      },
+      numeric(1)
+    )
   } else {
     # CPUE: single overall n (no per-stratum breakdown in creel_n_cpue)
-    n_required_scalar <- creel_n_cpue( # nolint: object_usage_linter
-      cv_catch = cv_catch, cv_effort = cv_effort,
-      rho = rho, cv_target = cv_target
+    n_required_scalar <- creel_n_cpue(
+      # nolint: object_usage_linter
+      cv_catch = cv_catch,
+      cv_effort = cv_effort,
+      rho = rho,
+      cv_target = cv_target
     )
     n_required_vec <- rep(n_required_scalar, length(N_h))
-    cv_actual_vec <- vapply(n_proposed, function(n) {
-      cv_from_n("cpue", n = n, cv_catch = cv_catch, cv_effort = cv_effort, rho = rho) # nolint: object_usage_linter
-    }, numeric(1))
+    cv_actual_vec <- vapply(
+      n_proposed,
+      function(n) {
+        cv_from_n("cpue", n = n, cv_catch = cv_catch, cv_effort = cv_effort, rho = rho) # nolint: object_usage_linter
+      },
+      numeric(1)
+    )
   }
 
   # Status logic: pass / warn / fail
@@ -111,18 +140,26 @@ validate_design <- function(
     cv_actual = round(cv_actual_vec, 4),
     cv_target = cv_target,
     message = dplyr::case_when(
-      status_vec == "pass" ~ paste0("Proposed n meets or exceeds required n (", n_required_vec, ")"),
+      status_vec == "pass" ~ paste0(
+        "Proposed n meets or exceeds required n (",
+        n_required_vec,
+        ")"
+      ),
       status_vec == "warn" ~ paste0(
-        "Proposed n below required (", n_required_vec, ") but CV within ", WARN_CV_BUFFER, "x target"
+        "Proposed n below required (",
+        n_required_vec,
+        ") but CV within ",
+        WARN_CV_BUFFER,
+        "x target"
       ),
       TRUE ~ paste0("Proposed n well below required (", n_required_vec, ")")
     )
   )
 
   new_creel_design_report(
-    results      = results,
-    passed       = all(status_vec == "pass"),
-    survey_type  = type
+    results = results,
+    passed = all(status_vec == "pass"),
+    survey_type = type
   )
 }
 
@@ -175,18 +212,23 @@ print.creel_design_report <- function(x, ...) {
 
 # ---- check_completeness internals -------------------------------------------
 
-new_creel_completeness_report <- function(missing_days, low_n_strata, refusals,
-                                          n_min, survey_type) {
+new_creel_completeness_report <- function(
+  missing_days,
+  low_n_strata,
+  refusals,
+  n_min,
+  survey_type
+) {
   passed <- (nrow(missing_days) == 0L) &&
     (is.null(low_n_strata) || nrow(low_n_strata) == 0L)
   structure(
     list(
       missing_days = missing_days,
       low_n_strata = low_n_strata,
-      refusals     = refusals,
-      n_min        = n_min,
-      survey_type  = survey_type,
-      passed       = passed
+      refusals = refusals,
+      n_min = n_min,
+      survey_type = survey_type,
+      passed = passed
     ),
     class = "creel_completeness_report"
   )
@@ -200,10 +242,7 @@ find_missing_days <- function(design) {
   }
   count_dates <- unique(design$counts[[design$date_col]])
   missing <- cal_dates[!cal_dates %in% count_dates]
-  design$calendar[design$calendar[[design$date_col]] %in% missing,
-    keep_cols,
-    drop = FALSE
-  ]
+  design$calendar[design$calendar[[design$date_col]] %in% missing, keep_cols, drop = FALSE]
 }
 
 find_low_n_strata <- function(design, n_min) {
@@ -211,7 +250,8 @@ find_low_n_strata <- function(design, n_min) {
   strata_cols <- intersect(design$strata_cols, names(interviews))
   if (length(strata_cols) == 0L) {
     return(data.frame(
-      key = character(0), n_observed = integer(0),
+      key = character(0),
+      n_observed = integer(0),
       stringsAsFactors = FALSE
     ))
   }
@@ -280,14 +320,16 @@ check_completeness <- function(design, n_min = 10L) {
   }
 
   survey_type <- design$design_type
-  if (is.null(survey_type)) survey_type <- "instantaneous"
+  if (is.null(survey_type)) {
+    survey_type <- "instantaneous"
+  }
 
   new_creel_completeness_report(
     missing_days = missing_days,
     low_n_strata = low_n_strata,
-    refusals     = refusals,
-    n_min        = n_min,
-    survey_type  = survey_type
+    refusals = refusals,
+    n_min = n_min,
+    survey_type = survey_type
   )
 }
 

--- a/R/design-validator.R
+++ b/R/design-validator.R
@@ -64,6 +64,12 @@ validate_design <- function(
 
   strata_names <- names(N_h)
 
+  # Re-key ybar_h, s2_h, n_proposed to N_h's stratum order so positional
+  # indexing below is correct even if the caller supplied named-but-reordered vectors.
+  if (!is.null(names(ybar_h))) ybar_h <- ybar_h[strata_names]
+  if (!is.null(names(s2_h))) s2_h <- s2_h[strata_names]
+  if (!is.null(names(n_proposed))) n_proposed <- n_proposed[strata_names]
+
   # Per-stratum calculations -- delegate entirely to Phase 49 functions
   if (type == "effort") {
     n_req_all <- creel_n_effort( # nolint: object_usage_linter

--- a/R/est-effort-camera.R
+++ b/R/est-effort-camera.R
@@ -100,13 +100,14 @@ est_effort_camera <- function(
     )
   }
 
-  estimate_effort_camera( # nolint: object_usage_linter
-    design          = design,
-    interviews      = interviews,
-    effort_col      = effort_col,
-    intercept_col   = intercept_col,
-    h_open          = h_open,
+  estimate_effort_camera(
+    # nolint: object_usage_linter
+    design = design,
+    interviews = interviews,
+    effort_col = effort_col,
+    intercept_col = intercept_col,
+    h_open = h_open,
     variance_method = variance,
-    conf_level      = conf_level
+    conf_level = conf_level
   )
 }

--- a/R/flag-outliers.R
+++ b/R/flag-outliers.R
@@ -46,7 +46,8 @@
 #'
 #' @family "Reporting & Diagnostics"
 #' @export
-flag_outliers <- function(data, col, k = 1.5, na.rm = TRUE) { # nolint: object_name_linter
+flag_outliers <- function(data, col, k = 1.5, na.rm = TRUE) {
+  # nolint: object_name_linter
   if (!is.data.frame(data)) {
     cli::cli_abort(c(
       "{.arg data} must be a {.cls data.frame}.",
@@ -117,10 +118,12 @@ flag_outliers <- function(data, col, k = 1.5, na.rm = TRUE) { # nolint: object_n
   is_out <- above | below
   reason <- character(nrow(data))
   reason[above] <- sprintf(
-    "above fence_high (%.4g)", fence_hi
+    "above fence_high (%.4g)",
+    fence_hi
   )
   reason[below] <- sprintf(
-    "below fence_low (%.4g)", fence_lo
+    "below fence_low (%.4g)",
+    fence_lo
   )
 
   data$is_outlier <- is_out

--- a/R/hybrid-design.R
+++ b/R/hybrid-design.R
@@ -116,16 +116,20 @@ as_hybrid_svydesign <- function(
     missing_strata <- setdiff(strata_vals, names(frac))
     if (length(missing_strata) > 0L) {
       cli::cli_abort(
-        "{.arg {name}} is missing entries for strata: ",
-        "{.val {missing_strata}}."
+        c(
+          "{.arg {name}} is missing entries for strata.",
+          "x" = "Missing: {.val {missing_strata}}."
+        )
       )
     }
     bad_vals <- frac[names(frac) %in% strata_vals]
     bad_vals <- bad_vals[bad_vals <= 0 | bad_vals > 1]
     if (length(bad_vals) > 0L) {
       cli::cli_abort(
-        "{.arg {name}} values must be in (0, 1]. ",
-        "Invalid: {.val {names(bad_vals)}} = {.val {bad_vals}}."
+        c(
+          "{.arg {name}} values must be in (0, 1].",
+          "x" = "Invalid strata: {.val {names(bad_vals)}} = {.val {bad_vals}}."
+        )
       )
     }
   }

--- a/R/hybrid-design.R
+++ b/R/hybrid-design.R
@@ -151,20 +151,26 @@ as_hybrid_svydesign <- function(
   if (length(only_access) > 0L || length(only_roving) > 0L) {
     msgs <- character(0)
     if (length(only_access) > 0L) {
-      msgs <- c(msgs, paste0(
-        "i" = paste(
-          length(only_access),
-          "date-stratum combination(s) only in access_data"
+      msgs <- c(
+        msgs,
+        paste0(
+          "i" = paste(
+            length(only_access),
+            "date-stratum combination(s) only in access_data"
+          )
         )
-      ))
+      )
     }
     if (length(only_roving) > 0L) {
-      msgs <- c(msgs, paste0(
-        "i" = paste(
-          length(only_roving),
-          "date-stratum combination(s) only in roving_data"
+      msgs <- c(
+        msgs,
+        paste0(
+          "i" = paste(
+            length(only_roving),
+            "date-stratum combination(s) only in roving_data"
+          )
         )
-      ))
+      )
     }
     cli::cli_warn(c(
       "Asymmetric date-stratum coverage between access and roving data.",
@@ -176,15 +182,17 @@ as_hybrid_svydesign <- function(
   # ---- Combine and weight --------------------------------------------------
   access_out <- access_data[, required_cols, drop = FALSE]
   access_out$component <- "access"
-  access_out$weight <- 1 / access_fraction[
-    as.character(access_out[[strata_col]])
-  ]
+  access_out$weight <- 1 /
+    access_fraction[
+      as.character(access_out[[strata_col]])
+    ]
 
   roving_out <- roving_data[, required_cols, drop = FALSE]
   roving_out$component <- "roving"
-  roving_out$weight <- 1 / roving_fraction[
-    as.character(roving_out[[strata_col]])
-  ]
+  roving_out$weight <- 1 /
+    roving_fraction[
+      as.character(roving_out[[strata_col]])
+    ]
 
   combined <- rbind(access_out, roving_out)
 
@@ -204,18 +212,18 @@ as_hybrid_svydesign <- function(
 
   if (fpc) {
     design <- survey::svydesign(
-      ids     = ids_formula,
-      strata  = strata_formula,
+      ids = ids_formula,
+      strata = strata_formula,
       weights = weights_formula,
-      fpc     = ~fpc_val, # nolint: object_usage_linter
-      data    = combined
+      fpc = ~fpc_val, # nolint: object_usage_linter
+      data = combined
     )
   } else {
     design <- survey::svydesign(
-      ids     = ids_formula,
-      strata  = strata_formula,
+      ids = ids_formula,
+      strata = strata_formula,
       weights = weights_formula,
-      data    = combined
+      data = combined
     )
   }
 

--- a/R/impute-camera-counts.R
+++ b/R/impute-camera-counts.R
@@ -86,8 +86,8 @@ impute_camera_counts <- function(
   count_col,
   strata_col,
   status_col = "camera_status",
-  method     = "glm",
-  site_col   = NULL
+  method = "glm",
+  site_col = NULL
 ) {
   # 1. Input validation --------------------------------------------------------
   checkmate::assert_data_frame(data, min.rows = 1L)
@@ -115,7 +115,10 @@ impute_camera_counts <- function(
 
   # 2. Guard: glmmTMB required for GLMM method --------------------------------
   if (method == "glmm") {
-    rlang::check_installed("glmmTMB", reason = "to fit a negative binomial GLMM for camera count imputation") # nolint: line_length_linter
+    rlang::check_installed(
+      "glmmTMB",
+      reason = "to fit a negative binomial GLMM for camera count imputation"
+    ) # nolint: line_length_linter
   }
 
   # 3. Identify outage rows ----------------------------------------------------
@@ -126,10 +129,14 @@ impute_camera_counts <- function(
 
   # 4. High-missingness warning (CAMP-04) -------------------------------------
   strata_vals <- unique(data[[strata_col]])
-  miss_fractions <- vapply(strata_vals, function(s) {
-    stratum_mask <- data[[strata_col]] == s
-    sum(is_outage[stratum_mask]) / sum(stratum_mask)
-  }, numeric(1L))
+  miss_fractions <- vapply(
+    strata_vals,
+    function(s) {
+      stratum_mask <- data[[strata_col]] == s
+      sum(is_outage[stratum_mask]) / sum(stratum_mask)
+    },
+    numeric(1L)
+  )
   names(miss_fractions) <- strata_vals
 
   high_miss_strata <- names(miss_fractions[miss_fractions > 0.5])
@@ -176,7 +183,7 @@ impute_camera_counts <- function(
     if (method == "glm") {
       fit <- stats::glm(
         glm_formula,
-        data   = stratum_data[obs_mask, , drop = FALSE],
+        data = stratum_data[obs_mask, , drop = FALSE],
         family = stats::poisson()
       )
     } else {
@@ -194,7 +201,7 @@ impute_camera_counts <- function(
       fit <- tryCatch(
         glmmTMB::glmmTMB(
           glmm_formula,
-          data   = stratum_data[obs_mask, , drop = FALSE],
+          data = stratum_data[obs_mask, , drop = FALSE],
           family = glmmTMB::nbinom2(link = "log")
         ),
         error = function(e) {
@@ -211,7 +218,7 @@ impute_camera_counts <- function(
       if (is.null(fit)) {
         fit <- stats::glm(
           glm_formula,
-          data   = stratum_data[obs_mask, , drop = FALSE],
+          data = stratum_data[obs_mask, , drop = FALSE],
           family = stats::poisson()
         )
       }
@@ -221,7 +228,7 @@ impute_camera_counts <- function(
     predicted <- predict(
       fit,
       newdata = stratum_data[outage_mask, , drop = FALSE],
-      type    = "response"
+      type = "response"
     )
     stratum_data[[count_col]][outage_mask] <- as.integer(round(predicted))
 

--- a/R/nonresponse-adjust.R
+++ b/R/nonresponse-adjust.R
@@ -77,10 +77,12 @@
 #'
 #' @family "Reporting & Diagnostics"
 #' @export
-adjust_nonresponse <- function(design,
-                               response_rates,
-                               method = c("postStratify", "calibrate"),
-                               stratum_col = "stratum") {
+adjust_nonresponse <- function(
+  design,
+  response_rates,
+  method = c("postStratify", "calibrate"),
+  stratum_col = "stratum"
+) {
   method <- match.arg(method)
 
   # Input validation -----------------------------------------------------------
@@ -168,10 +170,10 @@ adjust_nonresponse <- function(design,
 
   # Build diagnostics tibble
   diagnostics <- tibble::tibble(
-    stratum           = strata_vals,
-    n_sampled         = n_sampled,
-    n_responded       = n_responded,
-    response_rate     = response_rate,
+    stratum = strata_vals,
+    n_sampled = n_sampled,
+    n_responded = n_responded,
+    response_rate = response_rate,
     weight_adjustment = weight_adj
   )
 
@@ -220,8 +222,7 @@ adjust_nonresponse <- function(design,
 #' @return Updated svydesign.
 #' @keywords internal
 #' @noRd
-apply_nonresponse_weights <- function(svy, strata_cols, diagnostics,
-                                      method) {
+apply_nonresponse_weights <- function(svy, strata_cols, diagnostics, method) {
   if (is.null(svy)) {
     return(NULL)
   }

--- a/R/nonresponse-adjust.R
+++ b/R/nonresponse-adjust.R
@@ -21,11 +21,11 @@
 #'     \item{n_responded}{Integer. Number of units that actually responded.
 #'       Must be \code{<= n_sampled}.}
 #'   }
-#' @param method Character. Weighting method to apply. Either
-#'   \code{"postStratify"} (default, adjusts weights to match known stratum
-#'   totals inversely proportional to response rate) or \code{"calibrate"}
-#'   (calibration estimator via \code{survey::calibrate}; requires stratum
-#'   population totals in \code{response_rates}).
+#' @param method Character. Weighting method to apply. Currently only
+#'   \code{"postStratify"} (default) is implemented. It multiplies each
+#'   observation's sampling weight by the inverse response rate for its stratum.
+#'   Specifying \code{"calibrate"} raises an error; use \code{survey::calibrate}
+#'   directly with population totals from your sampling frame.
 #' @param stratum_col Character. Name of the stratum column in
 #'   \code{response_rates} (default: \code{"stratum"}).
 #'
@@ -229,6 +229,22 @@ apply_nonresponse_weights <- function(svy, strata_cols, diagnostics,
     return(svy)
   }
 
+  # "calibrate" requires population totals not available here; it must be
+  # called directly via survey::calibrate() with a suitable population frame.
+  if (method == "calibrate") {
+    cli::cli_abort(c(
+      '{.val "calibrate"} method is not yet implemented in {.fn adjust_nonresponse}.',
+      "i" = paste0(
+        'Use {.val "postStratify"} (the default), which applies the ',
+        'inverse-response-rate weight scaling documented in the function.'
+      ),
+      "i" = paste0(
+        'For calibration, call {.fn survey::calibrate} directly with ',
+        'population totals derived from your sampling frame.'
+      )
+    ))
+  }
+
   # Build stratum-weight mapping
   strat_weights <- setNames(
     diagnostics$weight_adjustment,
@@ -259,10 +275,16 @@ apply_nonresponse_weights <- function(svy, strata_cols, diagnostics,
   wt_multipliers[is.na(wt_multipliers)] <- 1.0
 
   if (inherits(svy, "svyrep.design")) {
-    # For replicate designs: scale the scale slot
-    svy$scale <- svy$scale * mean(wt_multipliers, na.rm = TRUE)
+    # Scale per-observation base weights (pweights = sampling weights = 1/prob).
+    # Multiply by per-stratum nonresponse multiplier to upweight respondents.
+    svy$pweights <- svy$pweights * wt_multipliers
+    # Scale replicate weight matrix row-wise by the same per-observation
+    # multipliers so that variance estimates reflect the adjusted weights.
+    rw <- as.matrix(svy$repweights)
+    svy$repweights <- sweep(rw, 1, wt_multipliers, "*")
   } else {
-    # For standard svydesign: scale prob / weights
+    # For standard svydesign: prob is the inclusion probability (lower = higher
+    # weight), so divide by multiplier to increase weight for respondents.
     svy$prob <- svy$prob / wt_multipliers
     svy$allprob <- lapply(
       svy$allprob,

--- a/R/power-creel.R
+++ b/R/power-creel.R
@@ -124,34 +124,36 @@ power_creel <- function(
   mode <- match.arg(mode)
   alternative <- match.arg(alternative)
 
-  switch(mode,
+  switch(
+    mode,
     effort_n = .power_creel_effort_n(
       target_rse = target_rse,
-      strata     = strata,
-      N_h        = N_h, # nolint: object_name_linter
-      ybar_h     = ybar_h, # nolint: object_name_linter
-      s2_h       = s2_h # nolint: object_name_linter
+      strata = strata,
+      N_h = N_h, # nolint: object_name_linter
+      ybar_h = ybar_h, # nolint: object_name_linter
+      s2_h = s2_h # nolint: object_name_linter
     ),
     cpue_n = .power_creel_cpue_n(
       target_rse = target_rse,
-      cv_catch   = cv_catch,
-      cv_effort  = cv_effort,
-      rho        = rho
+      cv_catch = cv_catch,
+      cv_effort = cv_effort,
+      rho = rho
     ),
     power = .power_creel_power(
-      n             = n,
+      n = n,
       cv_historical = cv_historical, # nolint: object_name_linter
-      cv_catch      = cv_catch,
-      delta_pct     = delta_pct,
-      alpha         = alpha,
-      alternative   = alternative
+      cv_catch = cv_catch,
+      delta_pct = delta_pct,
+      alpha = alpha,
+      alternative = alternative
     )
   )
 }
 
 # ---- Internal mode handlers -------------------------------------------------
 
-.power_creel_effort_n <- function(target_rse, strata, N_h, ybar_h, s2_h) { # nolint
+.power_creel_effort_n <- function(target_rse, strata, N_h, ybar_h, s2_h) {
+  # nolint
   if (is.null(target_rse)) {
     cli::cli_abort(
       "{.arg target_rse} is required for {.code mode = \"effort_n\"}."
@@ -171,11 +173,12 @@ power_creel <- function(
 
   names(N_h) <- strata # nolint: object_name_linter
 
-  raw <- creel_n_effort( # nolint: object_usage_linter
+  raw <- creel_n_effort(
+    # nolint: object_usage_linter
     cv_target = target_rse,
-    N_h       = N_h, # nolint: object_name_linter
-    ybar_h    = ybar_h, # nolint: object_name_linter
-    s2_h      = s2_h # nolint: object_name_linter
+    N_h = N_h, # nolint: object_name_linter
+    ybar_h = ybar_h, # nolint: object_name_linter
+    s2_h = s2_h # nolint: object_name_linter
   )
 
   all_strata <- c(strata, "total")
@@ -200,11 +203,12 @@ power_creel <- function(
     )
   }
 
-  n_req <- creel_n_cpue( # nolint: object_usage_linter
-    cv_catch   = cv_catch,
-    cv_effort  = cv_effort,
-    rho        = rho,
-    cv_target  = target_rse
+  n_req <- creel_n_cpue(
+    # nolint: object_usage_linter
+    cv_catch = cv_catch,
+    cv_effort = cv_effort,
+    rho = rho,
+    cv_target = target_rse
   )
 
   data.frame(
@@ -217,8 +221,14 @@ power_creel <- function(
   )
 }
 
-.power_creel_power <- function(n, cv_historical, cv_catch, delta_pct, # nolint
-                               alpha, alternative) {
+.power_creel_power <- function(
+  n,
+  cv_historical,
+  cv_catch,
+  delta_pct, # nolint
+  alpha,
+  alternative
+) {
   if (is.null(n)) {
     cli::cli_abort("{.arg n} is required for {.code mode = \"power\"}.")
   }
@@ -235,12 +245,13 @@ power_creel <- function(
     )
   }
 
-  pwr <- creel_power( # nolint: object_usage_linter
-    n             = n,
+  pwr <- creel_power(
+    # nolint: object_usage_linter
+    n = n,
     cv_historical = cv_hist, # nolint: object_name_linter
-    delta_pct     = delta_pct,
-    alpha         = alpha,
-    alternative   = alternative
+    delta_pct = delta_pct,
+    alpha = alpha,
+    alternative = alternative
   )
 
   data.frame(

--- a/R/power-sample-size.R
+++ b/R/power-sample-size.R
@@ -48,7 +48,8 @@
 #'   ybar_h = c(50, 60),
 #'   s2_h = c(400, 500)
 #' )
-creel_n_effort <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name_linter
+creel_n_effort <- function(cv_target, N_h, ybar_h, s2_h) {
+  # nolint: object_name_linter
   checkmate::assert_number(cv_target, lower = 1e-6, upper = 1.0)
   checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named") # nolint: object_name_linter
   checkmate::assert_numeric(ybar_h, lower = 0, len = length(N_h)) # nolint: object_name_linter
@@ -158,7 +159,8 @@ creel_n_effort <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name
 #'   s2_h       = c(400, 500),
 #'   cost_ratio = c(weekday = 1, weekend = 2)
 #' )
-optimal_n <- function(cv_target, N_h, ybar_h, s2_h, cost_ratio = 1) { # nolint: object_name_linter
+optimal_n <- function(cv_target, N_h, ybar_h, s2_h, cost_ratio = 1) {
+  # nolint: object_name_linter
   checkmate::assert_number(cv_target, lower = 1e-6, upper = 1.0)
   checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named") # nolint: object_name_linter
   checkmate::assert_numeric(ybar_h, lower = 0, len = length(N_h)) # nolint: object_name_linter
@@ -192,18 +194,18 @@ optimal_n <- function(cv_target, N_h, ybar_h, s2_h, cost_ratio = 1) { # nolint: 
     )
   }
 
-  V_0      <- (cv_target * E_total)^2
-  s_h      <- sqrt(s2_h)
+  V_0 <- (cv_target * E_total)^2
+  s_h <- sqrt(s2_h)
 
   # Cochran (1977) eq. 5.25/5.34 with FPC -- equal costs reduces to creel_n_effort n_total
-  A           <- sum(N_h * s_h / sqrt(cost_ratio))
-  C_cost      <- sum(N_h * s_h * sqrt(cost_ratio))
+  A <- sum(N_h * s_h / sqrt(cost_ratio))
+  C_cost <- sum(N_h * s_h * sqrt(cost_ratio))
   denominator <- V_0 + sum(N_h * s2_h)
-  n_total     <- max(ceiling(A * C_cost / denominator), 1L)
+  n_total <- max(ceiling(A * C_cost / denominator), 1L)
 
   # Neyman allocation with optional cost adjustment (Cochran eq. 5.24 / 5.30)
   neyman_w <- N_h * s_h / sqrt(cost_ratio)
-  n_h      <- ceiling(n_total * neyman_w / sum(neyman_w))
+  n_h <- ceiling(n_total * neyman_w / sum(neyman_w))
   names(n_h) <- names(N_h)
 
   storage.mode(n_h) <- "integer"
@@ -341,7 +343,8 @@ creel_n_cpue <- function(cv_catch, cv_effort, rho = 0, cv_target) {
 #'   ybar_h = c(15, 20),
 #'   s2_h = c(625, 900)
 #' )
-creel_n_camera <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name_linter
+creel_n_camera <- function(cv_target, N_h, ybar_h, s2_h) {
+  # nolint: object_name_linter
   checkmate::assert_number(cv_target, lower = 1e-6, upper = 1.0)
   checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named") # nolint: object_name_linter
   checkmate::assert_numeric(ybar_h, lower = 0, len = length(N_h)) # nolint: object_name_linter
@@ -362,12 +365,21 @@ creel_n_camera <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name
   names(n_h) <- names(N_h) # nolint: object_name_linter
 
   # Feltz-Middaugh (2025) minimum check -- D-06/D-07
-  min_h <- vapply(names(N_h), function(nm) { # nolint: object_name_linter
-    nm_lower <- tolower(nm)
-    if (grepl("weekday", nm_lower)) 12L
-    else if (grepl("weekend", nm_lower)) 7L
-    else NA_integer_
-  }, integer(1))
+  min_h <- vapply(
+    names(N_h),
+    function(nm) {
+      # nolint: object_name_linter
+      nm_lower <- tolower(nm)
+      if (grepl("weekday", nm_lower)) {
+        12L
+      } else if (grepl("weekend", nm_lower)) {
+        7L
+      } else {
+        NA_integer_
+      }
+    },
+    integer(1)
+  )
 
   below <- which(!is.na(min_h) & n_h < min_h) # nolint: object_name_linter
   generic_below <- which(is.na(min_h)) # unclassified strata always warned
@@ -376,14 +388,20 @@ creel_n_camera <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name
     bullet_items <- character(length(below) + length(generic_below))
     idx <- 1L
     for (i in below) {
-      bullet_items[idx] <- sprintf("%s: n = %d (minimum %d per Feltz-Middaugh 2025)",
-                                   names(n_h)[i], n_h[i], min_h[i])
+      bullet_items[idx] <- sprintf(
+        "%s: n = %d (minimum %d per Feltz-Middaugh 2025)",
+        names(n_h)[i],
+        n_h[i],
+        min_h[i]
+      )
       idx <- idx + 1L
     }
     for (i in generic_below) {
       bullet_items[idx] <- sprintf(
         "%s: n = %d (unclassified stratum -- consult Feltz-Middaugh 2025 for recommended minimum)",
-        names(n_h)[i], n_h[i])
+        names(n_h)[i],
+        n_h[i]
+      )
       idx <- idx + 1L
     }
     names(bullet_items) <- rep("*", length(bullet_items))
@@ -450,8 +468,13 @@ creel_n_camera <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name
 #'
 #' # One-sided test (higher power for same inputs)
 #' creel_power(n = 100, cv_historical = 0.5, delta_pct = 0.20, alternative = "one.sided")
-creel_power <- function(n, cv_historical, delta_pct, alpha = 0.05, # nolint: object_name_linter
-                        alternative = c("two.sided", "one.sided")) {
+creel_power <- function(
+  n,
+  cv_historical,
+  delta_pct,
+  alpha = 0.05, # nolint: object_name_linter
+  alternative = c("two.sided", "one.sided")
+) {
   checkmate::assert_integerish(n, lower = 1, len = 1)
   checkmate::assert_number(cv_historical, lower = 1e-6) # nolint: object_name_linter
   checkmate::assert_number(delta_pct, lower = 1e-6)

--- a/R/power-sample-size.R
+++ b/R/power-sample-size.R
@@ -108,7 +108,9 @@ creel_n_effort <- function(cv_target, N_h, ybar_h, s2_h) { # nolint: object_name
 #' \eqn{V_0 = (CV_{target} \cdot \hat{E})^2}, \eqn{\hat{E} = \sum_h N_h
 #' \bar{y}_h}, and \eqn{s_h = \sqrt{s_h^2}}. When all \eqn{c_h = 1}
 #' (equal costs) this reduces to \eqn{(\sum_h N_h s_h)^2 / (V_0 + \sum_h N_h
-#' s_h^2)}, identical to [creel_n_effort()].
+#' s_h^2)}, which gives the same `n_total` as [creel_n_effort()] (per-stratum
+#' allocation differs: Neyman uses \eqn{n_h \propto N_h s_h} vs proportional
+#' \eqn{n_h \propto N_h}).
 #'
 #' **Per-stratum allocation** uses the cost-adjusted Neyman formula (Cochran
 #' 1977 eq. 5.30):
@@ -167,23 +169,45 @@ optimal_n <- function(cv_target, N_h, ybar_h, s2_h, cost_ratio = 1) { # nolint: 
   }
   checkmate::assert_numeric(cost_ratio, lower = 1e-6, len = length(N_h), any.missing = FALSE)
 
-  E_total <- sum(N_h * ybar_h) # nolint: object_name_linter
-  V_0 <- (cv_target * E_total)^2 # nolint: object_name_linter
-  s_h <- sqrt(s2_h) # nolint: object_name_linter
+  # Reorder named cost_ratio to match N_h strata order; unnamed stays positional.
+  if (!is.null(names(cost_ratio))) {
+    cost_ratio <- cost_ratio[names(N_h)] # nolint: object_name_linter
+    if (anyNA(cost_ratio)) {
+      cli::cli_abort(
+        "{.arg cost_ratio} names must match strata names in {.arg N_h}."
+      )
+    }
+  }
 
-  # Cochran (1977) eq. 5.25/5.34 with FPC -- generalises to equal costs when
-  # all cost_ratio == 1 (reduces to creel_n_effort formula)
-  A <- sum(N_h * s_h / sqrt(cost_ratio)) # nolint: object_name_linter
-  C_cost <- sum(N_h * s_h * sqrt(cost_ratio)) # nolint: object_name_linter
-  denominator <- V_0 + sum(N_h * s2_h) # nolint: object_name_linter
-  n_total <- ceiling(A * C_cost / denominator)
+  # nolint start: object_name_linter
+  E_total <- sum(N_h * ybar_h)
+  if (E_total <= 0) {
+    cli::cli_abort(
+      "sum(N_h * ybar_h) must be > 0; CV of a zero total is undefined."
+    )
+  }
+  if (sum(s2_h) == 0) {
+    cli::cli_abort(
+      "All {.arg s2_h} are zero; no variance to allocate. Provide at least one s2_h > 0."
+    )
+  }
+
+  V_0      <- (cv_target * E_total)^2
+  s_h      <- sqrt(s2_h)
+
+  # Cochran (1977) eq. 5.25/5.34 with FPC -- equal costs reduces to creel_n_effort n_total
+  A           <- sum(N_h * s_h / sqrt(cost_ratio))
+  C_cost      <- sum(N_h * s_h * sqrt(cost_ratio))
+  denominator <- V_0 + sum(N_h * s2_h)
+  n_total     <- max(ceiling(A * C_cost / denominator), 1L)
 
   # Neyman allocation with optional cost adjustment (Cochran eq. 5.24 / 5.30)
-  neyman_w <- N_h * s_h / sqrt(cost_ratio) # nolint: object_name_linter
-  n_h <- ceiling(n_total * neyman_w / sum(neyman_w)) # nolint: object_name_linter
-  names(n_h) <- names(N_h) # nolint: object_name_linter
+  neyman_w <- N_h * s_h / sqrt(cost_ratio)
+  n_h      <- ceiling(n_total * neyman_w / sum(neyman_w))
+  names(n_h) <- names(N_h)
 
-  storage.mode(n_h) <- "integer" # nolint: object_name_linter
+  storage.mode(n_h) <- "integer"
+  # nolint end: object_name_linter
   storage.mode(n_total) <- "integer"
 
   c(n_h, total = n_total) # nolint: object_name_linter

--- a/R/prep-counts.R
+++ b/R/prep-counts.R
@@ -40,16 +40,18 @@
 #' @seealso [add_counts()]
 #' @family "Survey Design"
 #' @export
-prep_counts_daily_effort <- function(data,
-                                     date,
-                                     strata = NULL,
-                                     effort_type,
-                                     daily_effort,
-                                     correction_factor = 1,
-                                     psu = NULL,
-                                     n_counts = NULL,
-                                     within_day_var = NULL,
-                                     source_method = NULL) {
+prep_counts_daily_effort <- function(
+  data,
+  date,
+  strata = NULL,
+  effort_type,
+  daily_effort,
+  correction_factor = 1,
+  psu = NULL,
+  n_counts = NULL,
+  within_day_var = NULL,
+  source_method = NULL
+) {
   date_quo <- rlang::enquo(date)
   strata_quo <- rlang::enquo(strata)
   effort_type_quo <- rlang::enquo(effort_type)
@@ -255,17 +257,19 @@ prep_counts_daily_effort <- function(data,
 #' @seealso [prep_counts_daily_effort()], [add_counts()]
 #' @family "Survey Design"
 #' @export
-prep_counts_boat_party <- function(data,
-                                   date,
-                                   strata = NULL,
-                                   boat_count,
-                                   mean_party_size,
-                                   effort_type = "boat",
-                                   correction_factor = 1,
-                                   psu = NULL,
-                                   n_counts = NULL,
-                                   within_day_var = NULL,
-                                   source_method = "boat_count_x_mean_party_size") {
+prep_counts_boat_party <- function(
+  data,
+  date,
+  strata = NULL,
+  boat_count,
+  mean_party_size,
+  effort_type = "boat",
+  correction_factor = 1,
+  psu = NULL,
+  n_counts = NULL,
+  within_day_var = NULL,
+  source_method = "boat_count_x_mean_party_size"
+) {
   date_quo <- rlang::enquo(date)
   strata_quo <- rlang::enquo(strata)
   boat_count_quo <- rlang::enquo(boat_count)

--- a/R/prep-interviews.R
+++ b/R/prep-interviews.R
@@ -46,22 +46,24 @@
 #' @seealso [compute_effort()], [add_interviews()]
 #' @family "Survey Design"
 #' @export
-prep_interviews_trips <- function(data,
-                                  date,
-                                  interview_uid,
-                                  effort_hours = NULL,
-                                  trip_status,
-                                  trip_duration = NULL,
-                                  trip_start = NULL,
-                                  interview_time = NULL,
-                                  catch_total = NULL,
-                                  harvest_total = NULL,
-                                  angler_type = NULL,
-                                  angler_method = NULL,
-                                  species_sought = NULL,
-                                  n_anglers = NULL,
-                                  refused = NULL,
-                                  strata = NULL) {
+prep_interviews_trips <- function(
+  data,
+  date,
+  interview_uid,
+  effort_hours = NULL,
+  trip_status,
+  trip_duration = NULL,
+  trip_start = NULL,
+  interview_time = NULL,
+  catch_total = NULL,
+  harvest_total = NULL,
+  angler_type = NULL,
+  angler_method = NULL,
+  species_sought = NULL,
+  n_anglers = NULL,
+  refused = NULL,
+  strata = NULL
+) {
   date_quo <- rlang::enquo(date)
   interview_uid_quo <- rlang::enquo(interview_uid)
   effort_hours_quo <- rlang::enquo(effort_hours)
@@ -252,11 +254,7 @@ prep_interviews_trips <- function(data,
 #' @seealso [add_catch()]
 #' @family "Survey Design"
 #' @export
-prep_interview_catch <- function(data,
-                                 interview_uid,
-                                 species,
-                                 count,
-                                 catch_type) {
+prep_interview_catch <- function(data, interview_uid, species, count, catch_type) {
   interview_uid_quo <- rlang::enquo(interview_uid)
   species_quo <- rlang::enquo(species)
   count_quo <- rlang::enquo(count)

--- a/R/print-methods.R
+++ b/R/print-methods.R
@@ -23,7 +23,9 @@ format.creel_estimates_mor <- function(x, ...) {
     # Add truncation details if applicable
     if (!is.null(x$mor_truncate_at)) {
       if (x$mor_n_truncated > 0) {
-        cli::cli_text("Truncation: {x$mor_n_truncated} trip{?s} excluded (< {x$mor_truncate_at} hours)")
+        cli::cli_text(
+          "Truncation: {x$mor_n_truncated} trip{?s} excluded (< {x$mor_truncate_at} hours)"
+        )
       } else {
         cli::cli_text("Truncation: 0 trips excluded (threshold: {x$mor_truncate_at} hours)")
       }
@@ -133,23 +135,22 @@ print.creel_estimates_diagnostic <- function(x, ...) {
 #'
 #' @export
 print.creel_summary <- function(x, ...) {
-  method_display <- switch(x$method,
+  method_display <- switch(
+    x$method,
     total = "Total",
     "ratio-of-means-cpue" = "Ratio-of-Means CPUE",
     "mean-of-ratios-cpue" = "Mean-of-Ratios CPUE",
     "ratio-of-means-hpue" = "Ratio-of-Means HPUE",
-    "ratio-of-means-cpue-per-angler" =
-      "Ratio-of-Means CPUE (per angler)",
-    "mean-of-ratios-cpue-per-angler" =
-      "Mean-of-Ratios CPUE (per angler)",
-    "ratio-of-means-hpue-per-angler" =
-      "Ratio-of-Means HPUE (per angler)",
+    "ratio-of-means-cpue-per-angler" = "Ratio-of-Means CPUE (per angler)",
+    "mean-of-ratios-cpue-per-angler" = "Mean-of-Ratios CPUE (per angler)",
+    "ratio-of-means-hpue-per-angler" = "Ratio-of-Means HPUE (per angler)",
     "product-total-catch" = "Total Catch (Effort x CPUE)",
     "product-total-harvest" = "Total Harvest (Effort x HPUE)",
     x$method
   )
-  variance_display <- switch(x$variance_method,
-    taylor    = "Taylor linearization",
+  variance_display <- switch(
+    x$variance_method,
+    taylor = "Taylor linearization",
     bootstrap = "Bootstrap",
     jackknife = "Jackknife",
     x$variance_method
@@ -158,7 +159,9 @@ print.creel_summary <- function(x, ...) {
 
   cat(sprintf(
     "-- Creel Survey Summary (%s | %s | %s) --\n",
-    method_display, variance_display, conf_pct
+    method_display,
+    variance_display,
+    conf_pct
   ))
   print(x$table, row.names = FALSE, ...)
   invisible(x)

--- a/R/schedule-generators.R
+++ b/R/schedule-generators.R
@@ -908,7 +908,17 @@ generate_bus_schedule <- function(schedule, sampling_frame, site, p_site,
 
   # Add columns to output
   result[["p_period"]] <- p_period
-  result[["inclusion_prob"]] <- p_site_vals * p_period
+  inclusion_probs <- p_site_vals * p_period
+  result[["inclusion_prob"]] <- inclusion_probs
+
+  bad_sites <- which(inclusion_probs > 1)
+  if (length(bad_sites) > 0L) {
+    cli::cli_abort(c(
+      "Inclusion probabilities exceed 1 for {length(bad_sites)} site{?s}.",
+      "x" = "crew={crew}, n_circuits={n_circuits} → p_period={p_period}; max p_site={max(p_site_vals[bad_sites])}.",
+      "i" = "Reduce {.arg crew} or increase circuits so that p_site * (crew / n_circuits) ≤ 1 for all sites."
+    ))
+  }
 
   # Drop synthetic circuit column
   if (rlang::quo_is_null(circuit_quo)) {

--- a/R/schedule-generators.R
+++ b/R/schedule-generators.R
@@ -947,8 +947,8 @@ generate_bus_schedule <- function(
   if (length(bad_sites) > 0L) {
     cli::cli_abort(c(
       "Inclusion probabilities exceed 1 for {length(bad_sites)} site{?s}.",
-      "x" = "crew={crew}, n_circuits={n_circuits} → p_period={p_period}; max p_site={max(p_site_vals[bad_sites])}.",
-      "i" = "Reduce {.arg crew} or increase circuits so that p_site * (crew / n_circuits) ≤ 1 for all sites."
+      "x" = "crew={crew}, n_circuits={n_circuits}, p_period={p_period}; max p_site={max(p_site_vals[bad_sites])}.",
+      "i" = "Reduce {.arg crew} or increase circuits so that p_site * (crew / n_circuits) <= 1 for all sites."
     ))
   }
 

--- a/R/schedule-generators.R
+++ b/R/schedule-generators.R
@@ -37,8 +37,13 @@ new_creel_schedule <- function(data) {
 #'   sampled days.
 #'
 #' @noRd
-select_sampled_days <- function(all_dates, day_types, n_days = NULL,
-                                sampling_rate = NULL, valid_strata = NULL) {
+select_sampled_days <- function(
+  all_dates,
+  day_types,
+  n_days = NULL,
+  sampling_rate = NULL,
+  valid_strata = NULL
+) {
   strata <- unique(day_types)
   if (is.null(valid_strata)) {
     valid_strata <- strata
@@ -108,8 +113,7 @@ select_sampled_days <- function(all_dates, day_types, n_days = NULL,
 #'   column.
 #'
 #' @noRd
-expand_periods_impl <- function(base_df, n_periods, period_labels = NULL,
-                                ordered_periods = FALSE) {
+expand_periods_impl <- function(base_df, n_periods, period_labels = NULL, ordered_periods = FALSE) {
   if (!is.null(period_labels) && length(period_labels) != n_periods) {
     cli::cli_abort(c(
       "Length of {.arg period_labels} must equal {.arg n_periods}.",
@@ -273,15 +277,22 @@ resolve_special_periods <- function(all_dates, day_types, special_periods = NULL
     source_end_date = expanded$source_end_date,
     stringsAsFactors = FALSE
   )
-  audit$crosses_boundary <- format(audit$source_start_date, "%Y-%m") != format(audit$source_end_date, "%Y-%m")
+  audit$crosses_boundary <- format(audit$source_start_date, "%Y-%m") !=
+    format(audit$source_end_date, "%Y-%m")
 
   allocation <- as.data.frame(table(final_stratum), stringsAsFactors = FALSE)
   names(allocation) <- c("final_stratum", "available_days")
 
   diag_rows <- list()
-  all_strata <- unique(c(as.character(baseline_allocation$stratum), as.character(allocation$final_stratum)))
+  all_strata <- unique(c(
+    as.character(baseline_allocation$stratum),
+    as.character(allocation$final_stratum)
+  ))
   for (stratum_name in all_strata) {
-    baseline_days <- baseline_allocation$baseline_days[match(stratum_name, baseline_allocation$stratum)]
+    baseline_days <- baseline_allocation$baseline_days[match(
+      stratum_name,
+      baseline_allocation$stratum
+    )]
     final_days <- allocation$available_days[match(stratum_name, allocation$final_stratum)]
     baseline_days[is.na(baseline_days)] <- 0L
     final_days[is.na(final_days)] <- 0L
@@ -468,7 +479,8 @@ generate_schedule <- function(
     blocking <- diagnostics[
       diagnostics$severity == "error" &
         diagnostics$stratum %in% requested_strata &
-        season_fully_rewritten, ,
+        season_fully_rewritten,
+      ,
       drop = FALSE
     ]
     if (nrow(blocking) > 0L) {
@@ -476,9 +488,13 @@ generate_schedule <- function(
       cli::cli_abort(c(
         "Special-period declarations consumed a baseline stratum still requested for sampling.",
         "x" = paste0(
-          "Stratum ", b1$stratum,
-          " had ", b1$baseline_days, " baseline day(s) and ",
-          b1$final_days, " remaining final day(s)."
+          "Stratum ",
+          b1$stratum,
+          " had ",
+          b1$baseline_days,
+          " baseline day(s) and ",
+          b1$final_days,
+          " remaining final day(s)."
         ),
         "i" = paste0(
           "Update {.arg n_days} or {.arg sampling_rate} to match",
@@ -489,14 +505,19 @@ generate_schedule <- function(
 
     warnings <- diagnostics[
       diagnostics$severity == "warning" |
-        (diagnostics$severity == "error" & diagnostics$stratum %in% requested_strata), ,
+        (diagnostics$severity == "error" & diagnostics$stratum %in% requested_strata),
+      ,
       drop = FALSE
     ]
     if (nrow(warnings) > 0L) {
-      warn_labels <- paste0( # nolint: object_usage_linter.
+      warn_labels <- paste0(
+        # nolint: object_usage_linter.
         warnings$stratum,
-        " (baseline=", warnings$baseline_days,
-        ", final=", warnings$final_days, ")"
+        " (baseline=",
+        warnings$baseline_days,
+        ", final=",
+        warnings$final_days,
+        ")"
       )
       cli::cli_warn(c(
         "Special-period declarations produced a fragile schedule design.",
@@ -531,9 +552,9 @@ generate_schedule <- function(
 
   # Build base tibble with all season dates
   base <- tibble::tibble(
-    date     = all_dates,
+    date = all_dates,
     day_type = day_types,
-    sampled  = sampled
+    sampled = sampled
   )
 
   if (!is.null(special_periods)) {
@@ -805,10 +826,14 @@ generate_count_times <- function(
   # Generate windows
   t_starts <- withr::with_seed(seed, {
     if (strategy == "random") {
-      vapply(seq_len(n_windows) - 1L, function(i) {
-        stratum_start <- start_min + i * k
-        sample(stratum_start:(stratum_start + k - window_size), 1L)
-      }, integer(1))
+      vapply(
+        seq_len(n_windows) - 1L,
+        function(i) {
+          stratum_start <- start_min + i * k
+          sample(stratum_start:(stratum_start + k - window_size), 1L)
+        },
+        integer(1)
+      )
     } else {
       # systematic
       t1 <- sample(start_min:(start_min + k - window_size), 1L)
@@ -865,8 +890,15 @@ generate_count_times <- function(
 #'
 #' @family "Scheduling"
 #' @export
-generate_bus_schedule <- function(schedule, sampling_frame, site, p_site,
-                                  circuit = NULL, crew, seed = NULL) {
+generate_bus_schedule <- function(
+  schedule,
+  sampling_frame,
+  site,
+  p_site,
+  circuit = NULL,
+  crew,
+  seed = NULL
+) {
   # Capture tidy selectors
   site_quo <- rlang::enquo(site)
   p_site_quo <- rlang::enquo(p_site)
@@ -979,11 +1011,13 @@ attach_count_times <- function(schedule, count_times) {
   # merge() with no by columns performs a full cross-join
   result <- merge(schedule, count_times, by = NULL)
   # Restore intuitive row order: schedule rows primary, windows secondary
-  result <- result[order(
-    result$date,
-    if ("period_id" %in% names(result)) result$period_id else seq_len(nrow(result)),
-    result$window_id
-  ), ]
+  result <- result[
+    order(
+      result$date,
+      if ("period_id" %in% names(result)) result$period_id else seq_len(nrow(result)),
+      result$window_id
+    ),
+  ]
   rownames(result) <- NULL
   new_creel_schedule(result)
 }

--- a/R/schedule-io.R
+++ b/R/schedule-io.R
@@ -84,7 +84,12 @@ coerce_schedule_columns <- function(df) {
     df$day_type[!is.na(df$day_type) & df$day_type == "NA"] <- NA_character_
   }
   if ("period_id" %in% names(df)) {
-    df$period_id <- suppressWarnings(as.integer(df$period_id))
+    pid <- df$period_id
+    all_numeric <- all(is.na(pid) | grepl("^[0-9]+$", pid))
+    if (all_numeric) {
+      df$period_id <- as.integer(pid)
+    }
+    # else: character period labels (e.g. "AM"/"PM") — preserve as-is
   }
   if ("sampled" %in% names(df)) {
     df$sampled <- as.logical(df$sampled)

--- a/R/schedule-io.R
+++ b/R/schedule-io.R
@@ -110,6 +110,8 @@ coerce_schedule_columns <- function(df) {
 #'   is written with [utils::write.csv()] (no row names). When `"xlsx"`,
 #'   [writexl::write_xlsx()] is used behind an [rlang::check_installed()]
 #'   guard.
+#' @param overwrite Logical. If `FALSE` (default), aborts with an error when
+#'   `path` already exists. Set `TRUE` to replace an existing file.
 #'
 #' @return `path`, returned invisibly.
 #'
@@ -125,7 +127,13 @@ coerce_schedule_columns <- function(df) {
 #'
 #' @family "Scheduling"
 #' @export
-write_schedule <- function(schedule, path, format = c("csv", "xlsx")) {
+write_schedule <- function(schedule, path, format = c("csv", "xlsx"), overwrite = FALSE) {
+  if (!overwrite && file.exists(path)) {
+    cli::cli_abort(c(
+      "File already exists: {.path {path}}",
+      "i" = "Set {.code overwrite = TRUE} to replace it."
+    ))
+  }
   format <- match.arg(format)
   if (format == "xlsx") {
     rlang::check_installed("writexl", reason = "to write xlsx schedule files")

--- a/R/schedule-print.R
+++ b/R/schedule-print.R
@@ -73,9 +73,13 @@ build_cell_lookup <- function(x, abbrev_map, mode = "ascii") {
     )
     # Combine abbreviation + circuit
     date_keys <- names(abbrevs)
-    cell_content <- vapply(date_keys, function(d) {
-      paste(abbrevs[[d]], circuit_by_date[[d]], sep = sep)
-    }, character(1))
+    cell_content <- vapply(
+      date_keys,
+      function(d) {
+        paste(abbrevs[[d]], circuit_by_date[[d]], sep = sep)
+      },
+      character(1)
+    )
     names(cell_content) <- date_keys
     return(cell_content)
   }
@@ -108,19 +112,23 @@ build_month_grid <- function(month_start, cell_lookup, mode = "ascii") {
   date_slots <- c(rep(NA, pad_left), all_dates, rep(NA, pad_right))
 
   # Cell content for each slot
-  cell_content <- vapply(seq_along(date_slots), function(i) {
-    d <- date_slots[[i]]
-    if (is.na(d)) {
-      return("")
-    }
-    key <- as.character(as.Date(d, origin = "1970-01-01"))
-    val <- cell_lookup[key] # single bracket: returns NA if key not present
-    if (!is.na(val)) {
-      val
-    } else {
-      format(as.Date(d, origin = "1970-01-01"), "%d")
-    }
-  }, character(1))
+  cell_content <- vapply(
+    seq_along(date_slots),
+    function(i) {
+      d <- date_slots[[i]]
+      if (is.na(d)) {
+        return("")
+      }
+      key <- as.character(as.Date(d, origin = "1970-01-01"))
+      val <- cell_lookup[key] # single bracket: returns NA if key not present
+      if (!is.na(val)) {
+        val
+      } else {
+        format(as.Date(d, origin = "1970-01-01"), "%d")
+      }
+    },
+    character(1)
+  )
 
   if (mode == "pandoc") {
     .build_pandoc_grid(cell_content)
@@ -145,9 +153,13 @@ build_month_grid <- function(month_start, cell_lookup, mode = "ascii") {
   max_subrows <- max(vapply(cell_lines, length, integer(1)), na.rm = TRUE)
 
   # Determine max character width per cell (across all sub-lines)
-  all_widths <- vapply(cell_lines, function(cl) {
-    if (length(cl) == 0L || (length(cl) == 1L && cl == "")) 0L else max(nchar(cl))
-  }, integer(1))
+  all_widths <- vapply(
+    cell_lines,
+    function(cl) {
+      if (length(cl) == 0L || (length(cl) == 1L && cl == "")) 0L else max(nchar(cl))
+    },
+    integer(1)
+  )
   cell_w <- max(max(all_widths, na.rm = TRUE), 8L)
 
   pad_cell <- function(s, w) {
@@ -168,9 +180,13 @@ build_month_grid <- function(month_start, cell_lookup, mode = "ascii") {
     week_cells <- cell_lines[(r - 1L) * 7L + seq_len(7L)]
     # Render one sub-row per logical line in the cell (bus-route = 2+ lines)
     for (sub in seq_len(max_subrows)) {
-      sub_row_cells <- vapply(week_cells, function(cl) {
-        if (sub <= length(cl)) cl[[sub]] else ""
-      }, character(1))
+      sub_row_cells <- vapply(
+        week_cells,
+        function(cl) {
+          if (sub <= length(cl)) cl[[sub]] else ""
+        },
+        character(1)
+      )
       padded <- vapply(sub_row_cells, pad_cell, character(1), w = cell_w)
       lines <- c(lines, paste0("| ", paste(padded, collapse = " | "), " |"))
     }
@@ -235,9 +251,17 @@ format.creel_schedule <- function(x, ...) {
   if (is.data.frame(diagnostics) && nrow(diagnostics) > 0L) {
     summary_lines <- apply(diagnostics, 1, function(row) {
       paste0(
-        "- ", row[["severity"]], ": ", row[["stratum"]],
-        " \u2014 ", row[["issue"]],
-        " (baseline=", row[["baseline_days"]], ", final=", row[["final_days"]], ")"
+        "- ",
+        row[["severity"]],
+        ": ",
+        row[["stratum"]],
+        " \u2014 ",
+        row[["issue"]],
+        " (baseline=",
+        row[["baseline_days"]],
+        ", final=",
+        row[["final_days"]],
+        ")"
       )
     })
     diag_lines <- c("Special-period diagnostics", unname(summary_lines), "")

--- a/R/season-summary.R
+++ b/R/season-summary.R
@@ -62,9 +62,13 @@ season_summary <- function(estimates, ...) {
   # by_vars consistency guard
   by_vars_list <- lapply(estimates, function(x) x$by_vars)
   first_by <- by_vars_list[[1]]
-  all_consistent <- all(vapply(by_vars_list, function(bv) {
-    identical(bv, first_by)
-  }, logical(1)))
+  all_consistent <- all(vapply(
+    by_vars_list,
+    function(bv) {
+      identical(bv, first_by)
+    },
+    logical(1)
+  ))
   if (!all_consistent) {
     cli::cli_abort(
       c(
@@ -94,22 +98,25 @@ season_summary <- function(estimates, ...) {
     )
   }
 
-  effort_targets <- vapply(estimates, function(x) {
-    x$effort_target %||% NA_character_
-  }, character(1))
+  effort_targets <- vapply(
+    estimates,
+    function(x) {
+      x$effort_target %||% NA_character_
+    },
+    character(1)
+  )
 
   new_creel_season_summary(
-    table          = wide,
-    names          = names(estimates),
-    n_estimates    = length(estimates),
+    table = wide,
+    names = names(estimates),
+    n_estimates = length(estimates),
     effort_targets = effort_targets
   )
 }
 
 # ---- new_creel_season_summary ------------------------------------------------
 
-new_creel_season_summary <- function(table, names, n_estimates,
-                                     effort_targets = character(0)) {
+new_creel_season_summary <- function(table, names, n_estimates, effort_targets = character(0)) {
   structure(
     list(
       table = table,

--- a/R/simulate-creel-data.R
+++ b/R/simulate-creel-data.R
@@ -148,28 +148,32 @@
 #' @export
 simulate_creel_data <- function(
   params,
-  season_days     = 100L,
-  n_sampled_days  = 30L,
-  day_types       = NULL,
-  species         = "walleye",
+  season_days = 100L,
+  n_sampled_days = 30L,
+  day_types = NULL,
+  species = "walleye",
   species_weights = NULL,
-  p_complete      = 0.75,
-  p_zero_catch    = 0.40,
+  p_complete = 0.75,
+  p_zero_catch = 0.40,
   n_anglers_per_day = NULL,
-  start_date      = Sys.Date(),
+  start_date = Sys.Date(),
   n_counts_per_day = 3L,
-  seed            = NULL
+  seed = NULL
 ) {
   checkmate::assert_list(params, names = "named")
-  checkmate::assert_int(season_days,    lower = 1L)
+  checkmate::assert_int(season_days, lower = 1L)
   checkmate::assert_int(n_sampled_days, lower = 1L, upper = season_days)
   checkmate::assert_character(species, min.len = 1L, any.missing = FALSE)
-  checkmate::assert_number(p_complete,   lower = 1e-6, upper = 1.0)
-  checkmate::assert_number(p_zero_catch, lower = 0.0,  upper = 1.0 - 1e-9)
+  checkmate::assert_number(p_complete, lower = 1e-6, upper = 1.0)
+  checkmate::assert_number(p_zero_catch, lower = 0.0, upper = 1.0 - 1e-9)
   checkmate::assert_int(n_counts_per_day, lower = 1L)
-  if (!is.null(seed)) checkmate::assert_int(seed)
+  if (!is.null(seed)) {
+    checkmate::assert_int(seed)
+  }
 
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) {
+    set.seed(seed)
+  }
 
   sp_wt <- if (is.null(species_weights)) {
     rep(1.0 / length(species), length(species))
@@ -187,25 +191,24 @@ simulate_creel_data <- function(
   }
 
   # ── Season calendar: sample n_sampled_days from season_days ─────────────────
-  all_dates  <- seq.Date(as.Date(start_date), by = "day", length.out = season_days)
-  samp_idx   <- sort(sample.int(season_days, n_sampled_days, replace = FALSE))
+  all_dates <- seq.Date(as.Date(start_date), by = "day", length.out = season_days)
+  samp_idx <- sort(sample.int(season_days, n_sampled_days, replace = FALSE))
   samp_dates <- all_dates[samp_idx]
 
-  dt_names   <- names(day_types)
-  n_dt       <- length(day_types)
-  day_type_vec <- dt_names[sample.int(n_dt, n_sampled_days, replace = TRUE,
-                                      prob = day_types)]
+  dt_names <- names(day_types)
+  n_dt <- length(day_types)
+  day_type_vec <- dt_names[sample.int(n_dt, n_sampled_days, replace = TRUE, prob = day_types)]
 
   # Full-season day_type assignment (all days, not just sampled)
   all_day_types <- dt_names[sample.int(n_dt, season_days, replace = TRUE, prob = day_types)]
   all_day_types[samp_idx] <- day_type_vec
 
   # ── Effort + trip params ─────────────────────────────────────────────────────
-  eff_p   <- params$effort
+  eff_p <- params$effort
   party_p <- params$party
   catch_p <- params$catch_per_trip
-  harv_p  <- params$harvest
-  cnt_p   <- params$counts
+  harv_p <- params$harvest
+  cnt_p <- params$counts
 
   mu_anglers <- if (!is.null(n_anglers_per_day)) {
     checkmate::assert_number(n_anglers_per_day, lower = 0.1)
@@ -213,25 +216,25 @@ simulate_creel_data <- function(
   } else {
     cnt_p$mean_total_anglers
   }
-  if (is.na(mu_anglers) || mu_anglers <= 0) mu_anglers <- 10.0
+  if (is.na(mu_anglers) || mu_anglers <= 0) {
+    mu_anglers <- 10.0
+  }
 
   # ── Simulate ─────────────────────────────────────────────────────────────────
   interview_rows <- vector("list", n_sampled_days)
-  count_rows     <- vector("list", n_sampled_days)
-  int_id         <- 0L
+  count_rows <- vector("list", n_sampled_days)
+  int_id <- 0L
 
   for (d in seq_len(n_sampled_days)) {
-    d_date    <- samp_dates[d]
-    d_dtype   <- day_type_vec[d]
+    d_date <- samp_dates[d]
+    d_dtype <- day_type_vec[d]
 
     # Number of parties arriving this day — NB around mu_anglers
     n_trips_d <- max(0L, rnbinom(1, mu = mu_anglers, size = 1.5))
 
     if (n_trips_d > 0L) {
       # Trip-level draws
-      eff_total <- rgamma(n_trips_d,
-                          shape = eff_p$gamma_shape,
-                          rate  = eff_p$gamma_rate)
+      eff_total <- rgamma(n_trips_d, shape = eff_p$gamma_shape, rate = eff_p$gamma_rate)
       eff_total <- pmax(eff_total, 0.05)
 
       n_ang <- pmax(1L, rpois(n_trips_d, lambda = party_p$mean))
@@ -240,9 +243,8 @@ simulate_creel_data <- function(
 
       # Length-biased encounter probability ∝ trip length (roving clerk)
       enc_prob <- eff_total / sum(eff_total)
-      n_enc    <- min(n_trips_d, max(1L, round(n_trips_d * 0.70)))
-      enc_idx  <- sample.int(n_trips_d, size = n_enc, replace = FALSE,
-                             prob = enc_prob)
+      n_enc <- min(n_trips_d, max(1L, round(n_trips_d * 0.70)))
+      enc_idx <- sample.int(n_trips_d, size = n_enc, replace = FALSE, prob = enc_prob)
 
       for (ti in enc_idx) {
         int_id <- int_id + 1L
@@ -258,37 +260,37 @@ simulate_creel_data <- function(
         is_zero <- rbinom(1L, 1L, p_zero_catch) == 1L
         if (is_zero) {
           ctotal <- 0L
-          ckept  <- 0L
+          ckept <- 0L
         } else {
-          nb_sz  <- if (!is.na(catch_p$nb_size) && catch_p$nb_size > 0) catch_p$nb_size else 0.5
+          nb_sz <- if (!is.na(catch_p$nb_size) && catch_p$nb_size > 0) catch_p$nb_size else 0.5
           ctotal <- rnbinom(1L, mu = catch_p$mean, size = nb_sz)
-          p_h    <- if (!is.na(harv_p$mean_pct)) harv_p$mean_pct / 100 else 0.35
-          p_h    <- pmin(pmax(p_h, 0.0), 1.0)
-          ckept  <- rbinom(1L, ctotal, p_h)
+          p_h <- if (!is.na(harv_p$mean_pct)) harv_p$mean_pct / 100 else 0.35
+          p_h <- pmin(pmax(p_h, 0.0), 1.0)
+          ckept <- rbinom(1L, ctotal, p_h)
         }
 
         interview_rows[[d]][[ti]] <- list(
-          date         = d_date,
-          day_type     = d_dtype,
+          date = d_date,
+          day_type = d_dtype,
           interview_id = int_id,
-          trip_status  = if (is_complete[ti]) "complete" else "incomplete",
+          trip_status = if (is_complete[ti]) "complete" else "incomplete",
           hours_fished = round(eff_obs, 3),
           trip_duration = round(eff_total[ti], 3),
-          n_anglers    = n_ang[ti],
-          catch_total  = ctotal,
-          catch_kept   = ckept,
+          n_anglers = n_ang[ti],
+          catch_total = ctotal,
+          catch_kept = ckept,
           species_sought = species[which.max(stats::rmultinom(1L, 1L, sp_wt))]
         )
       }
     }
 
     # Instantaneous counts for this day
-    mu_cnt   <- max(0.1, mu_anglers * 0.6)  # count ~ 60% of daily arrivals
-    tot_cnt  <- rnbinom(n_counts_per_day, mu = mu_cnt, size = 1.5)
+    mu_cnt <- max(0.1, mu_anglers * 0.6) # count ~ 60% of daily arrivals
+    tot_cnt <- rnbinom(n_counts_per_day, mu = mu_cnt, size = 1.5)
     count_rows[[d]] <- data.frame(
-      date          = rep(d_date, n_counts_per_day),
-      day_type      = rep(d_dtype, n_counts_per_day),
-      count_time    = seq_len(n_counts_per_day),
+      date = rep(d_date, n_counts_per_day),
+      day_type = rep(d_dtype, n_counts_per_day),
+      count_time = seq_len(n_counts_per_day),
       total_anglers = as.integer(tot_cnt)
     )
   }
@@ -297,11 +299,16 @@ simulate_creel_data <- function(
   int_flat <- do.call(c, lapply(interview_rows, function(dl) Filter(Negate(is.null), dl)))
   if (length(int_flat) == 0L) {
     interviews <- data.frame(
-      date = as.Date(character(0)), day_type = character(0),
-      interview_id = integer(0), trip_status = character(0),
-      hours_fished = numeric(0), trip_duration = numeric(0),
-      n_anglers = integer(0), catch_total = integer(0),
-      catch_kept = integer(0), species_sought = character(0)
+      date = as.Date(character(0)),
+      day_type = character(0),
+      interview_id = integer(0),
+      trip_status = character(0),
+      hours_fished = numeric(0),
+      trip_duration = numeric(0),
+      n_anglers = integer(0),
+      catch_total = integer(0),
+      catch_kept = integer(0),
+      species_sought = character(0)
     )
   } else {
     interviews <- do.call(rbind, lapply(int_flat, as.data.frame, stringsAsFactors = FALSE))
@@ -316,35 +323,41 @@ simulate_creel_data <- function(
   # ── Build catch (long format, multi-species) ─────────────────────────────────
   if (nrow(interviews) == 0L || length(species) == 0L) {
     catch <- data.frame(
-      interview_id = integer(0), species = character(0),
-      count = integer(0), catch_type = character(0)
+      interview_id = integer(0),
+      species = character(0),
+      count = integer(0),
+      catch_type = character(0)
     )
   } else {
     catch_rows <- vector("list", nrow(interviews))
     for (i in seq_len(nrow(interviews))) {
-      iid    <- interviews$interview_id[i]
+      iid <- interviews$interview_id[i]
       ctotal <- interviews$catch_total[i]
-      ckept  <- interviews$catch_kept[i]
+      ckept <- interviews$catch_kept[i]
 
-      if (ctotal == 0L) next
+      if (ctotal == 0L) {
+        next
+      }
 
       # Distribute total catch across species, then draw kept within each
       # species using rbinom so sp_kept[s] <= sp_counts[s] always
       sp_counts <- as.integer(stats::rmultinom(1L, ctotal, sp_wt))
-      p_keep    <- if (ctotal > 0L) ckept / ctotal else 0
-      sp_kept   <- as.integer(stats::rbinom(length(species), sp_counts, p_keep))
+      p_keep <- if (ctotal > 0L) ckept / ctotal else 0
+      sp_kept <- as.integer(stats::rbinom(length(species), sp_counts, p_keep))
 
       sp_rows <- vector("list", length(species))
       for (s in seq_along(species)) {
         c_s <- sp_counts[s]
         k_s <- sp_kept[s]
         r_s <- c_s - k_s
-        if (c_s == 0L) next
+        if (c_s == 0L) {
+          next
+        }
         sp_rows[[s]] <- data.frame(
           interview_id = rep(iid, 3L),
-          species      = rep(species[s], 3L),
-          count        = c(c_s, k_s, r_s),
-          catch_type   = c("caught", "harvested", "released"),
+          species = rep(species[s], 3L),
+          count = c(c_s, k_s, r_s),
+          catch_type = c("caught", "harvested", "released"),
           stringsAsFactors = FALSE
         )
       }
@@ -353,8 +366,10 @@ simulate_creel_data <- function(
     catch <- do.call(rbind, Filter(Negate(is.null), catch_rows))
     if (is.null(catch)) {
       catch <- data.frame(
-        interview_id = integer(0), species = character(0),
-        count = integer(0), catch_type = character(0)
+        interview_id = integer(0),
+        species = character(0),
+        count = integer(0),
+        catch_type = character(0)
       )
     }
     rownames(catch) <- NULL
@@ -362,9 +377,9 @@ simulate_creel_data <- function(
 
   # ── Build full-season schedule (calendar for creel_design) ──────────────────
   schedule <- data.frame(
-    date     = all_dates,
+    date = all_dates,
     day_type = all_day_types,
-    sampled  = seq_len(season_days) %in% samp_idx,
+    sampled = seq_len(season_days) %in% samp_idx,
     stringsAsFactors = FALSE
   )
 
@@ -443,44 +458,50 @@ simulate_creel_data <- function(
 #' @export
 simulate_creel_catch <- function(
   n,
-  effort        = 1.0,
-  family        = c("negbin", "delta", "poisson"),
-  mu            = 5.0,
-  size          = 0.5,
-  p_zero        = 0.40,
-  sigma         = 1.0,
+  effort = 1.0,
+  family = c("negbin", "delta", "poisson"),
+  mu = 5.0,
+  size = 0.5,
+  p_zero = 0.40,
+  sigma = 1.0,
   var_structure = c("constant", "proportional", "squared"),
-  seed          = NULL
+  seed = NULL
 ) {
-  family        <- match.arg(family)
+  family <- match.arg(family)
   var_structure <- match.arg(var_structure)
 
-  checkmate::assert_int(n,      lower = 1L)
+  checkmate::assert_int(n, lower = 1L)
   checkmate::assert_numeric(effort, lower = 0, any.missing = FALSE)
-  checkmate::assert_number(mu,    lower = 1e-9)
-  checkmate::assert_number(size,  lower = 1e-9)
+  checkmate::assert_number(mu, lower = 1e-9)
+  checkmate::assert_number(size, lower = 1e-9)
   checkmate::assert_number(p_zero, lower = 0.0, upper = 1.0 - 1e-9)
-  checkmate::assert_number(sigma,  lower = 1e-9)
-  if (!is.null(seed)) checkmate::assert_int(seed)
+  checkmate::assert_number(sigma, lower = 1e-9)
+  if (!is.null(seed)) {
+    checkmate::assert_int(seed)
+  }
 
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) {
+    set.seed(seed)
+  }
 
   # Recycle effort to length n
   effort <- rep_len(effort, n)
 
   # Scale mu by effort based on variance structure
-  mu_i <- switch(var_structure,
-    "constant"     = rep(mu, n),
+  mu_i <- switch(
+    var_structure,
+    "constant" = rep(mu, n),
     "proportional" = mu * effort,
-    "squared"      = mu * effort^2
+    "squared" = mu * effort^2
   )
 
-  switch(family,
+  switch(
+    family,
     "negbin" = {
       as.integer(rnbinom(n, mu = pmax(mu_i, 1e-9), size = size))
     },
     "delta" = {
-      is_zero  <- rbinom(n, 1L, p_zero) == 1L
+      is_zero <- rbinom(n, 1L, p_zero) == 1L
       log_mean <- log(pmax(mu_i, 1e-9)) - sigma^2 / 2
       pos_vals <- as.integer(round(rlnorm(n, meanlog = log_mean, sdlog = sigma)))
       pos_vals[pos_vals < 0L] <- 0L

--- a/R/standardize-species.R
+++ b/R/standardize-species.R
@@ -5,26 +5,90 @@
 # Covers freshwater sport fish common in creel surveys.
 .afs_lookup <- data.frame(
   afs_code = c(
-    "WAE", "SMB", "LMB", "NOP", "MUE", "YEP",
-    "BLG", "RBT", "BNT", "LKT", "CHS", "CHN",
-    "COH", "SOC", "ATL", "PAC", "WPR", "SAU",
-    "FHC", "CCF", "BUF", "CRP", "GPS", "WCR",
-    "SPB", "STB", "WHB", "STR", "HYB", "BAS",
-    "CRK", "BKT", "LAT", "GRY", "MWF", "ELP",
-    "GLF", "BPS", "RSF", "CAS", "FRD"
+    "WAE",
+    "SMB",
+    "LMB",
+    "NOP",
+    "MUE",
+    "YEP",
+    "BLG",
+    "RBT",
+    "BNT",
+    "LKT",
+    "CHS",
+    "CHN",
+    "COH",
+    "SOC",
+    "ATL",
+    "PAC",
+    "WPR",
+    "SAU",
+    "FHC",
+    "CCF",
+    "BUF",
+    "CRP",
+    "GPS",
+    "WCR",
+    "SPB",
+    "STB",
+    "WHB",
+    "STR",
+    "HYB",
+    "BAS",
+    "CRK",
+    "BKT",
+    "LAT",
+    "GRY",
+    "MWF",
+    "ELP",
+    "GLF",
+    "BPS",
+    "RSF",
+    "CAS",
+    "FRD"
   ),
   common_name = c(
-    "walleye", "smallmouth bass", "largemouth bass", "northern pike",
-    "muskellunge", "yellow perch", "bluegill", "rainbow trout",
-    "brown trout", "lake trout", "chinook salmon", "chinook salmon",
-    "coho salmon", "sockeye salmon", "atlantic salmon", "pacific salmon",
-    "white perch", "sauger", "flathead catfish", "channel catfish",
-    "buffalo", "common carp", "gizzard shad", "white crappie",
-    "spotted bass", "striped bass", "white bass", "shovelnose sturgeon",
-    "hybrid striped bass", "bass", "creek chub", "brook trout",
-    "lake whitefish", "arctic grayling", "mountain whitefish",
-    "emerald shiner", "golden shiner", "black crappie", "redear sunfish",
-    "caspian tern", "freshwater drum"
+    "walleye",
+    "smallmouth bass",
+    "largemouth bass",
+    "northern pike",
+    "muskellunge",
+    "yellow perch",
+    "bluegill",
+    "rainbow trout",
+    "brown trout",
+    "lake trout",
+    "chinook salmon",
+    "chinook salmon",
+    "coho salmon",
+    "sockeye salmon",
+    "atlantic salmon",
+    "pacific salmon",
+    "white perch",
+    "sauger",
+    "flathead catfish",
+    "channel catfish",
+    "buffalo",
+    "common carp",
+    "gizzard shad",
+    "white crappie",
+    "spotted bass",
+    "striped bass",
+    "white bass",
+    "shovelnose sturgeon",
+    "hybrid striped bass",
+    "bass",
+    "creek chub",
+    "brook trout",
+    "lake whitefish",
+    "arctic grayling",
+    "mountain whitefish",
+    "emerald shiner",
+    "golden shiner",
+    "black crappie",
+    "redear sunfish",
+    "caspian tern",
+    "freshwater drum"
   ),
   aliases = c(
     "saugeye;pike-perch;yellow pike",
@@ -224,10 +288,7 @@ standardize_species <- function(
   # Exact common-name match (case-insensitive).
   lkp_lower <- tolower(lkp$common_name)
   name_idx <- match(lower, lkp_lower)
-  codes <- ifelse(is.na(codes) & !is.na(name_idx),
-    lkp$afs_code[name_idx],
-    codes
-  )
+  codes <- ifelse(is.na(codes) & !is.na(name_idx), lkp$afs_code[name_idx], codes)
 
   # Alias match (case-insensitive, semicolon-separated within each row).
   if (fuzzy) {
@@ -240,7 +301,9 @@ standardize_species <- function(
 # Apply project-defined custom_codes to rows still NA after AFS pass.
 .apply_custom_codes <- function(codes, raw, custom_codes) {
   still_na <- which(is.na(codes))
-  if (length(still_na) == 0L) return(codes)
+  if (length(still_na) == 0L) {
+    return(codes)
+  }
 
   lower_raw <- tolower(trimws(raw[still_na]))
   lower_names <- tolower(trimws(names(custom_codes)))
@@ -249,7 +312,7 @@ standardize_species <- function(
     hit <- lower_raw == lower_names[i]
     if (any(hit)) {
       codes[still_na[hit]] <- custom_codes[[i]]
-      still_na  <- still_na[!hit]
+      still_na <- still_na[!hit]
       lower_raw <- lower_raw[!hit]
     }
     if (length(still_na) == 0L) break

--- a/R/standardize-species.R
+++ b/R/standardize-species.R
@@ -165,8 +165,7 @@ standardize_species <- function(
     toupper(lookup) != "AFS"
   if (bad_lookup) {
     cli::cli_abort(
-      "{.arg lookup} must be {.val AFS}; no other code systems are ",
-      "currently supported."
+      "{.arg lookup} must be {.val AFS}; no other code systems are currently supported."
     )
   }
   if (!is.null(custom_codes)) {

--- a/R/strata-audit.R
+++ b/R/strata-audit.R
@@ -24,7 +24,8 @@ audit_strata <- function(x, ...) UseMethod("audit_strata")
 #' @param rse_target Numeric scalar. Target relative standard error threshold.
 #'   Default 0.20 (20 percent). Must be in (0, 1].
 #' @export
-audit_strata.creel_design <- function(x, rse_target = 0.20, ...) {  # nolint: object_name_linter
+audit_strata.creel_design <- function(x, rse_target = 0.20, ...) {
+  # nolint: object_name_linter
   design <- x
   checkmate::assert_number(rse_target, lower = 1e-6, upper = 1.0)
 
@@ -37,7 +38,7 @@ audit_strata.creel_design <- function(x, rse_target = 0.20, ...) {  # nolint: ob
   }
 
   strata_cols <- design$strata_cols
-  cal         <- design$calendar
+  cal <- design$calendar
 
   if (length(strata_cols) == 1) {
     cal$.strata_key <- as.character(cal[[strata_cols]])
@@ -46,10 +47,10 @@ audit_strata.creel_design <- function(x, rse_target = 0.20, ...) {  # nolint: ob
   }
   available_by_strata <- table(cal$.strata_key)
 
-  counts_data   <- design$counts
+  counts_data <- design$counts
   excluded_cols <- c(design$date_col, design$strata_cols, design$psu_col)
-  numeric_cols  <- names(counts_data)[vapply(counts_data, is.numeric, logical(1L))]
-  count_vars    <- setdiff(numeric_cols, excluded_cols)
+  numeric_cols <- names(counts_data)[vapply(counts_data, is.numeric, logical(1L))]
+  count_vars <- setdiff(numeric_cols, excluded_cols)
 
   if (length(count_vars) == 0) {
     cli::cli_abort(c(
@@ -69,33 +70,33 @@ audit_strata.creel_design <- function(x, rse_target = 0.20, ...) {  # nolint: ob
 
   strata_keys <- unique(counts_data$.strata_key)
 
-  n_h_vals    <- integer(length(strata_keys))
-  N_h_vals    <- integer(length(strata_keys))
+  n_h_vals <- integer(length(strata_keys))
+  N_h_vals <- integer(length(strata_keys))
   ybar_h_vals <- numeric(length(strata_keys))
-  s2_h_vals   <- numeric(length(strata_keys))
+  s2_h_vals <- numeric(length(strata_keys))
 
   for (i in seq_along(strata_keys)) {
-    sk           <- strata_keys[i]
-    rows         <- counts_data$.strata_key == sk
-    n_h_i        <- sum(rows)
-    n_h_vals[i]    <- n_h_i  # nolint: object_name_linter
-    N_h_vals[i]    <- as.integer(available_by_strata[sk])  # nolint: object_name_linter
-    ybar_h_vals[i] <- mean(counts_data[[count_var]][rows])  # nolint: object_name_linter
-    s2_h_vals[i]   <- if (n_h_i >= 2L) var(counts_data[[count_var]][rows]) else NA_real_  # nolint: object_name_linter
+    sk <- strata_keys[i]
+    rows <- counts_data$.strata_key == sk
+    n_h_i <- sum(rows)
+    n_h_vals[i] <- n_h_i # nolint: object_name_linter
+    N_h_vals[i] <- as.integer(available_by_strata[sk]) # nolint: object_name_linter
+    ybar_h_vals[i] <- mean(counts_data[[count_var]][rows]) # nolint: object_name_linter
+    s2_h_vals[i] <- if (n_h_i >= 2L) var(counts_data[[count_var]][rows]) else NA_real_ # nolint: object_name_linter
   }
 
-  names(n_h_vals)    <- strata_keys  # nolint: object_name_linter
-  names(N_h_vals)    <- strata_keys  # nolint: object_name_linter
-  names(ybar_h_vals) <- strata_keys  # nolint: object_name_linter
-  names(s2_h_vals)   <- strata_keys  # nolint: object_name_linter
+  names(n_h_vals) <- strata_keys # nolint: object_name_linter
+  names(N_h_vals) <- strata_keys # nolint: object_name_linter
+  names(ybar_h_vals) <- strata_keys # nolint: object_name_linter
+  names(s2_h_vals) <- strata_keys # nolint: object_name_linter
 
   .build_strata_audit(
-    N_h        = N_h_vals,  # nolint: object_name_linter
-    n_h        = n_h_vals,  # nolint: object_name_linter
-    ybar_h     = ybar_h_vals,  # nolint: object_name_linter
-    s2_h       = s2_h_vals,  # nolint: object_name_linter
+    N_h = N_h_vals, # nolint: object_name_linter
+    n_h = n_h_vals, # nolint: object_name_linter
+    ybar_h = ybar_h_vals, # nolint: object_name_linter
+    s2_h = s2_h_vals, # nolint: object_name_linter
     rse_target = rse_target,
-    stratum    = strata_keys
+    stratum = strata_keys
   )
 }
 
@@ -157,27 +158,29 @@ audit_strata.creel_design <- function(x, rse_target = 0.20, ...) {  # nolint: ob
 #' )
 #' audit$strata
 #' audit$deff
-audit_strata.default <- function(x, n_h, ybar_h, s2_h, rse_target = 0.20, ...) {  # nolint: object_name_linter
-  N_h <- x  # nolint: object_name_linter
-  checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named")  # nolint: object_name_linter
-  checkmate::assert_numeric(n_h, lower = 1, len = length(N_h), names = "named")  # nolint: object_name_linter
-  checkmate::assert_numeric(ybar_h, lower = 0, len = length(N_h))  # nolint: object_name_linter
-  checkmate::assert_numeric(s2_h, lower = 0, len = length(N_h))  # nolint: object_name_linter
+audit_strata.default <- function(x, n_h, ybar_h, s2_h, rse_target = 0.20, ...) {
+  # nolint: object_name_linter
+  N_h <- x # nolint: object_name_linter
+  checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named") # nolint: object_name_linter
+  checkmate::assert_numeric(n_h, lower = 1, len = length(N_h), names = "named") # nolint: object_name_linter
+  checkmate::assert_numeric(ybar_h, lower = 0, len = length(N_h)) # nolint: object_name_linter
+  checkmate::assert_numeric(s2_h, lower = 0, len = length(N_h)) # nolint: object_name_linter
   checkmate::assert_number(rse_target, lower = 1e-6, upper = 1.0)
 
   .build_strata_audit(
-    N_h        = N_h,  # nolint: object_name_linter
-    n_h        = n_h,  # nolint: object_name_linter
-    ybar_h     = ybar_h,  # nolint: object_name_linter
-    s2_h       = s2_h,  # nolint: object_name_linter
+    N_h = N_h, # nolint: object_name_linter
+    n_h = n_h, # nolint: object_name_linter
+    ybar_h = ybar_h, # nolint: object_name_linter
+    s2_h = s2_h, # nolint: object_name_linter
     rse_target = rse_target,
-    stratum    = names(N_h)  # nolint: object_name_linter
+    stratum = names(N_h) # nolint: object_name_linter
   )
 }
 
 # Internal: shared computation for both audit_strata methods.
-.build_strata_audit <- function(N_h, n_h, ybar_h, s2_h, rse_target, stratum) {  # nolint: object_name_linter
-  single_day <- names(n_h)[n_h == 1L]  # nolint: object_name_linter
+.build_strata_audit <- function(N_h, n_h, ybar_h, s2_h, rse_target, stratum) {
+  # nolint: object_name_linter
+  single_day <- names(n_h)[n_h == 1L] # nolint: object_name_linter
   if (length(single_day) > 0) {
     cli::cli_warn(c(
       "Single-day strata cannot estimate variance.",
@@ -186,38 +189,39 @@ audit_strata.default <- function(x, n_h, ybar_h, s2_h, rse_target = 0.20, ...) {
     ))
   }
 
-  N  <- sum(N_h)  # nolint: object_name_linter
-  n  <- sum(n_h)  # nolint: object_name_linter
+  N <- sum(N_h) # nolint: object_name_linter
+  n <- sum(n_h) # nolint: object_name_linter
 
-  se_h  <- sqrt((1 - n_h / N_h) * s2_h / n_h)  # nolint: object_name_linter
-  rse_h <- se_h / ybar_h  # nolint: object_name_linter
+  se_h <- sqrt((1 - n_h / N_h) * s2_h / n_h) # nolint: object_name_linter
+  rse_h <- se_h / ybar_h # nolint: object_name_linter
 
-  s2_overall <- sum(N_h * s2_h, na.rm = TRUE) / N  # nolint: object_name_linter
-  Var_SRS    <- (1 - n / N) * s2_overall / n  # nolint: object_name_linter
-  Var_strat  <- sum((N_h / N)^2 * (1 - n_h / N_h) * s2_h / n_h, na.rm = TRUE)  # nolint: object_name_linter
-  deff_overall <- if (!is.na(Var_SRS) && Var_SRS > .Machine$double.eps) {  # nolint: object_name_linter
-    Var_strat / Var_SRS  # nolint: object_name_linter
+  s2_overall <- sum(N_h * s2_h, na.rm = TRUE) / N # nolint: object_name_linter
+  Var_SRS <- (1 - n / N) * s2_overall / n # nolint: object_name_linter
+  Var_strat <- sum((N_h / N)^2 * (1 - n_h / N_h) * s2_h / n_h, na.rm = TRUE) # nolint: object_name_linter
+  deff_overall <- if (!is.na(Var_SRS) && Var_SRS > .Machine$double.eps) {
+    # nolint: object_name_linter
+    Var_strat / Var_SRS # nolint: object_name_linter
   } else {
     NA_real_
   }
 
-  deff_h <- ((1 - n_h / N_h) * s2_h / n_h) / ((1 - n / N) * s2_overall / n)  # nolint: object_name_linter
+  deff_h <- ((1 - n_h / N_h) * s2_h / n_h) / ((1 - n / N) * s2_overall / n) # nolint: object_name_linter
 
   structure(
     list(
       strata = tibble::tibble(
-        stratum      = stratum,
-        N_h          = as.integer(N_h),  # nolint: object_name_linter
-        n_h          = as.integer(n_h),  # nolint: object_name_linter
-        ybar_h       = ybar_h,  # nolint: object_name_linter
-        s2_h         = s2_h,  # nolint: object_name_linter
-        RSE          = rse_h,  # nolint: object_name_linter
-        DEFF         = deff_h,  # nolint: object_name_linter
+        stratum = stratum,
+        N_h = as.integer(N_h), # nolint: object_name_linter
+        n_h = as.integer(n_h), # nolint: object_name_linter
+        ybar_h = ybar_h, # nolint: object_name_linter
+        s2_h = s2_h, # nolint: object_name_linter
+        RSE = rse_h, # nolint: object_name_linter
+        DEFF = deff_h, # nolint: object_name_linter
         meets_target = rse_h <= rse_target
       ),
       rse_target = rse_target,
-      n_total    = as.integer(n),
-      deff       = deff_overall
+      n_total = as.integer(n),
+      deff = deff_overall
     ),
     class = "creel_strata_audit"
   )
@@ -279,17 +283,19 @@ simulate_strata_collapse <- function(audit, merge_strata) {
     ))
   }
 
-  strata_tbl    <- audit$strata
-  rse_target    <- audit$rse_target
-  N_total       <- sum(strata_tbl$N_h)  # nolint: object_name_linter
-  n_total       <- sum(strata_tbl$n_h)
-  s2_overall    <- sum(strata_tbl$N_h * strata_tbl$s2_h, na.rm = TRUE) / N_total  # nolint: object_name_linter
-  Var_SRS_denom <- (1 - n_total / N_total) * s2_overall / n_total  # nolint: object_name_linter
+  strata_tbl <- audit$strata
+  rse_target <- audit$rse_target
+  N_total <- sum(strata_tbl$N_h) # nolint: object_name_linter
+  n_total <- sum(strata_tbl$n_h)
+  s2_overall <- sum(strata_tbl$N_h * strata_tbl$s2_h, na.rm = TRUE) / N_total # nolint: object_name_linter
+  Var_SRS_denom <- (1 - n_total / N_total) * s2_overall / n_total # nolint: object_name_linter
 
-  .rse_deff <- function(N_h_i, n_h_i, ybar_h_i, s2_h_i) {  # nolint: object_name_linter
-    rse_i  <- sqrt((1 - n_h_i / N_h_i) * s2_h_i / n_h_i) / ybar_h_i  # nolint: object_name_linter
-    deff_i <- if (!is.na(Var_SRS_denom) && Var_SRS_denom > .Machine$double.eps) {  # nolint: object_name_linter
-      ((1 - n_h_i / N_h_i) * s2_h_i / n_h_i) / Var_SRS_denom  # nolint: object_name_linter
+  .rse_deff <- function(N_h_i, n_h_i, ybar_h_i, s2_h_i) {
+    # nolint: object_name_linter
+    rse_i <- sqrt((1 - n_h_i / N_h_i) * s2_h_i / n_h_i) / ybar_h_i # nolint: object_name_linter
+    deff_i <- if (!is.na(Var_SRS_denom) && Var_SRS_denom > .Machine$double.eps) {
+      # nolint: object_name_linter
+      ((1 - n_h_i / N_h_i) * s2_h_i / n_h_i) / Var_SRS_denom # nolint: object_name_linter
     } else {
       NA_real_
     }
@@ -297,49 +303,49 @@ simulate_strata_collapse <- function(audit, merge_strata) {
   }
 
   before_rows <- lapply(seq_len(nrow(strata_tbl)), function(i) {
-    s  <- strata_tbl[i, ]
-    rd <- .rse_deff(s$N_h, s$n_h, s$ybar_h, s$s2_h)  # nolint: object_name_linter
+    s <- strata_tbl[i, ]
+    rd <- .rse_deff(s$N_h, s$n_h, s$ybar_h, s$s2_h) # nolint: object_name_linter
     tibble::tibble(
-      state        = "before",
-      stratum      = s$stratum,
-      N_h          = s$N_h,  # nolint: object_name_linter
-      n_h          = s$n_h,  # nolint: object_name_linter
-      RSE          = rd$RSE,
-      DEFF         = rd$DEFF,
+      state = "before",
+      stratum = s$stratum,
+      N_h = s$N_h, # nolint: object_name_linter
+      n_h = s$n_h, # nolint: object_name_linter
+      RSE = rd$RSE,
+      DEFF = rd$DEFF,
       meets_target = rd$meets_target
     )
   })
 
-  merge_rows   <- strata_tbl[strata_tbl$stratum %in% merge_strata, ]
-  keep_rows    <- strata_tbl[!strata_tbl$stratum %in% merge_strata, ]
+  merge_rows <- strata_tbl[strata_tbl$stratum %in% merge_strata, ]
+  keep_rows <- strata_tbl[!strata_tbl$stratum %in% merge_strata, ]
 
-  N_merged     <- sum(merge_rows$N_h)  # nolint: object_name_linter
-  n_merged     <- sum(merge_rows$n_h)
-  ybar_merged  <- sum(merge_rows$N_h * merge_rows$ybar_h) / N_merged  # nolint: object_name_linter
-  s2_merged    <- sum(merge_rows$n_h * merge_rows$s2_h, na.rm = TRUE) / n_merged  # nolint: object_name_linter
+  N_merged <- sum(merge_rows$N_h) # nolint: object_name_linter
+  n_merged <- sum(merge_rows$n_h)
+  ybar_merged <- sum(merge_rows$N_h * merge_rows$ybar_h) / N_merged # nolint: object_name_linter
+  s2_merged <- sum(merge_rows$n_h * merge_rows$s2_h, na.rm = TRUE) / n_merged # nolint: object_name_linter
   merged_label <- paste(merge_strata, collapse = "+")
-  rd_merged    <- .rse_deff(N_merged, n_merged, ybar_merged, s2_merged)  # nolint: object_name_linter
+  rd_merged <- .rse_deff(N_merged, n_merged, ybar_merged, s2_merged) # nolint: object_name_linter
 
   merged_row <- tibble::tibble(
-    state        = "after",
-    stratum      = merged_label,
-    N_h          = as.integer(N_merged),  # nolint: object_name_linter
-    n_h          = as.integer(n_merged),
-    RSE          = rd_merged$RSE,
-    DEFF         = rd_merged$DEFF,
+    state = "after",
+    stratum = merged_label,
+    N_h = as.integer(N_merged), # nolint: object_name_linter
+    n_h = as.integer(n_merged),
+    RSE = rd_merged$RSE,
+    DEFF = rd_merged$DEFF,
     meets_target = rd_merged$meets_target
   )
 
   after_keep <- lapply(seq_len(nrow(keep_rows)), function(i) {
-    s  <- keep_rows[i, ]
-    rd <- .rse_deff(s$N_h, s$n_h, s$ybar_h, s$s2_h)  # nolint: object_name_linter
+    s <- keep_rows[i, ]
+    rd <- .rse_deff(s$N_h, s$n_h, s$ybar_h, s$s2_h) # nolint: object_name_linter
     tibble::tibble(
-      state        = "after",
-      stratum      = s$stratum,
-      N_h          = s$N_h,  # nolint: object_name_linter
-      n_h          = s$n_h,  # nolint: object_name_linter
-      RSE          = rd$RSE,
-      DEFF         = rd$DEFF,
+      state = "after",
+      stratum = s$stratum,
+      N_h = s$N_h, # nolint: object_name_linter
+      n_h = s$n_h, # nolint: object_name_linter
+      RSE = rd$RSE,
+      DEFF = rd$DEFF,
       meets_target = rd$meets_target
     )
   })
@@ -381,14 +387,15 @@ simulate_strata_collapse <- function(audit, merge_strata) {
 #'   N_h     = c(weekday = 65, weekend = 28),
 #'   s2_h    = c(400, 500)
 #' )
-reallocate_strata <- function(n_total, N_h, s2_h) {  # nolint: object_name_linter
+reallocate_strata <- function(n_total, N_h, s2_h) {
+  # nolint: object_name_linter
   checkmate::assert_integerish(n_total, lower = 1, len = 1)
-  checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named")  # nolint: object_name_linter
-  checkmate::assert_numeric(s2_h, lower = 0, len = length(N_h))  # nolint: object_name_linter
+  checkmate::assert_numeric(N_h, lower = 1, min.len = 1, names = "named") # nolint: object_name_linter
+  checkmate::assert_numeric(s2_h, lower = 0, len = length(N_h)) # nolint: object_name_linter
 
-  alloc_weights  <- N_h * sqrt(s2_h)  # nolint: object_name_linter
-  n_h_opt        <- ceiling(n_total * alloc_weights / sum(alloc_weights))  # nolint: object_name_linter
-  names(n_h_opt) <- names(N_h)  # nolint: object_name_linter
+  alloc_weights <- N_h * sqrt(s2_h) # nolint: object_name_linter
+  n_h_opt <- ceiling(n_total * alloc_weights / sum(alloc_weights)) # nolint: object_name_linter
+  names(n_h_opt) <- names(N_h) # nolint: object_name_linter
   storage.mode(n_h_opt) <- "integer"
-  n_h_opt  # nolint: object_name_linter
+  n_h_opt # nolint: object_name_linter
 }

--- a/R/survey-bridge.R
+++ b/R/survey-bridge.R
@@ -119,7 +119,8 @@ get_variance_design <- function(design, variance_method) {
             msg,
             regexpr("(?<=Stratum)(.+?)(?=has only one PSU)", msg, perl = TRUE)
           )
-          strat_label <- if (length(strat) > 0L && nzchar(strat)) { # nolint: object_usage_linter
+          strat_label <- if (length(strat) > 0L && nzchar(strat)) {
+            # nolint: object_usage_linter
             strat
           } else {
             "unknown"
@@ -230,7 +231,8 @@ validate_counts_tier1 <- function(counts, design, psu, allow_invalid = FALSE) {
     if (na_count_date > 0) {
       collection$push(sprintf(
         "Date column '%s' contains %d NA value(s)",
-        design$date_col, na_count_date
+        design$date_col,
+        na_count_date
       ))
     }
   }
@@ -242,7 +244,8 @@ validate_counts_tier1 <- function(counts, design, psu, allow_invalid = FALSE) {
       if (na_count_strata > 0) {
         collection$push(sprintf(
           "Strata column '%s' contains %d NA value(s)",
-          col, na_count_strata
+          col,
+          na_count_strata
         ))
       }
     }
@@ -254,7 +257,8 @@ validate_counts_tier1 <- function(counts, design, psu, allow_invalid = FALSE) {
     if (na_count_psu > 0) {
       collection$push(sprintf(
         "PSU column '%s' contains %d NA value(s)",
-        psu, na_count_psu
+        psu,
+        na_count_psu
       ))
     }
   }
@@ -292,7 +296,8 @@ validate_counts_tier1 <- function(counts, design, psu, allow_invalid = FALSE) {
   }
 
   # Return validation object
-  new_creel_validation( # nolint: object_usage_linter
+  new_creel_validation(
+    # nolint: object_usage_linter
     results = results,
     tier = 1L,
     context = "add_counts validation"
@@ -382,7 +387,7 @@ aggregate_within_day <- function(counts, psu_col, count_var, count_time_col, key
   }
 
   list(
-    aggregated     = do.call(rbind, agg_rows),
+    aggregated = do.call(rbind, agg_rows),
     within_day_var = do.call(rbind, var_rows)
   )
 }
@@ -577,7 +582,12 @@ warn_tier2_issues <- function(design) {
     for (i in seq_along(sparse_strata)) {
       stratum_name <- names(sparse_strata)[i]
       n_obs <- sparse_strata[i]
-      bullet_items[i] <- sprintf("Stratum %s: %d observation%s", stratum_name, n_obs, ifelse(n_obs == 1, "", "s"))
+      bullet_items[i] <- sprintf(
+        "Stratum %s: %d observation%s",
+        stratum_name,
+        n_obs,
+        ifelse(n_obs == 1, "", "s")
+      )
     }
     names(bullet_items) <- rep("*", length(sparse_strata))
 
@@ -959,8 +969,15 @@ mor_estimation_warning <- function(n_incomplete, n_total) {
 #'
 #' @keywords internal
 #' @noRd
-validate_interviews_tier1 <- function(interviews, design, catch_col, effort_col,
-                                      harvest_col, date_col, allow_invalid = FALSE) {
+validate_interviews_tier1 <- function(
+  interviews,
+  design,
+  catch_col,
+  effort_col,
+  harvest_col,
+  date_col,
+  allow_invalid = FALSE
+) {
   collection <- checkmate::makeAssertCollection()
 
   # Check 1: date_col exists in interviews
@@ -1021,7 +1038,8 @@ validate_interviews_tier1 <- function(interviews, design, catch_col, effort_col,
     if (na_count_date > 0) {
       collection$push(sprintf(
         "Date column '%s' contains %d NA value(s)",
-        date_col, na_count_date
+        date_col,
+        na_count_date
       ))
     }
   }
@@ -1091,7 +1109,8 @@ validate_interviews_tier1 <- function(interviews, design, catch_col, effort_col,
   }
 
   # Return validation object
-  new_creel_validation( # nolint: object_usage_linter
+  new_creel_validation(
+    # nolint: object_usage_linter
     results = results,
     tier = 1L,
     context = "add_interviews validation"
@@ -1114,8 +1133,13 @@ validate_interviews_tier1 <- function(interviews, design, catch_col, effort_col,
 #'
 #' @keywords internal
 #' @noRd
-validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_col,
-                                   trip_start_col, interview_time_col) {
+validate_trip_metadata <- function(
+  interviews,
+  trip_status_col,
+  trip_duration_col,
+  trip_start_col,
+  interview_time_col
+) {
   collection <- checkmate::makeAssertCollection()
 
   # Check 1: trip_status_col exists in interviews
@@ -1144,7 +1168,8 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
     if (na_count > 0) {
       collection$push(sprintf(
         "Trip status column '%s' contains %d NA value(s). Trip status is required for all interviews",
-        trip_status_col, na_count
+        trip_status_col,
+        na_count
       ))
     }
   }
@@ -1197,7 +1222,8 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
         if (na_count_duration > 0) {
           collection$push(sprintf(
             "Trip duration column '%s' contains %d NA value(s). Trip duration is required for all interviews",
-            trip_duration_col, na_count_duration
+            trip_duration_col,
+            na_count_duration
           ))
         }
 
@@ -1212,7 +1238,8 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
         # No values < 1/60 hours (1 minute)
         min_duration <- 1 / 60
         if (any(duration_vals < min_duration & duration_vals >= 0, na.rm = TRUE)) {
-          collection$push(sprintf( # nolint: line_length_linter
+          collection$push(sprintf(
+            # nolint: line_length_linter
             paste(
               "Trip duration column '%s' contains values less than 1 minute (1/60 hours).",
               "Trip durations less than 1 minute are unrealistic"
@@ -1224,7 +1251,8 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
         # Warn if any values > 48 hours
         if (any(duration_vals > 48, na.rm = TRUE)) {
           n_long <- sum(duration_vals > 48, na.rm = TRUE) # nolint: object_usage_linter
-          cli::cli_warn(c( # nolint: line_length_linter
+          cli::cli_warn(c(
+            # nolint: line_length_linter
             "!" = "Trip duration column '{trip_duration_col}' contains {n_long} value{?s} > 48 hours",
             "i" = "Multi-day trips are valid, but verify these are not data entry errors"
           ))
@@ -1258,7 +1286,8 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
       if (na_count_start > 0) {
         collection$push(sprintf(
           "Trip start column '%s' contains %d NA value(s)",
-          trip_start_col, na_count_start
+          trip_start_col,
+          na_count_start
         ))
       }
     }
@@ -1286,29 +1315,43 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
       if (na_count_interview > 0) {
         collection$push(sprintf(
           "Interview time column '%s' contains %d NA value(s)",
-          interview_time_col, na_count_interview
+          interview_time_col,
+          na_count_interview
         ))
       }
     }
 
     # If both columns exist and are time-like, check computed duration
-    if (trip_start_col %in% names(interviews) && # nolint: indentation_linter
-      interview_time_col %in% names(interviews)) { # nolint: indentation_linter
+    if (
+      trip_start_col %in%
+        names(interviews) && # nolint: indentation_linter
+        interview_time_col %in% names(interviews)
+    ) {
+      # nolint: indentation_linter
       start_vals <- interviews[[trip_start_col]]
       interview_vals <- interviews[[interview_time_col]]
 
-      if ((inherits(start_vals, "POSIXct") || inherits(start_vals, "POSIXlt")) && # nolint: indentation_linter
-        (inherits(interview_vals, "POSIXct") || inherits(interview_vals, "POSIXlt"))) { # nolint: indentation_linter
+      if (
+        (inherits(start_vals, "POSIXct") || inherits(start_vals, "POSIXlt")) && # nolint: indentation_linter
+          (inherits(interview_vals, "POSIXct") || inherits(interview_vals, "POSIXlt"))
+      ) {
+        # nolint: indentation_linter
         # Check timezone consistency
         tz_start <- attr(start_vals, "tzone")
         tz_interview <- attr(interview_vals, "tzone")
         # Only error if both explicitly set to different timezones
-        if (!is.null(tz_start) && !is.null(tz_interview) && # nolint: indentation_linter
-          nzchar(tz_start) && nzchar(tz_interview) && # nolint: indentation_linter
-          tz_start != tz_interview) {
-          collection$push(sprintf( # nolint: line_length_linter
+        if (
+          !is.null(tz_start) &&
+            !is.null(tz_interview) && # nolint: indentation_linter
+            nzchar(tz_start) &&
+            nzchar(tz_interview) && # nolint: indentation_linter
+            tz_start != tz_interview
+        ) {
+          collection$push(sprintf(
+            # nolint: line_length_linter
             "trip_start timezone '%s' differs from interview_time timezone '%s'. Use the same timezone for both columns", # nolint: line_length_linter
-            tz_start, tz_interview
+            tz_start,
+            tz_interview
           ))
         }
 
@@ -1341,7 +1384,8 @@ validate_trip_metadata <- function(interviews, trip_status_col, trip_duration_co
         # Warn if any > 48 hours
         if (any(computed_duration > 48, na.rm = TRUE)) {
           n_long <- sum(computed_duration > 48, na.rm = TRUE) # nolint: object_usage_linter
-          cli::cli_warn(c( # nolint: line_length_linter
+          cli::cli_warn(c(
+            # nolint: line_length_linter
             "!" = "Computed duration (interview_time - trip_start) > 48 hours for {n_long} interview{?s}",
             "i" = "Multi-day trips are valid, but verify these are not data entry errors"
           ))
@@ -1491,7 +1535,8 @@ validate_design_compatibility <- function(design) {
 #'
 #' @keywords internal
 #' @noRd
-validate_grouping_compatibility <- function(design, by_vars) { # nolint: object_length_linter
+validate_grouping_compatibility <- function(design, by_vars) {
+  # nolint: object_length_linter
   # Check grouping variables exist in count data
   missing_in_counts <- setdiff(by_vars, names(design$counts))
   if (length(missing_in_counts) > 0) {

--- a/R/theme-creel.R
+++ b/R/theme-creel.R
@@ -38,7 +38,7 @@ creel_palette <- function(n = NULL) {
     cli::cli_abort("{.arg n} must be a single positive number when provided.")
   }
 
-  palette_vals[seq_len(n) %% length(palette_vals)]
+  palette_vals[(seq_len(n) - 1L) %% length(palette_vals) + 1L]
 }
 
 #' Package-standard ggplot2 theme for tidycreel plots

--- a/R/tidy-methods.R
+++ b/R/tidy-methods.R
@@ -3,7 +3,9 @@
 #' @param x A \code{creel_estimates} object.
 #' @param ... Unused; reserved for future arguments.
 #' @return A tibble with one row per estimate. All columns from
-#'   \code{x$estimates} are returned unchanged. Required columns:
+#'   \code{x$estimates} are returned, plus \code{n} padded to
+#'   \code{NA_integer_} when the estimator does not produce a sample size
+#'   (e.g. mark-recapture harvest). Guaranteed columns:
 #'   \code{estimate}, \code{se}, \code{ci_lower}, \code{ci_upper}, \code{n}.
 #' @method tidy creel_estimates
 #' @export
@@ -11,5 +13,9 @@
 #' @seealso \code{\link{write_estimates}}
 #' @family "Reporting & Diagnostics"
 tidy.creel_estimates <- function(x, ...) {
-  tibble::as_tibble(x$estimates)
+  out <- tibble::as_tibble(x$estimates)
+  if (!"n" %in% names(out)) {
+    out[["n"]] <- NA_integer_
+  }
+  out
 }

--- a/R/validate-creel-data.R
+++ b/R/validate-creel-data.R
@@ -73,7 +73,8 @@ validate_creel_data <- function(
 
   bad_threshold <- !is.numeric(na_threshold) ||
     length(na_threshold) != 1L ||
-    na_threshold < 0 || na_threshold > 1
+    na_threshold < 0 ||
+    na_threshold > 1
   if (bad_threshold) {
     cli::cli_abort(
       "{.arg na_threshold} must be a single number in [0, 1].",
@@ -96,16 +97,15 @@ validate_creel_data <- function(
 
   if (!is.null(counts)) {
     if (!is.data.frame(counts)) {
-      cli::cli_abort("{.arg counts} must be a data frame.",
-        class = "creel_error_design_validation"
-      )
+      cli::cli_abort("{.arg counts} must be a data frame.", class = "creel_error_design_validation")
     }
     rows <- c(rows, .check_table(counts, "counts", na_threshold, date_range))
   }
 
   if (!is.null(interviews)) {
     if (!is.data.frame(interviews)) {
-      cli::cli_abort("{.arg interviews} must be a data frame.",
+      cli::cli_abort(
+        "{.arg interviews} must be a data frame.",
         class = "creel_error_design_validation"
       )
     }
@@ -141,23 +141,37 @@ validate_creel_data <- function(
 
   # -- type ------------------------------------------------------------------
   col_class <- paste(class(x), collapse = "/")
-  rows <- c(rows, list(.make_row(
-    table_name, col, "type", "pass",
-    paste0("class: ", col_class)
-  )))
+  rows <- c(
+    rows,
+    list(.make_row(
+      table_name,
+      col,
+      "type",
+      "pass",
+      paste0("class: ", col_class)
+    ))
+  )
 
   # -- NA rate ---------------------------------------------------------------
   n_total <- length(x)
   n_na <- sum(is.na(x))
   na_rate <- if (n_total > 0L) n_na / n_total else 0
   na_status <- if (na_rate > na_threshold) "warn" else "pass"
-  rows <- c(rows, list(.make_row(
-    table_name, col, "na_rate", na_status,
-    sprintf(
-      "%d / %d NA (%.0f%%)",
-      n_na, n_total, na_rate * 100
-    )
-  )))
+  rows <- c(
+    rows,
+    list(.make_row(
+      table_name,
+      col,
+      "na_rate",
+      na_status,
+      sprintf(
+        "%d / %d NA (%.0f%%)",
+        n_na,
+        n_total,
+        na_rate * 100
+      )
+    ))
+  )
 
   # -- Date-specific checks --------------------------------------------------
   if (inherits(x, "Date")) {
@@ -165,38 +179,50 @@ validate_creel_data <- function(
     if (length(non_na) > 0L) {
       out_of_range <- non_na < date_range[1] | non_na > date_range[2]
       range_status <- if (any(out_of_range)) "warn" else "pass"
-      rows <- c(rows, list(.make_row(
-        table_name, col, "date_range", range_status,
-        if (any(out_of_range)) {
-          sprintf(
-            "%d value(s) outside %s - %s",
-            sum(out_of_range),
-            format(date_range[1]),
-            format(date_range[2])
-          )
-        } else {
-          sprintf(
-            "all within %s - %s",
-            format(date_range[1]),
-            format(date_range[2])
-          )
-        }
-      )))
+      rows <- c(
+        rows,
+        list(.make_row(
+          table_name,
+          col,
+          "date_range",
+          range_status,
+          if (any(out_of_range)) {
+            sprintf(
+              "%d value(s) outside %s - %s",
+              sum(out_of_range),
+              format(date_range[1]),
+              format(date_range[2])
+            )
+          } else {
+            sprintf(
+              "all within %s - %s",
+              format(date_range[1]),
+              format(date_range[2])
+            )
+          }
+        ))
+      )
     }
   }
 
   # -- Numeric-specific checks -----------------------------------------------
   if (is.numeric(x) && !inherits(x, "Date")) {
     non_na <- x[!is.na(x)]
-    neg_status <- if (any(non_na < 0)) "warn" else "pass"
-    rows <- c(rows, list(.make_row(
-      table_name, col, "negative_values", neg_status,
-      if (any(non_na < 0)) {
-        sprintf("%d negative value(s)", sum(non_na < 0))
-      } else {
-        "none"
-      }
-    )))
+    neg_status <- if (any(non_na < 0)) "fail" else "pass"
+    rows <- c(
+      rows,
+      list(.make_row(
+        table_name,
+        col,
+        "negative_values",
+        neg_status,
+        if (any(non_na < 0)) {
+          sprintf("%d negative value(s)", sum(non_na < 0))
+        } else {
+          "none"
+        }
+      ))
+    )
   }
 
   # -- Character/factor-specific checks --------------------------------------
@@ -204,14 +230,20 @@ validate_creel_data <- function(
     chr_x <- as.character(x)
     non_na <- chr_x[!is.na(chr_x)]
     empty_status <- if (any(non_na == "")) "warn" else "pass"
-    rows <- c(rows, list(.make_row(
-      table_name, col, "empty_strings", empty_status,
-      if (any(non_na == "")) {
-        sprintf("%d empty string(s)", sum(non_na == ""))
-      } else {
-        "none"
-      }
-    )))
+    rows <- c(
+      rows,
+      list(.make_row(
+        table_name,
+        col,
+        "empty_strings",
+        empty_status,
+        if (any(non_na == "")) {
+          sprintf("%d empty string(s)", sum(non_na == ""))
+        } else {
+          "none"
+        }
+      ))
+    )
   }
 
   rows
@@ -278,7 +310,8 @@ print.creel_data_validation <- function(x, ...) {
       }
 
       for (i in seq_len(nrow(col_rows))) {
-        status_sym <- switch(col_rows$status[i], # nolint: object_usage_linter
+        status_sym <- switch(
+          col_rows$status[i], # nolint: object_usage_linter
           pass = cli::symbol$tick,
           warn = cli::symbol$warning,
           fail = cli::symbol$cross,

--- a/R/validate-incomplete-trips.R
+++ b/R/validate-incomplete-trips.R
@@ -263,7 +263,9 @@ validate_incomplete_trips <- function(design,
     )
 
     # Overall passed = overall test passes AND all group tests pass
-    passed <- overall_result$equivalence_passed && all(group_results$equivalence_passed)
+    # isTRUE guards NA from degenerate TOST groups (df<=0 or se_diff==0 outside bounds)
+    passed <- isTRUE(overall_result$equivalence_passed) &&
+      all(vapply(group_results$equivalence_passed, isTRUE, logical(1)))
 
     # Build plot_data for grouped estimation
     complete_df <- complete_result$estimates
@@ -512,6 +514,41 @@ perform_tost <- function(complete_estimate, complete_se, incomplete_estimate,
 
   # Degrees of freedom (conservative: min of two samples)
   df <- min(n_complete - 1, n_incomplete - 1)
+
+  # Guard: se_diff == 0 (both groups have identical estimates with zero SE)
+  # → t-statistics are ±Inf; treat as trivially equivalent if diff is within bounds.
+  if (se_diff == 0) {
+    equivalence_passed <- (diff_estimate >= equivalence_lower) &&
+      (diff_estimate <= equivalence_upper)
+    return(list(
+      p_lower = if (equivalence_passed) 0 else 1,
+      p_upper = if (equivalence_passed) 0 else 1,
+      equivalence_passed = equivalence_passed,
+      diff_estimate = diff_estimate,
+      equivalence_lower = equivalence_lower,
+      equivalence_upper = equivalence_upper,
+      se_diff = se_diff,
+      df = df
+    ))
+  }
+
+  # Guard: df <= 0 (n=1 in one or both groups) → cannot compute t-distribution
+  if (df <= 0L) {
+    cli::cli_warn(
+      "TOST: insufficient degrees of freedom (df={df}); equivalence cannot be tested.",
+      class = "creel_warn_tost_degenerate"
+    )
+    return(list(
+      p_lower = NA_real_,
+      p_upper = NA_real_,
+      equivalence_passed = NA,
+      diff_estimate = diff_estimate,
+      equivalence_lower = equivalence_lower,
+      equivalence_upper = equivalence_upper,
+      se_diff = se_diff,
+      df = df
+    ))
+  }
 
   # TOST: Two one-sided tests
   # Test 1: H0: diff <= lower_bound vs H1: diff > lower_bound

--- a/R/validate-incomplete-trips.R
+++ b/R/validate-incomplete-trips.R
@@ -129,13 +129,15 @@
 #' )
 #' @family "Reporting & Diagnostics"
 #' @export
-validate_incomplete_trips <- function(design,
-                                      catch,
-                                      effort,
-                                      by = NULL,
-                                      variance = "taylor",
-                                      conf_level = 0.95,
-                                      truncate_at = 0.5) {
+validate_incomplete_trips <- function(
+  design,
+  catch,
+  effort,
+  by = NULL,
+  variance = "taylor",
+  conf_level = 0.95,
+  truncate_at = 0.5
+) {
   # Capture bare column names
   catch_quo <- rlang::enquo(catch)
   effort_quo <- rlang::enquo(effort)
@@ -205,7 +207,8 @@ validate_incomplete_trips <- function(design,
 
   # Estimate CPUE for complete trips (ratio-of-means)
   complete_result <- suppressMessages(
-    estimate_catch_rate( # nolint: object_usage_linter
+    estimate_catch_rate(
+      # nolint: object_usage_linter
       design,
       by = !!by_quo,
       variance = variance,
@@ -218,7 +221,8 @@ validate_incomplete_trips <- function(design,
 
   # Estimate CPUE for incomplete trips (mean-of-ratios)
   incomplete_result <- suppressMessages(suppressWarnings(
-    estimate_catch_rate( # nolint: object_usage_linter
+    estimate_catch_rate(
+      # nolint: object_usage_linter
       design,
       by = !!by_quo,
       variance = variance,
@@ -318,7 +322,10 @@ validate_incomplete_trips <- function(design,
         recommendation <- paste0(
           "Validation failed: Use complete trips only. ",
           "Groups failed equivalence: ",
-          paste(apply(failing_groups, 1, function(x) paste(by_vars, "=", x, collapse = ", ")), collapse = "; ")
+          paste(
+            apply(failing_groups, 1, function(x) paste(by_vars, "=", x, collapse = ", ")),
+            collapse = "; "
+          )
         )
       } else {
         recommendation <- "Validation failed: Use complete trips only (overall test failed)"
@@ -414,11 +421,19 @@ validate_incomplete_trips <- function(design,
 #'
 #' @keywords internal
 #' @noRd
-perform_overall_tost <- function(design, catch_quo, effort_quo, variance,
-                                 conf_level, truncate_at, threshold) {
+perform_overall_tost <- function(
+  design,
+  catch_quo,
+  effort_quo,
+  variance,
+  conf_level,
+  truncate_at,
+  threshold
+) {
   # Estimate ungrouped complete CPUE
   complete_overall <- suppressMessages(
-    estimate_catch_rate( # nolint: object_usage_linter
+    estimate_catch_rate(
+      # nolint: object_usage_linter
       design,
       variance = variance,
       conf_level = conf_level,
@@ -430,7 +445,8 @@ perform_overall_tost <- function(design, catch_quo, effort_quo, variance,
 
   # Estimate ungrouped incomplete CPUE
   incomplete_overall <- suppressMessages(suppressWarnings(
-    estimate_catch_rate( # nolint: object_usage_linter
+    estimate_catch_rate(
+      # nolint: object_usage_linter
       design,
       variance = variance,
       conf_level = conf_level,
@@ -501,8 +517,15 @@ perform_grouped_tost <- function(complete_result, incomplete_result, by_vars, th
 #'
 #' @keywords internal
 #' @noRd
-perform_tost <- function(complete_estimate, complete_se, incomplete_estimate,
-                         incomplete_se, threshold, n_complete, n_incomplete) {
+perform_tost <- function(
+  complete_estimate,
+  complete_se,
+  incomplete_estimate,
+  incomplete_se,
+  threshold,
+  n_complete,
+  n_incomplete
+) {
   # Calculate difference and bounds
   diff_estimate <- complete_estimate - incomplete_estimate
   equivalence_lower <- -threshold * abs(complete_estimate)
@@ -585,60 +608,69 @@ perform_tost <- function(complete_estimate, complete_se, incomplete_estimate,
 format.creel_tost_validation <- function(x, ...) {
   output <- character()
 
-  output <- c(output, cli::cli_format_method({
-    cli::cli_h1("TOST Equivalence Validation Results")
-    cli::cli_text("Threshold: \u00b1{round(x$equivalence_threshold * 100, 1)}% of complete trip estimate")
+  output <- c(
+    output,
+    cli::cli_format_method({
+      cli::cli_h1("TOST Equivalence Validation Results")
+      cli::cli_text(
+        "Threshold: \u00b1{round(x$equivalence_threshold * 100, 1)}% of complete trip estimate"
+      )
 
-    # Overall status
-    if (x$passed) {
-      cli::cli_alert_success("Validation PASSED")
-    } else {
-      cli::cli_alert_danger("Validation FAILED")
-    }
+      # Overall status
+      if (x$passed) {
+        cli::cli_alert_success("Validation PASSED")
+      } else {
+        cli::cli_alert_danger("Validation FAILED")
+      }
 
-    cli::cli_text("")
-    cli::cli_text("Recommendation: {x$recommendation}")
-    cli::cli_text("")
-
-    # Overall test results
-    cli::cli_h2("Overall Test")
-
-    # Handle both ungrouped (metadata$complete) and grouped (metadata$overall$complete) structures
-    if (!is.null(x$metadata$overall)) {
-      # Grouped validation
-      complete_meta <- x$metadata$overall$complete # nolint: object_usage_linter
-      incomplete_meta <- x$metadata$overall$incomplete # nolint: object_usage_linter
-    } else {
-      # Ungrouped validation
-      complete_meta <- x$metadata$complete # nolint: object_usage_linter
-      incomplete_meta <- x$metadata$incomplete # nolint: object_usage_linter
-    }
-
-    cli::cli_text("Complete trips: n = {complete_meta$n}, CPUE = {round(complete_meta$estimate, 3)}")
-    cli::cli_text("Incomplete trips: n = {incomplete_meta$n}, CPUE = {round(incomplete_meta$estimate, 3)}")
-    cli::cli_text("Difference: {round(x$overall_test$diff_estimate, 3)}")
-    equiv_lower <- round(x$overall_test$equivalence_lower, 3) # nolint: object_usage_linter
-    equiv_upper <- round(x$overall_test$equivalence_upper, 3) # nolint: object_usage_linter
-    p_lower <- round(x$overall_test$p_lower, 4) # nolint: object_usage_linter
-    p_upper <- round(x$overall_test$p_upper, 4) # nolint: object_usage_linter
-    cli::cli_text("Equivalence bounds: [{equiv_lower}, {equiv_upper}]")
-    cli::cli_text("TOST p-values: p_lower = {p_lower}, p_upper = {p_upper}")
-
-    if (x$overall_test$equivalence_passed) {
-      cli::cli_alert_success("Overall equivalence: PASSED")
-    } else {
-      cli::cli_alert_danger("Overall equivalence: FAILED")
-    }
-
-    # Group results if present
-    if (!is.null(x$group_tests)) {
       cli::cli_text("")
-      cli::cli_h2("Per-Group Tests")
-      n_groups <- nrow(x$group_tests) # nolint: object_usage_linter
-      n_passed <- sum(x$group_tests$equivalence_passed) # nolint: object_usage_linter
-      cli::cli_text("{n_passed}/{n_groups} group{?s} passed equivalence")
-    }
-  }))
+      cli::cli_text("Recommendation: {x$recommendation}")
+      cli::cli_text("")
+
+      # Overall test results
+      cli::cli_h2("Overall Test")
+
+      # Handle both ungrouped (metadata$complete) and grouped (metadata$overall$complete) structures
+      if (!is.null(x$metadata$overall)) {
+        # Grouped validation
+        complete_meta <- x$metadata$overall$complete # nolint: object_usage_linter
+        incomplete_meta <- x$metadata$overall$incomplete # nolint: object_usage_linter
+      } else {
+        # Ungrouped validation
+        complete_meta <- x$metadata$complete # nolint: object_usage_linter
+        incomplete_meta <- x$metadata$incomplete # nolint: object_usage_linter
+      }
+
+      cli::cli_text(
+        "Complete trips: n = {complete_meta$n}, CPUE = {round(complete_meta$estimate, 3)}"
+      )
+      cli::cli_text(
+        "Incomplete trips: n = {incomplete_meta$n}, CPUE = {round(incomplete_meta$estimate, 3)}"
+      )
+      cli::cli_text("Difference: {round(x$overall_test$diff_estimate, 3)}")
+      equiv_lower <- round(x$overall_test$equivalence_lower, 3) # nolint: object_usage_linter
+      equiv_upper <- round(x$overall_test$equivalence_upper, 3) # nolint: object_usage_linter
+      p_lower <- round(x$overall_test$p_lower, 4) # nolint: object_usage_linter
+      p_upper <- round(x$overall_test$p_upper, 4) # nolint: object_usage_linter
+      cli::cli_text("Equivalence bounds: [{equiv_lower}, {equiv_upper}]")
+      cli::cli_text("TOST p-values: p_lower = {p_lower}, p_upper = {p_upper}")
+
+      if (x$overall_test$equivalence_passed) {
+        cli::cli_alert_success("Overall equivalence: PASSED")
+      } else {
+        cli::cli_alert_danger("Overall equivalence: FAILED")
+      }
+
+      # Group results if present
+      if (!is.null(x$group_tests)) {
+        cli::cli_text("")
+        cli::cli_h2("Per-Group Tests")
+        n_groups <- nrow(x$group_tests) # nolint: object_usage_linter
+        n_passed <- sum(x$group_tests$equivalence_passed) # nolint: object_usage_linter
+        cli::cli_text("{n_passed}/{n_groups} group{?s} passed equivalence")
+      }
+    })
+  )
 
   output
 }
@@ -667,17 +699,23 @@ print.creel_tost_validation <- function(x, ...) {
   graphics::par(mar = c(5, 5, 4, 2) + 0.1)
 
   # Determine axis ranges (include CI bounds)
-  x_range <- range(c(
-    plot_data$complete_est,
-    plot_data$complete_ci_lower,
-    plot_data$complete_ci_upper
-  ), na.rm = TRUE)
+  x_range <- range(
+    c(
+      plot_data$complete_est,
+      plot_data$complete_ci_lower,
+      plot_data$complete_ci_upper
+    ),
+    na.rm = TRUE
+  )
 
-  y_range <- range(c(
-    plot_data$incomplete_est,
-    plot_data$incomplete_ci_lower,
-    plot_data$incomplete_ci_upper
-  ), na.rm = TRUE)
+  y_range <- range(
+    c(
+      plot_data$incomplete_est,
+      plot_data$incomplete_ci_lower,
+      plot_data$incomplete_ci_upper
+    ),
+    na.rm = TRUE
+  )
 
   # Ensure ranges are equal (square plot)
   all_range <- range(c(x_range, y_range))

--- a/R/validation-report.R
+++ b/R/validation-report.R
@@ -128,8 +128,7 @@ validation_report <- function(
 .species_coverage_row <- function(interviews, species_col) {
   if (!species_col %in% names(interviews)) {
     cli::cli_warn(
-      "Column {.field {species_col}} not found in {.arg interviews}; ",
-      "skipping species coverage check."
+      "Column {.field {species_col}} not found in {.arg interviews}; skipping species coverage check."
     )
     return(NULL)
   }

--- a/R/validation-report.R
+++ b/R/validation-report.R
@@ -67,11 +67,12 @@ validation_report <- function(
   }
 
   # Run field-level validation.
-  raw <- validate_creel_data( # nolint: object_usage_linter
-    counts       = counts,
-    interviews   = interviews,
+  raw <- validate_creel_data(
+    # nolint: object_usage_linter
+    counts = counts,
+    interviews = interviews,
     na_threshold = na_threshold,
-    date_range   = date_range
+    date_range = date_range
   )
 
   # Aggregate: one row per table x check, with flagged column names.
@@ -98,7 +99,9 @@ validation_report <- function(
   for (tbl in tables) {
     for (chk in checks) {
       sub <- raw[raw$table == tbl & raw$check == chk, , drop = FALSE]
-      if (nrow(sub) == 0L) next
+      if (nrow(sub) == 0L) {
+        next
+      }
 
       n_pass <- sum(sub$status == "pass")
       n_warn <- sum(sub$status == "warn")
@@ -111,15 +114,18 @@ validation_report <- function(
         paste(flagged, collapse = ", ")
       }
 
-      rows <- c(rows, list(data.frame(
-        table = tbl,
-        check = chk,
-        n_pass = n_pass,
-        n_warn = n_warn,
-        n_fail = n_fail,
-        detail = detail_str,
-        stringsAsFactors = FALSE
-      )))
+      rows <- c(
+        rows,
+        list(data.frame(
+          table = tbl,
+          check = chk,
+          n_pass = n_pass,
+          n_warn = n_warn,
+          n_fail = n_fail,
+          detail = detail_str,
+          stringsAsFactors = FALSE
+        ))
+      )
     }
   }
   do.call(rbind, rows)
@@ -149,7 +155,10 @@ validation_report <- function(
     n_warn = n_warn,
     n_fail = 0L,
     detail = sprintf(
-      "%d / %d matched (%.1f%%)", n_matched, n_total, pct
+      "%d / %d matched (%.1f%%)",
+      n_matched,
+      n_total,
+      pct
     ),
     stringsAsFactors = FALSE
   )
@@ -172,7 +181,8 @@ print.creel_validation_report <- function(x, ...) {
   total_warn <- sum(x$n_warn)
   total_fail <- sum(x$n_fail)
 
-  overall <- if (total_fail > 0L) { # nolint: object_usage_linter
+  overall <- if (total_fail > 0L) {
+    # nolint: object_usage_linter
     "FAIL"
   } else if (total_warn > 0L) {
     "WARN"
@@ -190,8 +200,15 @@ print.creel_validation_report <- function(x, ...) {
 
     for (i in seq_len(nrow(tbl_rows))) {
       row <- tbl_rows[i, , drop = FALSE]
-      status <- if (row$n_fail > 0L) "fail" else if (row$n_warn > 0L) "warn" else "pass"
-      sym <- if (status == "pass") { # nolint: object_usage_linter
+      status <- if (row$n_fail > 0L) {
+        "fail"
+      } else if (row$n_warn > 0L) {
+        "warn"
+      } else {
+        "pass"
+      }
+      sym <- if (status == "pass") {
+        # nolint: object_usage_linter
         cli::symbol$tick
       } else if (status == "warn") {
         cli::symbol$warning

--- a/R/write-estimates.R
+++ b/R/write-estimates.R
@@ -96,7 +96,8 @@ write_estimates <- function(
   format <- match.arg(format)
   if (format == "auto") {
     ext <- tolower(tools::file_ext(path))
-    format <- switch(ext,
+    format <- switch(
+      ext,
       csv = "csv",
       xlsx = "xlsx",
       cli::cli_abort(c(
@@ -125,14 +126,25 @@ write_estimates <- function(
 
   # ---- Write ------------------------------------------------------------------
   if (format == "csv") {
-    con <- file(path, open = "wt")
-    on.exit(close(con), add = TRUE)
+    tmp <- tempfile(tmpdir = dirname(path), fileext = ".csv")
+    con <- file(tmp, open = "wt")
+    on.exit(
+      {
+        try(close(con), silent = TRUE)
+        if (file.exists(tmp)) file.remove(tmp)
+      },
+      add = TRUE
+    )
     header_lines <- c(
       "# Survey estimates - tidycreel",
       paste0(
-        "# Method: ", method_label,
-        " | ", var_label,
-        " | ", conf_label, " CI"
+        "# Method: ",
+        method_label,
+        " | ",
+        var_label,
+        " | ",
+        conf_label,
+        " CI"
       )
     )
     if (!is.null(effort_target) && nzchar(effort_target)) {
@@ -141,6 +153,8 @@ write_estimates <- function(
     header_lines <- c(header_lines, paste0("# Generated: ", ts))
     writeLines(header_lines, con = con)
     utils::write.csv(df, file = con, row.names = FALSE)
+    close(con)
+    file.rename(tmp, path)
   } else {
     rlang::check_installed(
       "writexl",

--- a/README.Rmd
+++ b/README.Rmd
@@ -83,7 +83,7 @@ devtools::install_github("chrischizinski/tidycreel")
 - **Stratification auditing** — `audit_strata()`, `simulate_strata_collapse()`, and `reallocate_strata()` diagnose stratum weights, inclusion probabilities, and coverage; test collapse scenarios before committing to a redesign.
 - **Validation and cleaning** — field-level validation, species standardisation, data-validation summaries, and toy datasets for examples.
 - **Planning and QA** — schedule generation, count-window planning, completeness checks, sample-size tools, and power calculators.
-- **Visualisation and reporting** — `autoplot()` methods, `theme_creel()`, `creel_palette()`, and a flexdashboard report template scaffold.
+- **Visualisation and reporting** — `autoplot()` methods, `theme_creel()`, `creel_palette()`, a Quarto Creel Report template scaffold, and the legacy flexdashboard scaffold.
 - **Documentation and onboarding** — glossary, workflow vignettes, statistical-method articles, and a pkgdown site.
 
 ## Quick Start
@@ -134,7 +134,7 @@ estimate_catch_rate(design)
 | Plan a season before sampling starts | [Survey Design Toolbox](https://chrischizinski.github.io/tidycreel/articles/survey-design-toolbox.html) |
 | Estimate angler population or exploitation rate from tag data | [Mark-Recapture and Exploitation Rate](https://chrischizinski.github.io/tidycreel/articles/mark-recapture.html) |
 | Understand plotting and output styling | [Visualisation](https://chrischizinski.github.io/tidycreel/articles/visualisation.html) and `theme_creel()` |
-| Build a report/dashboard | Install the package, then open **R Markdown > From Template > Creel Dashboard** in RStudio |
+| Build a report/dashboard | Use the bundled Quarto Creel Report starter template, or open **R Markdown > From Template > Creel Dashboard** for the legacy scaffold |
 
 ## Functions at a Glance
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,32 @@
-
+---
+output: github_document
+---
 <!-- Generated from README.Rmd — do not edit README.md directly -->
 
 # tidycreel
 
 <p align="center">
-
 <img src="https://raw.githubusercontent.com/chrischizinski/tidycreel/main/man/figures/logo.png" alt="tidycreel hex sticker" width="200"/>
 </p>
 
 <!-- badges: start -->
-
 [![R-CMD-check](https://github.com/chrischizinski/tidycreel/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/chrischizinski/tidycreel/actions/workflows/R-CMD-check.yaml)
 [![pkgdown](https://img.shields.io/badge/pkgdown-live-1B4F72)](https://chrischizinski.github.io/tidycreel/)
-[![License:
-MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Lifecycle:
-stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
-[![Codecov test
-coverage](https://codecov.io/gh/chrischizinski/tidycreel/graph/badge.svg)](https://app.codecov.io/gh/chrischizinski/tidycreel)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![Codecov test coverage](https://codecov.io/gh/chrischizinski/tidycreel/graph/badge.svg)](https://app.codecov.io/gh/chrischizinski/tidycreel)
 [![Release](https://img.shields.io/badge/release-v2.2.0%20%22Goldeye%22-4CAF50)](https://github.com/chrischizinski/tidycreel/releases)
 <!-- badges: end -->
 
 **Tidy Interface for Creel Survey Design, Estimation, and Reporting**
 
-tidycreel provides a pipe-friendly interface for creel survey design,
-data management, estimation, visualisation, and reporting. Built on the
-[`survey`](https://cran.r-project.org/package=survey) package for
-design-based inference, it lets fisheries biologists work in creel
-vocabulary — dates, strata, counts, effort, catch, lengths, schedules —
-without managing survey-package internals directly.
+tidycreel provides a pipe-friendly interface for creel survey design, data management, estimation, visualisation, and reporting. Built on the [`survey`](https://cran.r-project.org/package=survey) package for design-based inference, it lets fisheries biologists work in creel vocabulary — dates, strata, counts, effort, catch, lengths, schedules — without managing survey-package internals directly.
 
 ## Installation
 
 Install the development version from GitHub:
 
-``` r
+```r
 # install.packages("pak")
 pak::pak("chrischizinski/tidycreel")
 
@@ -45,165 +37,60 @@ devtools::install_github("chrischizinski/tidycreel")
 ## Survey Types
 
 <div class="row mt-4 mb-4">
-
 <div class="col-md-4 mb-3">
-
 <div class="card h-100 border-0 bg-light p-3">
-
-<h5 class="text-primary">
-
-Instantaneous Count
-</h5>
-
-<p class="small">
-
-Stratified effort estimation from periodic angler counts.
-</p>
-
-<p class="small">
-
-<a href="https://chrischizinski.github.io/tidycreel/articles/tidycreel.html">Getting
-Started →</a>
-</p>
-
+<h5 class="text-primary">Instantaneous Count</h5>
+<p class="small">Stratified effort estimation from periodic angler counts.</p>
+<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/tidycreel.html">Getting Started →</a></p>
 </div>
-
 </div>
-
 <div class="col-md-4 mb-3">
-
 <div class="card h-100 border-0 bg-light p-3">
-
-<h5 class="text-primary">
-
-Bus-Route
-</h5>
-
-<p class="small">
-
-PPS site selection with Horvitz-Thompson estimators and enumeration
-expansion.
-</p>
-
-<p class="small">
-
-<a href="https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html">Bus-Route
-vignette →</a>
-</p>
-
+<h5 class="text-primary">Bus-Route</h5>
+<p class="small">PPS site selection with Horvitz-Thompson estimators and enumeration expansion.</p>
+<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html">Bus-Route vignette →</a></p>
 </div>
-
 </div>
-
 <div class="col-md-4 mb-3">
-
 <div class="card h-100 border-0 bg-light p-3">
-
-<h5 class="text-primary">
-
-Ice Fishing
-</h5>
-
-<p class="small">
-
-Degenerate bus-route design with certainty site sampling.
-</p>
-
-<p class="small">
-
-<a href="https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html">Ice
-Fishing vignette →</a>
-</p>
-
+<h5 class="text-primary">Ice Fishing</h5>
+<p class="small">Degenerate bus-route design with certainty site sampling.</p>
+<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html">Ice Fishing vignette →</a></p>
 </div>
-
 </div>
-
 <div class="col-md-4 mb-3">
-
 <div class="card h-100 border-0 bg-light p-3">
-
-<h5 class="text-primary">
-
-Camera-Monitored
-</h5>
-
-<p class="small">
-
-Counter and ingress-egress preprocessing, NB GLMM count imputation, and
-camera effort indexing.
-</p>
-
-<p class="small">
-
-<a href="https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html">Camera
-Survey vignette →</a>
-</p>
-
+<h5 class="text-primary">Camera-Monitored</h5>
+<p class="small">Counter and ingress-egress preprocessing, NB GLMM count imputation, and camera effort indexing.</p>
+<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html">Camera Survey vignette →</a></p>
 </div>
-
 </div>
-
 <div class="col-md-4 mb-3">
-
 <div class="card h-100 border-0 bg-light p-3">
-
-<h5 class="text-primary">
-
-Aerial Survey
-</h5>
-
-<p class="small">
-
-Single-overflight effort estimation with calibrated open-hours scaling.
-</p>
-
-<p class="small">
-
-<a href="https://chrischizinski.github.io/tidycreel/articles/aerial-surveys.html">Aerial
-vignette →</a> \|
-<a href="https://chrischizinski.github.io/tidycreel/articles/aerial-glmm.html">GLMM
-variant →</a>
-</p>
-
+<h5 class="text-primary">Aerial Survey</h5>
+<p class="small">Single-overflight effort estimation with calibrated open-hours scaling.</p>
+<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/aerial-surveys.html">Aerial vignette →</a> | <a href="https://chrischizinski.github.io/tidycreel/articles/aerial-glmm.html">GLMM variant →</a></p>
 </div>
-
 </div>
-
 </div>
 
 ## Key Capabilities
 
-- **Design-based inference** — wraps the `survey` package; biologists
-  write creel vocabulary, not survey-package internals.
-- **Single design entry point** — `creel_design()` dispatches to the
-  correct workflow for each survey type.
-- **Core estimation surface** — effort, catch rate, harvest rate,
-  release rate, and total-catch estimators share a common API.
-- **Extended estimation methods** — camera effort indexing, NB GLMM
-  count imputation, weighted length distributions, mark-recapture
-  population and harvest estimators (Petersen, Schnabel), and
-  exploitation rate from tag returns (Pollock et al.).
-- **Stratification auditing** — `audit_strata()`,
-  `simulate_strata_collapse()`, and `reallocate_strata()` diagnose
-  stratum weights, inclusion probabilities, and coverage; test collapse
-  scenarios before committing to a redesign.
-- **Validation and cleaning** — field-level validation, species
-  standardisation, data-validation summaries, and toy datasets for
-  examples.
-- **Planning and QA** — schedule generation, count-window planning,
-  completeness checks, sample-size tools, and power calculators.
-- **Visualisation and reporting** — `autoplot()` methods,
-  `theme_creel()`, `creel_palette()`, and a flexdashboard report
-  template scaffold.
-- **Documentation and onboarding** — glossary, workflow vignettes,
-  statistical-method articles, and a pkgdown site.
+- **Design-based inference** — wraps the `survey` package; biologists write creel vocabulary, not survey-package internals.
+- **Single design entry point** — `creel_design()` dispatches to the correct workflow for each survey type.
+- **Core estimation surface** — effort, catch rate, harvest rate, release rate, and total-catch estimators share a common API.
+- **Extended estimation methods** — camera effort indexing, NB GLMM count imputation, weighted length distributions, mark-recapture population and harvest estimators (Petersen, Schnabel), and exploitation rate from tag returns (Pollock et al.).
+- **Stratification auditing** — `audit_strata()`, `simulate_strata_collapse()`, and `reallocate_strata()` diagnose stratum weights, inclusion probabilities, and coverage; test collapse scenarios before committing to a redesign.
+- **Validation and cleaning** — field-level validation, species standardisation, data-validation summaries, and toy datasets for examples.
+- **Planning and QA** — schedule generation, count-window planning, completeness checks, sample-size tools, and power calculators.
+- **Visualisation and reporting** — `autoplot()` methods, `theme_creel()`, `creel_palette()`, a Quarto Creel Report template scaffold, and the legacy flexdashboard scaffold.
+- **Documentation and onboarding** — glossary, workflow vignettes, statistical-method articles, and a pkgdown site.
 
 ## Quick Start
 
 ### Instantaneous Count Survey
 
-``` r
+```r
 library(tidycreel)
 
 # 1. Define survey structure with tidy selectors
@@ -218,7 +105,7 @@ estimate_effort(design)
 
 ### Bus-Route Survey
 
-``` r
+```r
 # Probability-proportional-to-size site selection
 design <- creel_design(
   example_calendar,
@@ -241,78 +128,53 @@ estimate_catch_rate(design)
 ## Where to Start
 
 | If you want to… | Start here |
-|----|----|
+|---|---|
 | Learn the package vocabulary | [Glossary](https://chrischizinski.github.io/tidycreel/articles/glossary.html) |
 | See the main end-to-end workflow | [Getting Started](https://chrischizinski.github.io/tidycreel/articles/tidycreel.html) |
 | Plan a season before sampling starts | [Survey Design Toolbox](https://chrischizinski.github.io/tidycreel/articles/survey-design-toolbox.html) |
 | Estimate angler population or exploitation rate from tag data | [Mark-Recapture and Exploitation Rate](https://chrischizinski.github.io/tidycreel/articles/mark-recapture.html) |
 | Understand plotting and output styling | [Visualisation](https://chrischizinski.github.io/tidycreel/articles/visualisation.html) and `theme_creel()` |
-| Build a report/dashboard | Install the package, then open **R Markdown \> From Template \> Creel Dashboard** in RStudio |
+| Build a report/dashboard | Use the bundled Quarto Creel Report starter template, or open **R Markdown > From Template > Creel Dashboard** for the legacy scaffold |
 
 ## Functions at a Glance
 
 ### Survey Design
-
-- **`creel_design()`** — single entry point; dispatches on
-  `survey_type`.
-- **`add_counts()`**, **`add_interviews()`**, **`add_catch()`**,
-  **`add_lengths()`**, **`add_sections()`** — attach observation data.
+- **`creel_design()`** — single entry point; dispatches on `survey_type`.
+- **`add_counts()`**, **`add_interviews()`**, **`add_catch()`**, **`add_lengths()`**, **`add_sections()`** — attach observation data.
 
 ### Estimation
-
-- **`estimate_effort()`** — total effort with Taylor linearization,
-  bootstrap, or jackknife variance.
-- **`estimate_catch_rate()`**, **`estimate_harvest_rate()`**,
-  **`estimate_release_rate()`** — ratio-based interview estimators.
-- **`estimate_total_catch()`**, **`estimate_total_harvest()`**,
-  **`estimate_total_release()`** — totals via delta-method propagation.
-- **`est_effort_camera()`**, **`est_length_distribution()`** — camera
-  effort indexing and weighted size-structure estimation.
-- **`estimate_exploitation_rate()`** — exploitation rate from tag
-  returns (Pollock et al.; simple and T-weighted stratified paths).
-- **`estimate_angler_n()`** — Petersen and Schnabel mark-recapture
-  population size estimators.
-- **`estimate_mr_harvest()`** — population-scale total harvest from
-  mark-recapture data.
+- **`estimate_effort()`** — total effort with Taylor linearization, bootstrap, or jackknife variance.
+- **`estimate_catch_rate()`**, **`estimate_harvest_rate()`**, **`estimate_release_rate()`** — ratio-based interview estimators.
+- **`estimate_total_catch()`**, **`estimate_total_harvest()`**, **`estimate_total_release()`** — totals via delta-method propagation.
+- **`est_effort_camera()`**, **`est_length_distribution()`** — camera effort indexing and weighted size-structure estimation.
+- **`estimate_exploitation_rate()`** — exploitation rate from tag returns (Pollock et al.; simple and T-weighted stratified paths).
+- **`estimate_angler_n()`** — Petersen and Schnabel mark-recapture population size estimators.
+- **`estimate_mr_harvest()`** — population-scale total harvest from mark-recapture data.
 
 ### Validation and Diagnostics
-
-- **`validate_creel_data()`**, **`validation_report()`**,
-  **`standardize_species()`** — clean and validate real-world creel
-  inputs.
-- **`validate_incomplete_trips()`**, **`validate_design()`**,
-  **`check_completeness()`**, **`compare_variance()`**,
-  **`adjust_nonresponse()`** — QA and estimator diagnostics.
-- **`audit_strata()`**, **`simulate_strata_collapse()`**,
-  **`reallocate_strata()`** — stratification diagnostics; verify
-  weights, simulate collapse scenarios, and rebalance allocations.
+- **`validate_creel_data()`**, **`validation_report()`**, **`standardize_species()`** — clean and validate real-world creel inputs.
+- **`validate_incomplete_trips()`**, **`validate_design()`**, **`check_completeness()`**, **`compare_variance()`**, **`adjust_nonresponse()`** — QA and estimator diagnostics.
+- **`audit_strata()`**, **`simulate_strata_collapse()`**, **`reallocate_strata()`** — stratification diagnostics; verify weights, simulate collapse scenarios, and rebalance allocations.
 
 ### Planning and Reporting
-
-- **`generate_schedule()`**, **`generate_bus_schedule()`**,
-  **`generate_count_times()`**, **`attach_count_times()`** —
-  planning/scheduling helpers.
-- **`creel_n_effort()`**, **`creel_n_cpue()`**, **`creel_n_camera()`**,
-  **`creel_power()`**, **`cv_from_n()`** — sample-size and power tools.
-- **`season_summary()`**, **`summary.creel_estimates()`**,
-  **`write_estimates()`** — report-ready summary/export helpers.
-- **`autoplot.creel_estimates()`**, **`autoplot.creel_schedule()`**,
-  **`autoplot.creel_length_distribution()`**, **`theme_creel()`**,
-  **`creel_palette()`** — visualisation helpers.
+- **`generate_schedule()`**, **`generate_bus_schedule()`**, **`generate_count_times()`**, **`attach_count_times()`** — planning/scheduling helpers.
+- **`creel_n_effort()`**, **`creel_n_cpue()`**, **`creel_n_camera()`**, **`creel_power()`**, **`cv_from_n()`** — sample-size and power tools.
+- **`season_summary()`**, **`summary.creel_estimates()`**, **`write_estimates()`** — report-ready summary/export helpers.
+- **`autoplot.creel_estimates()`**, **`autoplot.creel_schedule()`**, **`autoplot.creel_length_distribution()`**, **`theme_creel()`**, **`creel_palette()`** — visualisation helpers.
 
 ## Vignettes
 
 ### Get Started
 
 | Vignette | Description |
-|----|----|
+|---|---|
 | [Getting Started](https://chrischizinski.github.io/tidycreel/articles/tidycreel.html) | Core workflow: design → counts → effort estimation |
 | [Glossary](https://chrischizinski.github.io/tidycreel/articles/glossary.html) | Plain-language guide to tidycreel terms and concepts |
 
 ### Survey Types
 
 | Vignette | Description |
-|----|----|
+|---|---|
 | [Bus-Route Surveys](https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html) | PPS site selection with Horvitz-Thompson estimators |
 | [Ice Fishing](https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html) | Certainty-site (degenerate bus-route) design |
 | [Camera Surveys](https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html) | Counter and ingress-egress preprocessing, count imputation, camera effort |
@@ -322,7 +184,7 @@ estimate_catch_rate(design)
 ### Estimation
 
 | Vignette | Description |
-|----|----|
+|---|---|
 | [Survey Integration](https://chrischizinski.github.io/tidycreel/articles/survey-tidycreel.html) | Using tidycreel alongside the `survey` package directly |
 | [Interview Estimation](https://chrischizinski.github.io/tidycreel/articles/interview-estimation.html) | CPUE, catch, and harvest from interview data |
 | [Mark-Recapture and Exploitation Rate](https://chrischizinski.github.io/tidycreel/articles/mark-recapture.html) | Chapman, Petersen, Schnabel estimators; MR harvest; exploitation rate from tag returns |
@@ -335,7 +197,7 @@ estimate_catch_rate(design)
 ### Reporting & Planning
 
 | Vignette | Description |
-|----|----|
+|---|---|
 | [Unextrapolated Summaries](https://chrischizinski.github.io/tidycreel/articles/unextrapolated-summaries.html) | Raw interview summaries without season-level expansion |
 | [Survey Design Toolbox](https://chrischizinski.github.io/tidycreel/articles/survey-design-toolbox.html) | Sample-size, power, scheduling, and pre-season planning tools |
 | [Survey Scheduling](https://chrischizinski.github.io/tidycreel/articles/survey-scheduling.html) | Count windows, schedules, validation, and completeness checks |
@@ -344,7 +206,7 @@ estimate_catch_rate(design)
 ### Statistical Methods
 
 | Vignette | Description |
-|----|----|
+|---|---|
 | [Effort Pipeline](https://chrischizinski.github.io/tidycreel/articles/effort-pipeline.html) | Statistical mechanics of the effort estimation pipeline |
 | [Catch Pipeline](https://chrischizinski.github.io/tidycreel/articles/catch-pipeline.html) | Statistical mechanics of the catch estimation pipeline |
 | [Replicate Designs](https://chrischizinski.github.io/tidycreel/articles/replicate-designs.html) | Variance workflows and replicate-design reasoning |
@@ -353,7 +215,7 @@ estimate_catch_rate(design)
 ### Ecosystem
 
 | Vignette | Description |
-|----|----|
+|---|---|
 | [tidycreel.connect](https://chrischizinski.github.io/tidycreel/articles/tidycreel-connect.html) | Database integration and reproducible data pipelines |
 
 ## Getting Help and Reporting Bugs
@@ -364,55 +226,52 @@ If you have questions about which survey type to use, how to interpret
 results, or how to structure your data, the best place to start is
 **GitHub Discussions**:
 
-> <https://github.com/chrischizinski/tidycreel/discussions>
+> https://github.com/chrischizinski/tidycreel/discussions
 
-GitHub Discussions works like a threaded forum attached to the
-repository. If you do not already have a GitHub account, you can create
-one for free at <https://github.com/signup> — it only requires an email
-address. Once signed in, click **New discussion**, select the **Q&A**
-category, and describe what you are trying to do. Searching existing
-threads first is worth a moment; your question may already have an
-answer.
+GitHub Discussions works like a threaded forum attached to the repository.
+If you do not already have a GitHub account, you can create one for free at
+https://github.com/signup — it only requires an email address. Once signed
+in, click **New discussion**, select the **Q&A** category, and describe what
+you are trying to do. Searching existing threads first is worth a moment;
+your question may already have an answer.
 
 ### Reporting a bug or unexpected result
 
-If a function returns an error, produces a result that does not look
-right, or behaves differently from what the documentation describes,
-please open a **GitHub Issue**:
+If a function returns an error, produces a result that does not look right,
+or behaves differently from what the documentation describes, please open a
+**GitHub Issue**:
 
-> <https://github.com/chrischizinski/tidycreel/issues>
+> https://github.com/chrischizinski/tidycreel/issues
 
 **Step-by-step for first-time GitHub users:**
 
-1.  Go to the Issues link above. If you are not signed in, click **Sign
-    in** in the top-right corner (or **Sign up** if you do not yet have
-    an account).
-2.  Click the green **New issue** button.
-3.  Select the **Bug report** template — it will open a pre-filled form.
-4.  Fill in each section of the form:
-    - **Survey type** — which design you are using (`instantaneous`,
-      `bus_route`, `ice`, `camera`, or `aerial`)
-    - **tidycreel version** — run `packageVersion("tidycreel")` in R and
-      paste the result (e.g., `1.6.0`)
-    - **What you expected** — describe the output or behavior you
-      expected
-    - **What actually happened** — paste the full error message, or
-      describe the result that does not look right
-    - **Reproducible example** — a short R snippet that shows the
-      problem (see below)
-5.  Click **Submit new issue** at the bottom of the form.
+1. Go to the Issues link above. If you are not signed in, click **Sign in**
+   in the top-right corner (or **Sign up** if you do not yet have an account).
+2. Click the green **New issue** button.
+3. Select the **Bug report** template — it will open a pre-filled form.
+4. Fill in each section of the form:
+   - **Survey type** — which design you are using (`instantaneous`,
+     `bus_route`, `ice`, `camera`, or `aerial`)
+   - **tidycreel version** — run `packageVersion("tidycreel")` in R and
+     paste the result (e.g., `1.6.0`)
+   - **What you expected** — describe the output or behavior you expected
+   - **What actually happened** — paste the full error message, or describe
+     the result that does not look right
+   - **Reproducible example** — a short R snippet that shows the problem
+     (see below)
+5. Click **Submit new issue** at the bottom of the form.
 
 **Writing a reproducible example**
 
-The single most useful thing you can include is a short, self-contained
-R snippet that demonstrates the problem without needing your real data.
-Use the package’s built-in example datasets (`example_calendar`,
-`example_counts`, `example_interviews`, etc.) wherever possible, or
-create a small data frame that triggers the issue.
+The single most useful thing you can include is a short, self-contained R
+snippet that demonstrates the problem without needing your real data. Use
+the package's built-in example datasets (`example_calendar`,
+`example_counts`, `example_interviews`, etc.) wherever possible, or create a
+small data frame that triggers the issue.
 
 A good example looks like this:
 
-``` r
+```r
 library(tidycreel)
 
 design <- creel_design(example_calendar, date = date, strata = day_type)
@@ -423,13 +282,12 @@ estimate_effort(design)
 #> Error: ...  (paste the full error message here)
 ```
 
-The snippet should run from scratch without any additional files or
-setup. If reducing your data to a minimal example is not
-straightforward, share what you have and describe the context — that is
-still very helpful. The `reprex` package can automatically format and
-share R output if you want a polished submission: install it with
-`install.packages("reprex")` and run `reprex::reprex()` around your
-code.
+The snippet should run from scratch without any additional files or setup.
+If reducing your data to a minimal example is not straightforward, share
+what you have and describe the context — that is still very helpful. The
+`reprex` package can automatically format and share R output if you want a
+polished submission: install it with `install.packages("reprex")` and run
+`reprex::reprex()` around your code.
 
 For guidance on contributing code, requesting new features, or the
 development workflow, see
@@ -441,15 +299,15 @@ MIT License — see [LICENSE.md](LICENSE.md) for details.
 
 ## AI Use Acknowledgement
 
-Artificial intelligence tools were used during the development of
-tidycreel, primarily through Claude Code (Anthropic), with selected code
-and outputs reviewed using Codex (OpenAI). These tools supported code
-refinement, consistency across functions, GitHub Actions workflows,
-error checking, and the development of testing infrastructure.
+Artificial intelligence tools were used during the development of tidycreel,
+primarily through Claude Code (Anthropic), with selected code and outputs
+reviewed using Codex (OpenAI). These tools supported code refinement,
+consistency across functions, GitHub Actions workflows, error checking, and
+the development of testing infrastructure.
 
-All functions and analytical outputs have been reviewed by the author
-team and validated against real-world creel survey data and expected
-analytical behavior. Despite these review and testing efforts, errors
-may still occur. If you identify a problem or unexpected result, please
+All functions and analytical outputs have been reviewed by the author team
+and validated against real-world creel survey data and expected analytical
+behavior. Despite these review and testing efforts, errors may still occur.
+If you identify a problem or unexpected result, please
 [submit an issue](https://github.com/chrischizinski/tidycreel/issues) so
 that it can be reviewed and addressed.

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,2 @@
+[format]
+line-width = 100

--- a/inst/quarto/templates/creel-report/README.md
+++ b/inst/quarto/templates/creel-report/README.md
@@ -1,0 +1,18 @@
+# Creel Report template
+
+This starter template shows how to build a Quarto creel report with `tidycreel`.
+
+It is intentionally aligned with the package surface:
+
+- `creel_design()`
+- `add_counts()`
+- `add_interviews()`
+- `add_catch()`
+- `add_lengths()`
+- `validation_report()`
+- `summarize_*()` helpers
+- `estimate_*()` helpers
+- `season_summary()`
+- `autoplot()` methods with `theme = "creel"`
+
+Replace the example data imports in `template.qmd` with your own project data.

--- a/inst/quarto/templates/creel-report/template.qmd
+++ b/inst/quarto/templates/creel-report/template.qmd
@@ -1,0 +1,378 @@
+---
+title: "Creel Report"
+subtitle: "A tidycreel Quarto starter template"
+author: "Your Name"
+date: today
+format:
+  pdf:
+    toc: true
+    toc-depth: 3
+    number-sections: true
+    colorlinks: true
+    geometry: margin=1in
+  html:
+    toc: true
+    toc-depth: 3
+    number-sections: true
+    theme: [cosmo, theme.scss]
+execute:
+  echo: false
+  warning: false
+  message: false
+  freeze: auto
+---
+
+```{r setup}
+library(tidycreel)
+library(ggplot2)
+library(knitr)
+
+data(example_calendar)
+data(example_counts)
+data(example_interviews)
+data(example_catch)
+data(example_lengths)
+
+# Replace these example objects with your own project data imports.
+calendar <- example_calendar
+counts <- example_counts
+interviews <- example_interviews
+catch <- example_catch
+lengths <- example_lengths
+
+design <- creel_design(calendar, date = date, strata = day_type)
+design <- add_counts(design, counts)
+design <- add_interviews(
+  design,
+  interviews,
+  catch = catch_total,
+  effort = hours_fished,
+  harvest = catch_kept,
+  trip_status = trip_status,
+  trip_duration = trip_duration,
+  angler_type = angler_type,
+  angler_method = angler_method,
+  species_sought = species_sought,
+  n_anglers = n_anglers,
+  refused = refused
+)
+design <- add_catch(
+  design,
+  catch,
+  catch_uid = interview_id,
+  interview_uid = interview_id,
+  species = species,
+  count = count,
+  catch_type = catch_type
+)
+design <- add_lengths(
+  design,
+  lengths,
+  length_uid = interview_id,
+  interview_uid = interview_id,
+  species = species,
+  length = length,
+  length_type = length_type,
+  count = count,
+  release_format = "binned"
+)
+
+design_table <- data.frame(
+  Metric = c(
+    "Survey type",
+    "Date column",
+    "Strata",
+    "Calendar days",
+    "Calendar range",
+    "Count records",
+    "Interview records",
+    "Catch records",
+    "Length records"
+  ),
+  Value = c(
+    design$design_type,
+    design$date_col,
+    paste(design$strata_cols, collapse = ", "),
+    nrow(design$calendar),
+    paste(range(design$calendar[[design$date_col]]), collapse = " to "),
+    nrow(design$counts),
+    nrow(design$interviews),
+    nrow(design$catch),
+    nrow(design$lengths)
+  ),
+  stringsAsFactors = FALSE
+)
+
+maybe <- function(expr, required = character()) {
+  if (length(required) > 0L && !all(required %in% names(design$interviews))) {
+    return(NULL)
+  }
+  tryCatch(expr, error = function(e) NULL)
+}
+
+validation <- validation_report(
+  counts = counts,
+  interviews = interviews
+)
+trip_summary <- summarize_trips(design)
+refusal_summary <- maybe(summarize_refusals(design))
+day_type_summary <- maybe(summarize_by_day_type(design), required = "day_type")
+angler_type_summary <- maybe(summarize_by_angler_type(design), required = "angler_type")
+method_summary <- maybe(summarize_by_method(design), required = "angler_method")
+species_sought_summary <- maybe(
+  summarize_by_species_sought(design),
+  required = "species_sought"
+)
+trip_length_summary <- maybe(summarize_by_trip_length(design), required = "trip_duration")
+successful_parties_summary <- maybe(
+  summarize_successful_parties(design),
+  required = c("angler_type", "species_sought")
+)
+cws_month_species_summary <- maybe(
+  summarize_cws_rates(design, by = c(month, species_sought)),
+  required = "species_sought"
+)
+cws_group_summary <- maybe(
+  summarize_cws_rates(design, by = c(month, angler_type, species_sought)),
+  required = c("angler_type", "species_sought")
+)
+hws_month_species_summary <- maybe(
+  summarize_hws_rates(design, by = c(month, species_sought)),
+  required = "species_sought"
+)
+hws_group_summary <- maybe(
+  summarize_hws_rates(design, by = c(month, angler_type, species_sought)),
+  required = c("angler_type", "species_sought")
+)
+length_catch_summary <- maybe(
+  summarize_length_freq(design, type = "catch", by = species, bin_width = 25),
+  required = "species"
+)
+length_harvest_summary <- maybe(
+  summarize_length_freq(design, type = "harvest", by = species, bin_width = 25),
+  required = "species"
+)
+length_release_summary <- maybe(
+  summarize_length_freq(design, type = "release", by = species, bin_width = 25),
+  required = "species"
+)
+
+effort_total <- estimate_effort(design)
+effort_by_day <- estimate_effort(design, by = day_type)
+angler_trips <- estimate_angler_trips(effort_total, design)
+catch_rate_by_species <- maybe(
+  estimate_catch_rate(design, by = species_sought),
+  required = "species_sought"
+)
+harvest_rate_by_species <- maybe(
+  estimate_harvest_rate(design, by = species_sought),
+  required = "species_sought"
+)
+release_rate_by_species <- maybe(
+  estimate_release_rate(design, by = species_sought),
+  required = "species_sought"
+)
+total_catch <- estimate_total_catch(design)
+total_harvest <- estimate_total_harvest(design)
+total_release <- estimate_total_release(design)
+season_totals <- season_summary(list(
+  effort = effort_total,
+  trips = angler_trips,
+  catch = total_catch,
+  harvest = total_harvest,
+  release = total_release
+))
+```
+
+## Design Parameters
+
+Replace the example data imports in the setup chunk with your own survey tables, then keep the report structure and `tidycreel` calls intact.
+
+```{r design-parameters}
+knitr::kable(design_table, col.names = c("Metric", "Value"))
+```
+
+## Data Validation
+
+```{r validation-report}
+knitr::kable(as.data.frame(validation))
+```
+
+## Unextrapolated Summaries
+
+### Trip Summary
+
+```{r trip-summary}
+knitr::kable(
+  data.frame(
+    Metric = c("Total interviews", "Complete trips", "Incomplete trips", "Complete share"),
+    Value = c(
+      trip_summary$n_total,
+      trip_summary$n_complete,
+      trip_summary$n_incomplete,
+      sprintf("%.1f%%", trip_summary$pct_complete)
+    ),
+    stringsAsFactors = FALSE
+  )
+)
+```
+
+### Refusals
+
+```{r refusals}
+if (!is.null(refusal_summary)) knitr::kable(as.data.frame(refusal_summary))
+```
+
+### By Day Type
+
+```{r by-day-type}
+if (!is.null(day_type_summary)) knitr::kable(as.data.frame(day_type_summary))
+```
+
+### By Angler Type
+
+```{r by-angler-type}
+if (!is.null(angler_type_summary)) knitr::kable(as.data.frame(angler_type_summary))
+```
+
+### By Angler Method
+
+```{r by-method}
+if (!is.null(method_summary)) knitr::kable(as.data.frame(method_summary))
+```
+
+### By Species Sought
+
+```{r by-species-sought}
+if (!is.null(species_sought_summary)) knitr::kable(as.data.frame(species_sought_summary))
+```
+
+### Successful Parties
+
+```{r successful-parties}
+if (!is.null(successful_parties_summary)) knitr::kable(as.data.frame(successful_parties_summary))
+```
+
+### Trip Length
+
+```{r trip-length}
+if (!is.null(trip_length_summary)) knitr::kable(as.data.frame(trip_length_summary))
+```
+
+## Length Frequencies
+
+### Catch
+
+```{r length-catch}
+if (!is.null(length_catch_summary)) knitr::kable(as.data.frame(length_catch_summary))
+```
+
+### Harvest
+
+```{r length-harvest}
+if (!is.null(length_harvest_summary)) knitr::kable(as.data.frame(length_harvest_summary))
+```
+
+### Release
+
+```{r length-release}
+if (!is.null(length_release_summary)) knitr::kable(as.data.frame(length_release_summary))
+```
+
+## Caught-while-sought and Harvest-while-sought
+
+### CWS Rates by Month and Species Sought
+
+```{r cws-month-species}
+if (!is.null(cws_month_species_summary)) knitr::kable(as.data.frame(cws_month_species_summary))
+```
+
+### CWS Rates by Month, Angler Type, and Species Sought
+
+```{r cws-group}
+if (!is.null(cws_group_summary)) knitr::kable(as.data.frame(cws_group_summary))
+```
+
+### HWS Rates by Month and Species Sought
+
+```{r hws-month-species}
+if (!is.null(hws_month_species_summary)) knitr::kable(as.data.frame(hws_month_species_summary))
+```
+
+### HWS Rates by Month, Angler Type, and Species Sought
+
+```{r hws-group}
+if (!is.null(hws_group_summary)) knitr::kable(as.data.frame(hws_group_summary))
+```
+
+## Extrapolated Estimates
+
+### Effort
+
+```{r effort-total}
+ggplot2::autoplot(
+  effort_total,
+  title = "Estimated total effort",
+  theme = "creel"
+)
+```
+
+```{r effort-by-day}
+ggplot2::autoplot(
+  effort_by_day,
+  title = "Effort by day type",
+  theme = "creel"
+)
+```
+
+### Angler Trips
+
+```{r angler-trips}
+ggplot2::autoplot(
+  angler_trips,
+  title = "Estimated angler trips",
+  theme = "creel"
+)
+```
+
+### Catch, Harvest, and Release
+
+```{r catch-rate}
+if (!is.null(catch_rate_by_species)) {
+  ggplot2::autoplot(
+    catch_rate_by_species,
+    title = "Catch rate by species sought",
+    theme = "creel"
+  )
+}
+```
+
+```{r harvest-rate}
+if (!is.null(harvest_rate_by_species)) {
+  ggplot2::autoplot(
+    harvest_rate_by_species,
+    title = "Harvest rate by species sought",
+    theme = "creel"
+  )
+}
+```
+
+```{r release-rate}
+if (!is.null(release_rate_by_species)) {
+  ggplot2::autoplot(
+    release_rate_by_species,
+    title = "Release rate by species sought",
+    theme = "creel"
+  )
+}
+```
+
+```{r total-estimates}
+knitr::kable(season_totals$table)
+```
+
+## Notes
+
+- Use the example data as a working starting point, then swap in your own calendar, count, interview, catch, and length tables.
+- Keep the `creel_design()` through `season_summary()` workflow so the report stays aligned with `tidycreel`.
+- Prefer `theme = "creel"` for plots so the report matches package styling.

--- a/inst/quarto/templates/creel-report/theme.scss
+++ b/inst/quarto/templates/creel-report/theme.scss
@@ -1,0 +1,6 @@
+$primary: #0b3b5e;
+$link-color: #f47d65;
+$headings-color: #1f5e80;
+$body-color: #1f2933;
+$font-size-base: 1rem;
+$border-radius: 0.375rem;

--- a/justfile
+++ b/justfile
@@ -32,3 +32,19 @@ security:
 # Incremental: only fetches creels not already in ~/.cache/tidycreel/ngpc_creel_inventory.rds
 refresh-inventory:
     Rscript data-raw/ngpc_creel_inventory.R
+
+# Show all files with needs-review status in REVIEW-MANIFEST.md
+review-status:
+    @grep "needs-review" .ai/REVIEW-MANIFEST.md | grep "^| R/" | awk -F'|' '{printf "%-45s tier=%s\n", $2, $7}' || echo "Nothing needs review."
+
+# Update REVIEW-MANIFEST.md after reviewing a file.
+# Usage: just review-update R/foo.R clean "notes here"
+# Performs best-effort row update; on no-match, prints reminder to edit manually.
+review-update file status notes:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sha=$(git log -1 --format="%h" -- "{{file}}")
+    rdate=$(git log -1 --format="%as" -- "{{file}}")
+    today=$(date +%Y-%m-%d)
+    echo "Updating {{file}} -> {{status}} (reviewed $today)"
+    python3 scripts/review_update.py "{{file}}" "{{status}}" "{{notes}}" "$sha" "$rdate" "$today"

--- a/man/adjust_nonresponse.Rd
+++ b/man/adjust_nonresponse.Rd
@@ -27,11 +27,11 @@ the stratum.}
 Must be \code{<= n_sampled}.}
 }}
 
-\item{method}{Character. Weighting method to apply. Either
-\code{"postStratify"} (default, adjusts weights to match known stratum
-totals inversely proportional to response rate) or \code{"calibrate"}
-(calibration estimator via \code{survey::calibrate}; requires stratum
-population totals in \code{response_rates}).}
+\item{method}{Character. Weighting method to apply. Currently only
+\code{"postStratify"} (default) is implemented. It multiplies each
+observation's sampling weight by the inverse response rate for its stratum.
+Specifying \code{"calibrate"} raises an error; use \code{survey::calibrate}
+directly with population totals from your sampling frame.}
 
 \item{stratum_col}{Character. Name of the stratum column in
 \code{response_rates} (default: \code{"stratum"}).}

--- a/man/creel_design.Rd
+++ b/man/creel_design.Rd
@@ -18,7 +18,8 @@ creel_design(
   effort_type = NULL,
   camera_mode = NULL,
   h_open = NULL,
-  visibility_correction = NULL
+  visibility_correction = NULL,
+  open_start = NULL
 )
 }
 \arguments{
@@ -93,6 +94,15 @@ the proportion of anglers on the water that are detectable from the
 aircraft. Used only when \code{survey_type = "aerial"}. Defaults to \code{1.0}
 (all anglers visible) when \code{NULL}. A value of 0.85 means 85\% of anglers
 are detected; the effort estimate is scaled up by \eqn{1 / 0.85}.}
+
+\item{open_start}{Optional non-negative numeric scalar specifying the
+hour of day (decimal, 24-hour clock) when the fishery opens. Used only
+when \code{survey_type = "aerial"} and only by \code{\link[=estimate_effort_aerial_glmm]{estimate_effort_aerial_glmm()}}
+to anchor the numerical integration window. If \code{NULL} (default), the
+GLMM estimator derives the window start from the earliest observed flight
+time minus 0.5 hours, with an informational message. Supplying
+\code{open_start} fixes the window across surveys for consistent comparisons.
+Example: \code{open_start = 5.5} means fishing begins at 5:30 AM.}
 }
 \value{
 A \code{creel_design} S3 object (list) with components:
@@ -203,7 +213,7 @@ estimators; pp. 883--884 define the inclusion probability
 \eqn{\pi_i = p_{\text{site}} \times p_{\text{period}}}.
 }
 \seealso{
-Other "Survey Design": 
+Other "Survey Design":
 \code{\link{add_catch}()},
 \code{\link{add_counts}()},
 \code{\link{add_interviews}()},

--- a/man/example_ice_interviews.Rd
+++ b/man/example_ice_interviews.Rd
@@ -5,7 +5,7 @@
 \alias{example_ice_interviews}
 \title{Example interview data for ice fishing creel survey}
 \format{
-A data frame with 72 rows and 10 columns:
+A data frame with 72 rows and 11 columns:
 \describe{
 \item{date}{Interview date (Date class), matching \link{example_ice_sampling_frame}}
 \item{n_counted}{Integer total number of angler parties counted at the

--- a/man/optimal_n.Rd
+++ b/man/optimal_n.Rd
@@ -48,7 +48,9 @@ where \eqn{A = \sum_h N_h s_h / \sqrt{c_h}},
 \eqn{V_0 = (CV_{target} \cdot \hat{E})^2}, \eqn{\hat{E} = \sum_h N_h
 \bar{y}_h}, and \eqn{s_h = \sqrt{s_h^2}}. When all \eqn{c_h = 1}
 (equal costs) this reduces to \eqn{(\sum_h N_h s_h)^2 / (V_0 + \sum_h N_h
-s_h^2)}, identical to \code{\link[=creel_n_effort]{creel_n_effort()}}.
+s_h^2)}, which gives the same \code{n_total} as \code{\link[=creel_n_effort]{creel_n_effort()}} (per-stratum
+allocation differs: Neyman uses \eqn{n_h \propto N_h s_h} vs proportional
+\eqn{n_h \propto N_h}).
 
 \strong{Per-stratum allocation} uses the cost-adjusted Neyman formula (Cochran
 1977 eq. 5.30):

--- a/man/tidy.creel_estimates.Rd
+++ b/man/tidy.creel_estimates.Rd
@@ -13,7 +13,9 @@
 }
 \value{
 A tibble with one row per estimate. All columns from
-\code{x$estimates} are returned unchanged. Required columns:
+\code{x$estimates} are returned, plus \code{n} padded to
+\code{NA_integer_} when the estimator does not produce a sample size
+(e.g. mark-recapture harvest). Guaranteed columns:
 \code{estimate}, \code{se}, \code{ci_lower}, \code{ci_upper}, \code{n}.
 }
 \description{

--- a/man/write_schedule.Rd
+++ b/man/write_schedule.Rd
@@ -4,7 +4,7 @@
 \alias{write_schedule}
 \title{Write a creel schedule to a CSV or xlsx file}
 \usage{
-write_schedule(schedule, path, format = c("csv", "xlsx"))
+write_schedule(schedule, path, format = c("csv", "xlsx"), overwrite = FALSE)
 }
 \arguments{
 \item{schedule}{A \code{creel_schedule} object (or plain data frame) to export.}
@@ -15,6 +15,9 @@ write_schedule(schedule, path, format = c("csv", "xlsx"))
 is written with \code{\link[utils:write.table]{utils::write.csv()}} (no row names). When \code{"xlsx"},
 \code{\link[writexl:write_xlsx]{writexl::write_xlsx()}} is used behind an \code{\link[rlang:is_installed]{rlang::check_installed()}}
 guard.}
+
+\item{overwrite}{Logical. If \code{FALSE} (default), aborts with an error when
+\code{path} already exists. Set \code{TRUE} to replace an existing file.}
 }
 \value{
 \code{path}, returned invisibly.
@@ -37,7 +40,7 @@ write_schedule(sched, tmp)
 
 }
 \seealso{
-Other "Scheduling": 
+Other "Scheduling":
 \code{\link{attach_count_times}()},
 \code{\link{generate_bus_schedule}()},
 \code{\link{generate_count_times}()},

--- a/scripts/review_update.py
+++ b/scripts/review_update.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Update a row in .ai/REVIEW-MANIFEST.md after a function review."""
+import re
+import sys
+
+def main():
+    if len(sys.argv) != 7:
+        print("Usage: review_update.py <file> <status> <notes> <sha> <commit_date> <review_date>")
+        sys.exit(1)
+
+    rfile, status, notes, sha, commit_date, review_date = sys.argv[1:]
+    manifest = ".ai/REVIEW-MANIFEST.md"
+
+    with open(manifest) as fh:
+        text = fh.read()
+
+    # Match the row for this file (any current values in SHA/date/reviewed/reviewer/status cols)
+    escaped = re.escape(rfile)
+    pattern = (
+        r"(\| " + escaped + r" \| )"
+        r"[a-f0-9]+ \| [0-9-]+ \| "   # last commit sha + date
+        r"[^\|]* \| [^\|]* \| [a-z-]+"  # last reviewed + reviewer + status
+        r"( \|[^\n]*)"
+    )
+    replacement = (
+        r"\g<1>"
+        f"{sha} | {commit_date} | {review_date} | claude-opus-4 | {status}"
+        r"\g<2>"
+    )
+
+    new_text, count = re.subn(pattern, replacement, text)
+    if count == 0:
+        print(f"WARNING: row for {rfile} not matched — edit .ai/REVIEW-MANIFEST.md manually")
+        print(f"  Expected row starting with: | {rfile} |")
+        sys.exit(0)
+
+    # Also update Notes column if notes provided
+    if notes and notes != '""' and notes != "''":
+        # Find the updated row and tack notes onto the last column
+        # Notes col is the last | ... | segment; replace it
+        notes_pattern = (
+            r"(\| " + escaped + r" \| "
+            + re.escape(sha) + r" \| " + re.escape(commit_date) + r" \| "
+            + re.escape(review_date) + r" \| claude-opus-4 \| " + re.escape(status)
+            + r" \| )[^\n]*(\|)"
+        )
+        notes_repl = r"\g<1>" + f" {notes} " + r"\g<2>"
+        new_text, _ = re.subn(notes_pattern, notes_repl, new_text)
+
+    with open(manifest, "w") as fh:
+        fh.write(new_text)
+
+    print(f"Updated {rfile} -> {status}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/testthat/_snaps/bootstrap-snapshots.md
+++ b/tests/testthat/_snaps/bootstrap-snapshots.md
@@ -33,8 +33,8 @@
     Code
       tidy(result)
     Output
-      # A tibble: 1 x 5
-        parameter     estimate    se ci_lower ci_upper
-        <chr>            <dbl> <dbl>    <dbl>    <dbl>
-      1 total_harvest     326.  81.1     167.     485.
+      # A tibble: 1 x 6
+        parameter     estimate    se ci_lower ci_upper     n
+        <chr>            <dbl> <dbl>    <dbl>    <dbl> <int>
+      1 total_harvest     326.  81.1     167.     485.    NA
 

--- a/tests/testthat/helper-generators.R
+++ b/tests/testthat/helper-generators.R
@@ -9,12 +9,14 @@ build_property_calendar <- function(n_days, start_date = as.Date("2024-06-01")) 
   calendar
 }
 
-build_trip_interviews_for_tests <- function(calendar,
-                                            n_interviews,
-                                            site_ids = NULL,
-                                            circuit_id = NULL,
-                                            catch_total = NULL,
-                                            catch_kept = NULL) {
+build_trip_interviews_for_tests <- function(
+  calendar,
+  n_interviews,
+  site_ids = NULL,
+  circuit_id = NULL,
+  catch_total = NULL,
+  catch_kept = NULL
+) {
   interview_dates <- sample(rep(calendar$date, length.out = n_interviews))
   interview_day_type <- calendar$day_type[match(interview_dates, calendar$date)]
   n_anglers <- sample(1:3, n_interviews, replace = TRUE)
@@ -77,8 +79,14 @@ build_trip_interviews_for_tests <- function(calendar,
 
 species_pool_for_tests <- function(n_species) {
   base_species <- c(
-    "bass", "panfish", "walleye", "perch", "crappie",
-    "trout", "catfish", "bluegill"
+    "bass",
+    "panfish",
+    "walleye",
+    "perch",
+    "crappie",
+    "trout",
+    "catfish",
+    "bluegill"
   )
 
   if (n_species <= length(base_species)) {
@@ -164,9 +172,12 @@ build_br_design_for_tests <- function(n_sites, n_days, n_interviews, seed = NULL
   }
 
   stopifnot(
-    is.numeric(n_sites), n_sites >= 2,
-    is.numeric(n_days), n_days >= 4,
-    is.numeric(n_interviews), n_interviews >= 2
+    is.numeric(n_sites),
+    n_sites >= 2,
+    is.numeric(n_days),
+    n_days >= 4,
+    is.numeric(n_interviews),
+    n_interviews >= 2
   )
 
   n_sites <- as.integer(n_sites)
@@ -221,18 +232,18 @@ build_br_design_for_tests <- function(n_sites, n_days, n_interviews, seed = NULL
   )
 }
 
-build_multispecies_design_for_tests <- function(n_days,
-                                                n_interviews,
-                                                n_species = 3L,
-                                                seed = NULL) {
+build_multispecies_design_for_tests <- function(n_days, n_interviews, n_species = 3L, seed = NULL) {
   if (!is.null(seed)) {
     set.seed(seed)
   }
 
   stopifnot(
-    is.numeric(n_days), n_days >= 4,
-    is.numeric(n_interviews), n_interviews >= 10,
-    is.numeric(n_species), n_species >= 2
+    is.numeric(n_days),
+    n_days >= 4,
+    is.numeric(n_interviews),
+    n_interviews >= 10,
+    is.numeric(n_species),
+    n_species >= 2
   )
 
   n_days <- as.integer(n_days)
@@ -241,7 +252,7 @@ build_multispecies_design_for_tests <- function(n_days,
 
   dates <- seq.Date(as.Date("2024-06-01"), by = "day", length.out = n_days)
   calendar <- data.frame(
-    date     = dates,
+    date = dates,
     day_type = rep_len(c("weekday", "weekend"), n_days),
     stringsAsFactors = FALSE
   )
@@ -304,18 +315,23 @@ build_multispecies_design_for_tests <- function(n_days,
   )
 }
 
-build_multistrata_multispecies_design_for_tests <- function(n_days,
-                                                           n_interviews,
-                                                           n_species = 3L,
-                                                           seed = NULL) {
+build_multistrata_multispecies_design_for_tests <- function(
+  n_days,
+  n_interviews,
+  n_species = 3L,
+  seed = NULL
+) {
   if (!is.null(seed)) {
     set.seed(seed)
   }
 
   stopifnot(
-    is.numeric(n_days), n_days >= 4,
-    is.numeric(n_interviews), n_interviews >= 10,
-    is.numeric(n_species), n_species >= 2
+    is.numeric(n_days),
+    n_days >= 4,
+    is.numeric(n_interviews),
+    n_interviews >= 10,
+    is.numeric(n_species),
+    n_species >= 2
   )
 
   n_days <- as.integer(n_days)
@@ -472,8 +488,10 @@ build_ice_design <- function(n_days, n_interviews, seed = NULL) {
   }
 
   stopifnot(
-    is.numeric(n_days), n_days >= 4,
-    is.numeric(n_interviews), n_interviews >= 10
+    is.numeric(n_days),
+    n_days >= 4,
+    is.numeric(n_interviews),
+    n_interviews >= 10
   )
 
   n_days <- as.integer(n_days)
@@ -517,8 +535,10 @@ build_br_degenerate_design <- function(n_days, n_interviews, seed = NULL) {
   }
 
   stopifnot(
-    is.numeric(n_days), n_days >= 4,
-    is.numeric(n_interviews), n_interviews >= 10
+    is.numeric(n_days),
+    n_days >= 4,
+    is.numeric(n_interviews),
+    n_interviews >= 10
   )
 
   n_days <- as.integer(n_days)

--- a/tests/testthat/test-add-ages.R
+++ b/tests/testthat/test-add-ages.R
@@ -9,7 +9,9 @@ make_design <- function() {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -20,9 +22,9 @@ make_design <- function() {
 make_ages <- function(interview_ids = 1:5) {
   data.frame(
     interview_id = interview_ids,
-    species      = "walleye",
-    est_age      = c(2L, 4L, 3L, 5L, 2L)[seq_along(interview_ids)],
-    fate         = "harvest",
+    species = "walleye",
+    est_age = c(2L, 4L, 3L, 5L, 2L)[seq_along(interview_ids)],
+    fate = "harvest",
     stringsAsFactors = FALSE
   )
 }
@@ -31,22 +33,40 @@ make_ages <- function(interview_ids = 1:5) {
 
 test_that("add_ages() errors when design is not creel_design", {
   expect_error(
-    add_ages(list(), make_ages(),
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      list(),
+      make_ages(),
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "creel_design"
   )
 })
 
 test_that("add_ages() errors when ages already attached", {
   d <- make_design()
-  d2 <- add_ages(d, make_ages(),
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  d2 <- add_ages(
+    d,
+    make_ages(),
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_error(
-    add_ages(d2, make_ages(),
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      d2,
+      make_ages(),
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "already has age data"
   )
 })
@@ -57,9 +77,15 @@ test_that("add_ages() errors when interviews not attached", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   expect_error(
-    add_ages(d_bare, make_ages(),
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      d_bare,
+      make_ages(),
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "Interviews must be attached"
   )
 })
@@ -69,9 +95,15 @@ test_that("add_ages() errors when age_type has invalid values", {
   bad <- make_ages()
   bad$fate <- "dead"
   expect_error(
-    add_ages(d, bad,
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      d,
+      bad,
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "Invalid"
   )
 })
@@ -80,9 +112,15 @@ test_that("add_ages() errors when age_uid references interview not in design", {
   d <- make_design()
   bad <- make_ages(interview_ids = c(1, 2, 9999))
   expect_error(
-    add_ages(d, bad,
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      d,
+      bad,
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "not found in design interviews"
   )
 })
@@ -92,9 +130,15 @@ test_that("add_ages() errors when age values are non-numeric", {
   bad <- make_ages()
   bad$est_age <- c("two", "four", "three", "five", "two")
   expect_error(
-    add_ages(d, bad,
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      d,
+      bad,
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "must be numeric"
   )
 })
@@ -104,9 +148,15 @@ test_that("add_ages() errors when age values are negative", {
   bad <- make_ages()
   bad$est_age[1] <- -1L
   expect_error(
-    add_ages(d, bad,
-      age_uid = interview_id, interview_uid = interview_id,
-      species = species, age = est_age, age_type = fate),
+    add_ages(
+      d,
+      bad,
+      age_uid = interview_id,
+      interview_uid = interview_id,
+      species = species,
+      age = est_age,
+      age_type = fate
+    ),
     "non-negative"
   )
 })
@@ -115,27 +165,45 @@ test_that("add_ages() errors when age values are negative", {
 
 test_that("add_ages() returns a creel_design object", {
   d <- make_design()
-  result <- add_ages(d, make_ages(),
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  result <- add_ages(
+    d,
+    make_ages(),
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_s3_class(result, "creel_design")
 })
 
 test_that("add_ages() attaches data to design$ages", {
   d <- make_design()
   ages <- make_ages()
-  result <- add_ages(d, ages,
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  result <- add_ages(
+    d,
+    ages,
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_false(is.null(result$ages))
   expect_equal(nrow(result$ages), nrow(ages))
 })
 
 test_that("add_ages() stores correct column-name slots", {
   d <- make_design()
-  result <- add_ages(d, make_ages(),
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  result <- add_ages(
+    d,
+    make_ages(),
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_equal(result$ages_uid_col, "interview_id")
   expect_equal(result$ages_interview_uid_col, "interview_id")
   expect_equal(result$ages_species_col, "species")
@@ -145,9 +213,15 @@ test_that("add_ages() stores correct column-name slots", {
 
 test_that("add_ages() is immutable — original design unchanged", {
   d <- make_design()
-  add_ages(d, make_ages(),
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  add_ages(
+    d,
+    make_ages(),
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_null(d$ages)
 })
 
@@ -155,9 +229,15 @@ test_that("add_ages() normalises age_type to lowercase", {
   d <- make_design()
   ages <- make_ages()
   ages$fate <- "Harvest"
-  result <- add_ages(d, ages,
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  result <- add_ages(
+    d,
+    ages,
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_true(all(result$ages$fate == "harvest"))
 })
 
@@ -165,9 +245,15 @@ test_that("add_ages() accepts age = 0 (age-0 fish)", {
   d <- make_design()
   ages <- make_ages()
   ages$est_age[1] <- 0L
-  result <- add_ages(d, ages,
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  result <- add_ages(
+    d,
+    ages,
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_equal(result$ages$est_age[1], 0L)
 })
 
@@ -175,8 +261,14 @@ test_that("add_ages() accepts release age_type", {
   d <- make_design()
   ages <- make_ages()
   ages$fate <- "release"
-  result <- add_ages(d, ages,
-    age_uid = interview_id, interview_uid = interview_id,
-    species = species, age = est_age, age_type = fate)
+  result <- add_ages(
+    d,
+    ages,
+    age_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    age = est_age,
+    age_type = fate
+  )
   expect_s3_class(result, "creel_design")
 })

--- a/tests/testthat/test-add-catch.R
+++ b/tests/testthat/test-add-catch.R
@@ -9,7 +9,9 @@ make_design_with_interviews <- function() {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -31,18 +33,28 @@ minimal_catch <- data.frame(
 
 test_that("add_catch() returns a creel_design", {
   d <- make_design_with_interviews()
-  result <- add_catch(d, minimal_catch,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  result <- add_catch(
+    d,
+    minimal_catch,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   expect_s3_class(result, "creel_design")
 })
 
 test_that("add_catch() stores catch data on design$catch", {
   d <- make_design_with_interviews()
-  result <- add_catch(d, minimal_catch,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  result <- add_catch(
+    d,
+    minimal_catch,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   expect_equal(nrow(result$catch), 2L)
   expect_true("interview_id" %in% names(result$catch))
@@ -50,9 +62,14 @@ test_that("add_catch() stores catch data on design$catch", {
 
 test_that("add_catch() sets all $catch_*_col fields", {
   d <- make_design_with_interviews()
-  result <- add_catch(d, minimal_catch,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  result <- add_catch(
+    d,
+    minimal_catch,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   expect_equal(result$catch_uid_col, "interview_id")
   expect_equal(result$catch_interview_uid_col, "interview_id")
@@ -65,9 +82,14 @@ test_that("add_catch() works with example_catch dataset (CATCH-01)", {
   data(example_catch, package = "tidycreel")
   d <- make_design_with_interviews()
   expect_no_error(
-    add_catch(d, example_catch,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      example_catch,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     )
   )
 })
@@ -75,12 +97,20 @@ test_that("add_catch() works with example_catch dataset (CATCH-01)", {
 test_that("interviews with no catch rows are valid (CATCH-01)", {
   d <- make_design_with_interviews()
   one_row <- data.frame(
-    interview_id = 1L, species = "walleye", count = 5L,
-    catch_type = "caught", stringsAsFactors = FALSE
+    interview_id = 1L,
+    species = "walleye",
+    count = 5L,
+    catch_type = "caught",
+    stringsAsFactors = FALSE
   )
-  result <- add_catch(d, one_row,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  result <- add_catch(
+    d,
+    one_row,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   expect_equal(nrow(result$catch), 1L)
 })
@@ -89,23 +119,38 @@ test_that("interviews with no catch rows are valid (CATCH-01)", {
 
 test_that("add_catch() does not modify the original design", {
   d <- make_design_with_interviews()
-  add_catch(d, minimal_catch,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  add_catch(
+    d,
+    minimal_catch,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   expect_null(d[["catch"]])
 })
 
 test_that("add_catch() errors when catch already attached", {
   d <- make_design_with_interviews()
-  d2 <- add_catch(d, minimal_catch,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  d2 <- add_catch(
+    d,
+    minimal_catch,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   expect_error(
-    add_catch(d2, minimal_catch,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d2,
+      minimal_catch,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "already has catch"
   )
@@ -117,9 +162,14 @@ test_that("add_catch() errors when no interviews attached", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   expect_error(
-    add_catch(d, minimal_catch,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      minimal_catch,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "Interviews must be attached"
   )
@@ -130,13 +180,21 @@ test_that("add_catch() errors when no interviews attached", {
 test_that("add_catch() errors on unmatched interview IDs (CATCH-02)", {
   d <- make_design_with_interviews()
   bad <- data.frame(
-    interview_id = 999L, species = "walleye", count = 1L,
-    catch_type = "caught", stringsAsFactors = FALSE
+    interview_id = 999L,
+    species = "walleye",
+    count = 1L,
+    catch_type = "caught",
+    stringsAsFactors = FALSE
   )
   expect_error(
-    add_catch(d, bad,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      bad,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "not found in design interviews"
   )
@@ -154,9 +212,14 @@ test_that("add_catch() normalizes catch_type to lowercase silently (CATCH-03)", 
     stringsAsFactors = FALSE
   )
   result <- expect_no_warning(
-    add_catch(d, mixed_case,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      mixed_case,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     )
   )
   expect_true(all(result$catch$catch_type %in% c("caught", "harvested", "released")))
@@ -165,14 +228,21 @@ test_that("add_catch() normalizes catch_type to lowercase silently (CATCH-03)", 
 test_that("add_catch() errors on invalid catch_type after normalization (CATCH-03)", {
   d <- make_design_with_interviews()
   bad_type <- data.frame(
-    interview_id = 1L, species = "walleye", count = 1L,
+    interview_id = 1L,
+    species = "walleye",
+    count = 1L,
     catch_type = "KEPT",
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_catch(d, bad_type,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      bad_type,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "Invalid.*catch_type"
   )
@@ -190,9 +260,14 @@ test_that("add_catch() errors when caught < harvested (CATCH-04)", {
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_catch(d, bad,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      bad,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "Harvest \\+ release exceeds"
   )
@@ -208,9 +283,14 @@ test_that("add_catch() errors when caught < released (CATCH-04)", {
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_catch(d, bad,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      bad,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "Harvest \\+ release exceeds"
   )
@@ -219,13 +299,21 @@ test_that("add_catch() errors when caught < released (CATCH-04)", {
 test_that("add_catch() allows harvested rows with no caught row (CATCH-04)", {
   d <- make_design_with_interviews()
   harvest_only <- data.frame(
-    interview_id = 1L, species = "walleye", count = 5L,
-    catch_type = "harvested", stringsAsFactors = FALSE
+    interview_id = 1L,
+    species = "walleye",
+    count = 5L,
+    catch_type = "harvested",
+    stringsAsFactors = FALSE
   )
   expect_no_error(
-    add_catch(d, harvest_only,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      harvest_only,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     )
   )
 })
@@ -240,9 +328,14 @@ test_that("add_catch() allows caught == harvested + released (CATCH-04)", {
     stringsAsFactors = FALSE
   )
   expect_no_error(
-    add_catch(d, exact,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      exact,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     )
   )
 })
@@ -252,9 +345,14 @@ test_that("add_catch() allows caught == harvested + released (CATCH-04)", {
 test_that("print shows Catch Data section when attached (CATCH-05)", {
   data(example_catch, package = "tidycreel")
   d <- make_design_with_interviews()
-  d2 <- add_catch(d, example_catch,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  d2 <- add_catch(
+    d,
+    example_catch,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   )
   out <- capture.output(print(d2))
   expect_true(any(grepl("Catch Data", out)))
@@ -272,13 +370,21 @@ test_that("print omits Catch Data section when not attached (CATCH-05)", {
 test_that("add_catch() warns when catch totals diverge from interview-level catch", {
   d <- make_design_with_interviews()
   diverged <- data.frame(
-    interview_id = 1L, species = "walleye", count = 99L,
-    catch_type = "caught", stringsAsFactors = FALSE
+    interview_id = 1L,
+    species = "walleye",
+    count = 99L,
+    catch_type = "caught",
+    stringsAsFactors = FALSE
   )
   expect_warning(
-    add_catch(d, diverged,
-      catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-      species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+    add_catch(
+      d,
+      diverged,
+      catch_uid = interview_id,
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species,
+      count = count,
+      catch_type = catch_type # nolint: object_usage_linter
     ),
     regexp = "diverge"
   )

--- a/tests/testthat/test-add-counts.R
+++ b/tests/testthat/test-add-counts.R
@@ -4,8 +4,14 @@
 make_test_calendar <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -17,8 +23,14 @@ make_test_calendar <- function() {
 make_test_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     count = c(15, 23, 18, 21, 45, 52, 48, 51),
@@ -225,8 +237,14 @@ test_that("survey object has correct strata - single stratum", {
 test_that("survey object has correct strata - multiple strata", {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     season = rep(c("spring", "summer"), 4)
@@ -235,8 +253,14 @@ test_that("survey object has correct strata - multiple strata", {
 
   counts <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     season = rep(c("spring", "summer"), 4),
@@ -412,8 +436,14 @@ test_that("add_counts() aborts when count_type = 'progressive' and circuit_time 
 make_progressive_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     n_anglers = c(15L, 23L, 18L, 21L, 45L, 52L, 48L, 51L),
@@ -427,7 +457,8 @@ test_that("add_counts() accepts count_type = 'progressive' with required args (C
   prog_counts <- make_progressive_counts()
   expect_no_error(
     add_counts(
-      design, prog_counts,
+      design,
+      prog_counts,
       count_type = "progressive",
       circuit_time = 2,
       period_length_col = shift_hours # nolint: object_usage_linter
@@ -451,7 +482,8 @@ test_that("add_counts() replaces raw counts with Ê_d = count × period_length f
   expected_effort <- prog_counts$n_anglers * prog_counts$shift_hours
 
   d <- add_counts(
-    design, prog_counts,
+    design,
+    prog_counts,
     count_type = "progressive",
     circuit_time = 2,
     period_length_col = shift_hours # nolint: object_usage_linter
@@ -463,7 +495,8 @@ test_that("add_counts() replaces raw counts with Ê_d = count × period_length f
 test_that("add_counts() drops period_length_col from design$counts after progressive computation", {
   design <- creel_design(make_test_calendar(), date = date, strata = day_type)
   d <- add_counts(
-    design, make_progressive_counts(),
+    design,
+    make_progressive_counts(),
     count_type = "progressive",
     circuit_time = 2,
     period_length_col = shift_hours # nolint: object_usage_linter
@@ -474,7 +507,8 @@ test_that("add_counts() drops period_length_col from design$counts after progres
 test_that("add_counts() stores circuit_time and period_length_col slots (CNT-03)", {
   design <- creel_design(make_test_calendar(), date = date, strata = day_type)
   d <- add_counts(
-    design, make_progressive_counts(),
+    design,
+    make_progressive_counts(),
     count_type = "progressive",
     circuit_time = 2,
     period_length_col = shift_hours # nolint: object_usage_linter
@@ -489,7 +523,8 @@ test_that("add_counts() aborts when count_time_col and count_type = 'progressive
   prog_counts$circuit_id <- rep(c("am", "pm"), length.out = nrow(prog_counts))
   expect_error(
     add_counts(
-      design, prog_counts,
+      design,
+      prog_counts,
       count_time_col = circuit_id, # nolint: object_usage_linter
       count_type = "progressive",
       circuit_time = 2,
@@ -505,7 +540,8 @@ test_that("add_counts() aborts when period_length column contains non-positive v
   bad_counts$shift_hours[1] <- 0
   expect_error(
     add_counts(
-      design, bad_counts,
+      design,
+      bad_counts,
       count_type = "progressive",
       circuit_time = 2,
       period_length_col = shift_hours # nolint: object_usage_linter

--- a/tests/testthat/test-add-interviews.R
+++ b/tests/testthat/test-add-interviews.R
@@ -7,7 +7,9 @@ make_interview_test_calendar <- function() {
   data.frame(
     date = dates,
     day_type = ifelse(
-      weekdays(dates) %in% c("Saturday", "Sunday"), "weekend", "weekday"
+      weekdays(dates) %in% c("Saturday", "Sunday"),
+      "weekend",
+      "weekday"
     ),
     stringsAsFactors = FALSE
   )
@@ -17,16 +19,31 @@ make_interview_test_calendar <- function() {
 make_test_interviews <- function() {
   data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04",
-      "2025-07-05", "2025-07-06", "2025-07-07", "2025-07-08",
-      "2025-07-09", "2025-07-10"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04",
+      "2025-07-05",
+      "2025-07-06",
+      "2025-07-07",
+      "2025-07-08",
+      "2025-07-09",
+      "2025-07-10"
     )),
     hours_fished = c(2.0, 2.5, 3.0, 1.5, 2.0, 2.5, 3.0, 1.5, 2.0, 2.5),
     catch_total = c(5, 3, 7, 2, 6, 4, 8, 1, 5, 3),
     catch_kept = c(2, 1, 5, 2, 4, 2, 6, 1, 3, 2),
     trip_status = c(
-      "complete", "complete", "incomplete", "complete", "complete",
-      "incomplete", "complete", "complete", "complete", "incomplete"
+      "complete",
+      "complete",
+      "incomplete",
+      "complete",
+      "complete",
+      "incomplete",
+      "complete",
+      "complete",
+      "complete",
+      "incomplete"
     ),
     trip_duration = c(2.0, 2.5, 1.5, 1.5, 2.0, 1.0, 3.0, 1.5, 2.0, 1.0),
     stringsAsFactors = FALSE
@@ -45,9 +62,12 @@ test_that("add_interviews returns creel_design S3 class", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_s3_class(result, "creel_design")
@@ -58,9 +78,12 @@ test_that("add_interviews attaches interview data to $interviews slot", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_false(is.null(result$interviews))
@@ -73,9 +96,12 @@ test_that("add_interviews constructs interview survey.design2 object eagerly", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_false(is.null(result$interview_survey))
@@ -87,9 +113,12 @@ test_that("add_interviews preserves immutability - original design unchanged", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_null(design$interviews)
@@ -103,7 +132,10 @@ test_that("add_interviews works with named arguments", {
   result <- add_interviews(
     design,
     interviews = interviews,
-    catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_s3_class(result, "creel_design")
@@ -115,9 +147,12 @@ test_that("add_interviews retains all original design fields", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_identical(result$calendar, design$calendar)
@@ -132,9 +167,12 @@ test_that("add_interviews stores catch_col and effort_col correctly", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_equal(result$catch_col, "catch_total")
@@ -146,9 +184,12 @@ test_that("add_interviews stores interview_type correctly (defaults to access)",
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_equal(result$interview_type, "access")
@@ -159,9 +200,12 @@ test_that("add_interviews works without harvest column (harvest = NULL)", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_null(result$harvest_col)
@@ -173,9 +217,13 @@ test_that("add_interviews stores harvest_col when provided", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_equal(result$harvest_col, "catch_kept")
@@ -188,7 +236,10 @@ test_that("add_interviews works when counts already attached (parallel streams)"
   # First add some counts
   counts <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-05", "2025-07-06"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-05",
+      "2025-07-06"
     )),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     count = c(15, 23, 45, 52)
@@ -197,8 +248,12 @@ test_that("add_interviews works when counts already attached (parallel streams)"
 
   # Then add interviews
   result <- add_interviews(
-    design_with_counts, interviews,
-    catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+    design_with_counts,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_false(is.null(result$counts))
@@ -210,9 +265,12 @@ test_that("add_interviews joins interviews with calendar data (strata inherited)
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   # Check that calendar strata are present in joined interviews
@@ -228,16 +286,22 @@ test_that("add_interviews errors when interviews already attached", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_error(
     add_interviews(
-      result, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      result,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "already"
   )
@@ -249,9 +313,12 @@ test_that("add_interviews errors when design is not creel_design class", {
 
   expect_error(
     add_interviews(
-      fake_design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      fake_design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "creel_design"
   )
@@ -267,9 +334,12 @@ test_that("add_interviews errors when interview data has no Date column", {
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "Date"
   )
@@ -295,9 +365,12 @@ test_that("add_interviews errors when date_col from design not found in intervie
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "date"
   )
@@ -310,9 +383,12 @@ test_that("add_interviews errors when catch column not found in data", {
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "catch_total"
   )
@@ -325,9 +401,12 @@ test_that("add_interviews errors when effort column not found in data", {
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "hours_fished"
   )
@@ -340,9 +419,12 @@ test_that("add_interviews errors when date column contains NA values", {
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "NA"
   )
@@ -356,9 +438,12 @@ test_that("add_interviews errors when interview dates not in calendar", {
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "not found in design calendar"
   )
@@ -373,9 +458,13 @@ test_that("add_interviews errors when harvest > catch", {
 
   expect_error(
     add_interviews(
-      design, bad_interviews,
-      catch = catch_total, effort = hours_fished, harvest = catch_kept,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      bad_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      harvest = catch_kept,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "Harvest exceeds catch"
   )
@@ -388,9 +477,12 @@ test_that("interview_survey has correct class (survey.design2)", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_s3_class(result$interview_survey, "survey.design2")
@@ -401,9 +493,12 @@ test_that("interview_survey uses ~1 for ids (terminal units, no clustering)", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   # Check that ids formula is ~1 (terminal sampling units)
@@ -415,9 +510,12 @@ test_that("interview_survey has correct strata (from calendar join)", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   # Survey object should have strata based on day_type
@@ -431,9 +529,12 @@ test_that("add_interviews stores validation results in $validation slot", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_s3_class(result$validation, "creel_validation")
@@ -444,9 +545,12 @@ test_that("validation$passed is TRUE when interviews are valid", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_true(result$validation$passed)
@@ -457,9 +561,12 @@ test_that("validation$tier is 1L (integer Tier 1)", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_identical(result$validation$tier, 1L)
@@ -473,7 +580,9 @@ test_that("example_interviews works with example_calendar in complete workflow",
 
   design <- creel_design(example_calendar, date = date, strata = day_type)
   result <- suppressWarnings({
-    add_interviews(design, example_interviews,
+    add_interviews(
+      design,
+      example_interviews,
       catch = catch_total,
       effort = hours_fished,
       harvest = catch_kept,
@@ -515,9 +624,12 @@ test_that("add_interviews stores trip_status_col in design object", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_equal(result$trip_status_col, "trip_status")
@@ -528,9 +640,12 @@ test_that("add_interviews stores trip_duration_col in design object", {
   interviews <- make_test_interviews()
 
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
 
   expect_equal(result$trip_duration_col, "trip_duration")
@@ -540,15 +655,26 @@ test_that("trip_status normalized to lowercase (uppercase input)", {
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   interviews$trip_status <- c(
-    "Complete", "COMPLETE", "INCOMPLETE", "Complete", "Complete",
-    "incomplete", "COMPLETE", "Complete", "complete", "Incomplete"
+    "Complete",
+    "COMPLETE",
+    "INCOMPLETE",
+    "Complete",
+    "Complete",
+    "incomplete",
+    "COMPLETE",
+    "Complete",
+    "complete",
+    "Incomplete"
   )
 
   result <- suppressWarnings({
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     )
   })
 
@@ -560,17 +686,28 @@ test_that("case-insensitive trip_status accepted (Complete, COMPLETE, complete)"
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   interviews$trip_status <- c(
-    "Complete", "COMPLETE", "complete", "Incomplete", "INCOMPLETE",
-    "incomplete", "Complete", "complete", "INCOMPLETE", "Incomplete"
+    "Complete",
+    "COMPLETE",
+    "complete",
+    "Incomplete",
+    "INCOMPLETE",
+    "incomplete",
+    "Complete",
+    "complete",
+    "INCOMPLETE",
+    "Incomplete"
   )
 
   # Should not error (message is expected informational output)
   expect_no_error({
     result <- suppressWarnings({
       add_interviews(
-        design, interviews,
-        catch = catch_total, effort = hours_fished,
-        trip_status = trip_status, trip_duration = trip_duration
+        design,
+        interviews,
+        catch = catch_total,
+        effort = hours_fished,
+        trip_status = trip_status,
+        trip_duration = trip_duration
       )
     })
   })
@@ -582,9 +719,12 @@ test_that("trip status summary message emitted", {
 
   expect_message(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "Added.*interview"
   )
@@ -597,9 +737,12 @@ test_that("trip status summary message shows correct counts", {
   # 7 complete, 3 incomplete
   expect_message(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "7 complete.*3 incomplete"
   )
@@ -612,9 +755,12 @@ test_that("trip status summary message shows correct percentages", {
   # 7 complete (70%), 3 incomplete (30%)
   expect_message(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "70%.*30%"
   )
@@ -630,9 +776,14 @@ test_that("duration calculated from trip_start + interview_time (POSIXct)", {
   interviews$trip_duration <- NULL # Remove direct duration
 
   result <- suppressWarnings({
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     )
   })
 
@@ -651,9 +802,14 @@ test_that("calculated duration stored as numeric hours", {
   interviews$trip_duration <- NULL
 
   result <- suppressWarnings({
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     )
   })
 
@@ -672,9 +828,14 @@ test_that("trip_start_col and interview_time_col stored when provided", {
   interviews$trip_duration <- NULL
 
   result <- suppressWarnings({
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     )
   })
 
@@ -691,9 +852,12 @@ test_that("error when trip_status column has invalid values", {
 
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "invalid value.*finished"
   )
@@ -706,9 +870,12 @@ test_that("error when trip_status column has NA values", {
 
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "NA value"
   )
@@ -723,10 +890,15 @@ test_that("error when both trip_duration AND trip_start are provided (mutually e
   interviews$interview_time <- interviews$trip_start + interviews$trip_duration * 3600
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
-      trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
+      trip_start = trip_start,
+      interview_time = interview_time
     ),
     "Provide either.*not both"
   )
@@ -740,9 +912,13 @@ test_that("error when trip_start provided without interview_time", {
   interviews$trip_duration <- NULL
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start
     ),
     "trip_start requires interview_time"
   )
@@ -756,9 +932,13 @@ test_that("error when interview_time provided without trip_start", {
   interviews$trip_duration <- NULL
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      interview_time = interview_time
     ),
     "interview_time requires trip_start"
   )
@@ -771,9 +951,12 @@ test_that("error when trip_duration has negative values", {
 
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "negative values"
   )
@@ -786,9 +969,12 @@ test_that("error when trip_duration < 1/60 hours (less than 1 minute)", {
 
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "less than 1 minute"
   )
@@ -801,9 +987,12 @@ test_that("error when trip_duration has NA values", {
 
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "NA value"
   )
@@ -818,9 +1007,14 @@ test_that("error when calculated duration is negative (interview_time < trip_sta
   interviews$trip_duration <- NULL
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     ),
     "negative"
   )
@@ -835,9 +1029,14 @@ test_that("error when calculated duration < 1 minute", {
   interviews$trip_duration <- NULL
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     ),
     "less than 1 minute"
   )
@@ -852,9 +1051,14 @@ test_that("error when trip_start/interview_time are not POSIXct", {
   interviews$trip_duration <- NULL
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     ),
     "POSIXct"
   )
@@ -867,9 +1071,12 @@ test_that("warning when trip_duration > 48 hours", {
 
   expect_warning(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "48 hours"
   )
@@ -888,9 +1095,14 @@ test_that("overnight trip (start evening, interview next morning) calculates cor
   interviews$interview_time[2:nrow(interviews)] <- as.POSIXct("2025-07-01 10:00:00")
   interviews$trip_duration <- NULL # Force calculation from timestamps
 
-  result <- add_interviews(design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+  result <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_start = trip_start,
+    interview_time = interview_time
   )
 
   duration_col <- result$trip_duration_col
@@ -909,9 +1121,14 @@ test_that("multi-day trip calculates correct duration", {
   interviews$trip_duration <- NULL
 
   expect_warning(
-    result <- add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    result <- add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     ),
     "48 hours"
   )
@@ -931,9 +1148,14 @@ test_that("overnight trip near midnight calculates correct duration", {
   interviews$interview_time[2:nrow(interviews)] <- as.POSIXct("2025-07-01 10:00:00")
   interviews$trip_duration <- NULL
 
-  result <- add_interviews(design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+  result <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_start = trip_start,
+    interview_time = interview_time
   )
 
   duration_col <- result$trip_duration_col
@@ -951,9 +1173,14 @@ test_that("error when trip_start and interview_time have different timezones", {
   interviews$trip_duration <- NULL
 
   expect_error(
-    add_interviews(design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_start = trip_start,
+      interview_time = interview_time
     ),
     regex = "timezone",
     ignore.case = TRUE
@@ -968,9 +1195,14 @@ test_that("same explicit timezone produces correct duration", {
   interviews$interview_time <- as.POSIXct("2025-07-01 10:00:00", tz = "America/Denver")
   interviews$trip_duration <- NULL
 
-  result <- add_interviews(design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+  result <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_start = trip_start,
+    interview_time = interview_time
   )
 
   duration_col <- result$trip_duration_col
@@ -987,9 +1219,14 @@ test_that("UTC timezone works correctly for overnight trips", {
   interviews$interview_time[2:nrow(interviews)] <- as.POSIXct("2025-07-01 10:00:00", tz = "UTC")
   interviews$trip_duration <- NULL
 
-  result <- add_interviews(design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+  result <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_start = trip_start,
+    interview_time = interview_time
   )
 
   duration_col <- result$trip_duration_col
@@ -1027,9 +1264,14 @@ test_that("summarize_trips shows correct statistics for overnight trip data", {
   )
   interviews$trip_duration <- NULL
 
-  result <- add_interviews(design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_start = trip_start, interview_time = interview_time
+  result <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_start = trip_start,
+    interview_time = interview_time
   )
 
   # Call summarize_trips and check it runs without error
@@ -1060,9 +1302,12 @@ test_that("format.creel_design() shows trip status summary when trip metadata pr
 
   result <- suppressWarnings({
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     )
   })
 
@@ -1091,12 +1336,17 @@ make_bus_route_test_design <- function() {
     p_period = rep(0.5, 3),
     stringsAsFactors = FALSE
   )
-  creel_design( # nolint: object_usage_linter
+  creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, circuit = circuit, # nolint: object_usage_linter
-    p_site = p_site, p_period = p_period # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    circuit = circuit, # nolint: object_usage_linter
+    p_site = p_site,
+    p_period = p_period # nolint: object_usage_linter
   )
 }
 
@@ -1122,10 +1372,14 @@ test_that("add_interviews joins pi_i to bus-route interview data", {
   design <- make_bus_route_test_design()
   interviews <- make_bus_route_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   expect_true(".pi_i" %in% names(result$interviews))
   # Site A: p_site=0.3, p_period=0.5 -> pi_i = 0.15
@@ -1136,10 +1390,14 @@ test_that("add_interviews computes .expansion correctly", {
   design <- make_bus_route_test_design()
   interviews <- make_bus_route_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   expect_true(".expansion" %in% names(result$interviews))
   # n_counted=5, n_interviewed=3 -> expansion = 5/3
@@ -1150,10 +1408,14 @@ test_that("add_interviews sets n_counted_col and n_interviewed_col on design", {
   design <- make_bus_route_test_design()
   interviews <- make_bus_route_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   expect_equal(result$n_counted_col, "n_counted")
   expect_equal(result$n_interviewed_col, "n_interviewed")
@@ -1165,10 +1427,14 @@ test_that("n_interviewed = 0 produces NA .expansion without error", {
   interviews$n_counted <- 0L
   interviews$n_interviewed <- 0L
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   expect_true(is.na(result$interviews$.expansion[1]))
 })
@@ -1180,10 +1446,14 @@ test_that("n_counted > 0 and n_interviewed = 0 issues a warning", {
   interviews$n_interviewed <- 0L
   expect_warning(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
-      n_counted = n_counted, n_interviewed = n_interviewed
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
+      n_counted = n_counted,
+      n_interviewed = n_interviewed
     ),
     regexp = "n_counted > 0 but n_interviewed = 0"
   )
@@ -1195,9 +1465,12 @@ test_that("non-bus-route design silently ignores n_counted and n_interviewed", {
   # Should complete without error
   expect_no_error(
     add_interviews(
-      design_std, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+      design_std,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     )
   )
 })
@@ -1209,9 +1482,12 @@ test_that("add_interviews errors when n_counted missing for bus-route design", {
   interviews <- make_bus_route_interviews()
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
       n_interviewed = n_interviewed
       # n_counted omitted
     ),
@@ -1224,9 +1500,12 @@ test_that("add_interviews errors when n_interviewed missing for bus-route design
   interviews <- make_bus_route_interviews()
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
       n_counted = n_counted
       # n_interviewed omitted
     ),
@@ -1240,10 +1519,14 @@ test_that("add_interviews errors when site column missing from interview data", 
   interviews$site <- NULL
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
-      n_counted = n_counted, n_interviewed = n_interviewed
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
+      n_counted = n_counted,
+      n_interviewed = n_interviewed
     ),
     regexp = "missing site column"
   )
@@ -1255,10 +1538,14 @@ test_that("add_interviews errors when circuit column missing from interview data
   interviews$circuit <- NULL
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
-      n_counted = n_counted, n_interviewed = n_interviewed
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
+      n_counted = n_counted,
+      n_interviewed = n_interviewed
     ),
     regexp = "missing circuit column"
   )
@@ -1270,10 +1557,14 @@ test_that("add_interviews errors when n_counted < n_interviewed", {
   interviews$n_counted <- 2L # less than n_interviewed = 3
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
-      n_counted = n_counted, n_interviewed = n_interviewed
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
+      n_counted = n_counted,
+      n_interviewed = n_interviewed
     ),
     regexp = "n_counted must be >= n_interviewed"
   )
@@ -1285,10 +1576,14 @@ test_that("add_interviews errors with site+circuit listing when interview unmatc
   interviews$site <- "ZZZZ" # not in sampling frame
   expect_error(
     add_interviews(
-      design, interviews,
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration,
-      n_counted = n_counted, n_interviewed = n_interviewed
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration,
+      n_counted = n_counted,
+      n_interviewed = n_interviewed
     ),
     regexp = "not found in sampling frame"
   )
@@ -1300,10 +1595,14 @@ test_that("get_enumeration_counts returns data frame with required columns", {
   design <- make_bus_route_test_design()
   interviews <- make_bus_route_interviews()
   d <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   ec <- get_enumeration_counts(d)
   expect_s3_class(ec, "data.frame")
@@ -1318,10 +1617,14 @@ test_that("get_enumeration_counts .expansion values are correct", {
   design <- make_bus_route_test_design()
   interviews <- make_bus_route_interviews()
   d <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   ec <- get_enumeration_counts(d)
   expect_equal(ec$.expansion[1], 5 / 3, tolerance = 1e-10)
@@ -1369,10 +1672,14 @@ test_that("print includes Enumeration Counts section for bus-route with intervie
   design <- make_bus_route_test_design()
   interviews <- make_bus_route_interviews()
   d <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
-    n_counted = n_counted, n_interviewed = n_interviewed
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
+    n_counted = n_counted,
+    n_interviewed = n_interviewed
   )
   out <- capture.output(print(d))
   expect_true(any(grepl("Enumeration Counts", out)))
@@ -1398,9 +1705,12 @@ test_that("add_interviews stores angler_type_col as NULL when angler_type not pr
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
   expect_null(result$angler_type_col)
 })
@@ -1409,9 +1719,12 @@ test_that("add_interviews stores angler_method_col as NULL when angler_method no
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
   expect_null(result$angler_method_col)
 })
@@ -1420,9 +1733,12 @@ test_that("add_interviews stores species_sought_col as NULL when species_sought 
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
   expect_null(result$species_sought_col)
 })
@@ -1431,9 +1747,12 @@ test_that("add_interviews stores n_anglers_col as NULL when n_anglers not provid
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
   expect_null(result$n_anglers_col)
 })
@@ -1442,9 +1761,12 @@ test_that("add_interviews stores refused_col as NULL when refused not provided",
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
   expect_null(result$refused_col)
 })
@@ -1455,9 +1777,12 @@ test_that("add_interviews stores angler_type_col when angler_type provided", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     angler_type = angler_type
   )
   expect_equal(result$angler_type_col, "angler_type")
@@ -1467,9 +1792,12 @@ test_that("add_interviews stores angler_method_col when angler_method provided",
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     angler_method = angler_method
   )
   expect_equal(result$angler_method_col, "angler_method")
@@ -1479,9 +1807,12 @@ test_that("add_interviews stores species_sought_col when species_sought provided
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     species_sought = species_sought
   )
   expect_equal(result$species_sought_col, "species_sought")
@@ -1491,9 +1822,12 @@ test_that("add_interviews stores n_anglers_col when n_anglers provided", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     n_anglers = n_anglers
   )
   expect_equal(result$n_anglers_col, "n_anglers")
@@ -1503,9 +1837,12 @@ test_that("add_interviews stores refused_col when refused provided", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     refused = refused
   )
   expect_equal(result$refused_col, "refused")
@@ -1517,9 +1854,12 @@ test_that("format.creel_design shows angler_type_col when present", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     angler_type = angler_type
   )
   output <- paste(format(result), collapse = "\n")
@@ -1530,9 +1870,12 @@ test_that("format.creel_design shows angler_method_col when present", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     angler_method = angler_method
   )
   output <- paste(format(result), collapse = "\n")
@@ -1543,9 +1886,12 @@ test_that("format.creel_design shows species_sought_col when present", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     species_sought = species_sought
   )
   output <- paste(format(result), collapse = "\n")
@@ -1556,9 +1902,12 @@ test_that("format.creel_design shows n_anglers_col when present", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     n_anglers = n_anglers
   )
   output <- paste(format(result), collapse = "\n")
@@ -1569,9 +1918,12 @@ test_that("format.creel_design shows refused_col when present", {
   design <- make_interview_test_design()
   interviews <- make_extended_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     refused = refused
   )
   output <- paste(format(result), collapse = "\n")
@@ -1584,9 +1936,12 @@ test_that("add_interviews with no new params is backward-compatible with pre-Pha
   design <- make_interview_test_design()
   interviews <- make_test_interviews()
   result <- add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
   expect_null(result$angler_type_col)
   expect_null(result$angler_method_col)
@@ -1609,9 +1964,11 @@ make_camera_counts_design <- function() {
   dates <- unique(cal$date)[1:4]
   day_types <- cal$day_type[match(dates, cal$date)]
 
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "camera",
     camera_mode = "counter"
   )
@@ -1646,8 +2003,10 @@ test_that("CAM-04: add_interviews() on camera design produces non-NULL interview
   design <- make_camera_counts_design() # nolint: object_usage_linter
   interviews <- make_camera_interviews_df() # nolint: object_usage_linter
 
-  result <- add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  result <- add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
@@ -1660,8 +2019,10 @@ test_that("CAM-04: add_interviews() on camera design returns creel_design with i
   design <- make_camera_counts_design() # nolint: object_usage_linter
   interviews <- make_camera_interviews_df() # nolint: object_usage_linter
 
-  result <- add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  result <- add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
@@ -1684,9 +2045,11 @@ make_aerial_counts_design <- function() {
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "aerial",
     h_open = 14
   )
@@ -1708,7 +2071,24 @@ make_aerial_interviews_df <- function() {
     date = rep(as.Date(c("2024-07-01", "2024-07-02", "2024-07-03", "2024-07-04")), each = 4),
     day_type = rep(c("weekday", "weekday", "weekend", "weekend"), each = 4),
     trip_status = rep("complete", 16),
-    hours_fished = c(2.5, 3.0, 1.5, 4.0, 2.0, 3.5, 1.0, 2.5, 3.0, 4.5, 2.0, 3.5, 4.0, 3.0, 2.5, 1.5),
+    hours_fished = c(
+      2.5,
+      3.0,
+      1.5,
+      4.0,
+      2.0,
+      3.5,
+      1.0,
+      2.5,
+      3.0,
+      4.5,
+      2.0,
+      3.5,
+      4.0,
+      3.0,
+      2.5,
+      1.5
+    ),
     walleye = c(0L, 1L, 2L, 0L, 1L, 0L, 3L, 1L, 0L, 2L, 1L, 0L, 3L, 1L, 0L, 2L),
     walleye_kept = c(0L, 1L, 1L, 0L, 1L, 0L, 2L, 1L, 0L, 1L, 1L, 0L, 2L, 1L, 0L, 1L),
     stringsAsFactors = FALSE
@@ -1719,8 +2099,10 @@ test_that("AIR-05: add_interviews() on aerial design produces non-NULL interview
   design <- make_aerial_counts_design() # nolint: object_usage_linter
   interviews <- make_aerial_interviews_df() # nolint: object_usage_linter
 
-  result <- add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  result <- add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
@@ -1733,8 +2115,10 @@ test_that("AIR-05: add_interviews() on aerial design returns creel_design with i
   design <- make_aerial_counts_design() # nolint: object_usage_linter
   interviews <- make_aerial_interviews_df() # nolint: object_usage_linter
 
-  result <- add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  result <- add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter

--- a/tests/testthat/test-add-lengths.R
+++ b/tests/testthat/test-add-lengths.R
@@ -9,7 +9,9 @@ make_design_with_interviews <- function() {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -43,7 +45,9 @@ minimal_lengths_individual <- data.frame(
 
 test_that("add_lengths() returns a creel_design (LEN-01)", {
   d <- make_design_with_interviews()
-  result <- add_lengths(d, minimal_lengths_binned,
+  result <- add_lengths(
+    d,
+    minimal_lengths_binned,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -57,7 +61,9 @@ test_that("add_lengths() returns a creel_design (LEN-01)", {
 
 test_that("add_lengths() stores data on design$lengths (LEN-01)", {
   d <- make_design_with_interviews()
-  result <- add_lengths(d, minimal_lengths_binned,
+  result <- add_lengths(
+    d,
+    minimal_lengths_binned,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -72,7 +78,9 @@ test_that("add_lengths() stores data on design$lengths (LEN-01)", {
 
 test_that("add_lengths() sets all $lengths_*_col fields (LEN-01)", {
   d <- make_design_with_interviews()
-  result <- add_lengths(d, minimal_lengths_binned,
+  result <- add_lengths(
+    d,
+    minimal_lengths_binned,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -94,7 +102,9 @@ test_that("add_lengths() works with example_lengths dataset (LEN-01)", {
   data(example_lengths, package = "tidycreel")
   d <- make_design_with_interviews()
   expect_no_error(
-    add_lengths(d, example_lengths,
+    add_lengths(
+      d,
+      example_lengths,
       length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
       species = species, # nolint: object_usage_linter
@@ -108,7 +118,9 @@ test_that("add_lengths() works with example_lengths dataset (LEN-01)", {
 
 test_that("add_lengths() works without count arg when release_format is individual (LEN-02)", {
   d <- make_design_with_interviews()
-  result <- add_lengths(d, minimal_lengths_individual,
+  result <- add_lengths(
+    d,
+    minimal_lengths_individual,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -123,16 +135,21 @@ test_that("add_lengths() works without count arg when release_format is individu
 test_that("interviews with no length rows are valid (LEN-01)", {
   d <- make_design_with_interviews()
   one_row <- data.frame(
-    interview_id = 1L, species = "walleye", length = "420",
-    length_type = "harvest", count = NA_integer_,
+    interview_id = 1L,
+    species = "walleye",
+    length = "420",
+    length_type = "harvest",
+    count = NA_integer_,
     stringsAsFactors = FALSE
   )
-  result <- add_lengths(d, one_row,
-    length_uid    = interview_id, # nolint: object_usage_linter
+  result <- add_lengths(
+    d,
+    one_row,
+    length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
-    species       = species, # nolint: object_usage_linter
-    length        = length, # nolint: object_usage_linter
-    length_type   = length_type # nolint: object_usage_linter
+    species = species, # nolint: object_usage_linter
+    length = length, # nolint: object_usage_linter
+    length_type = length_type # nolint: object_usage_linter
   )
   expect_equal(nrow(result[["lengths"]]), 1L)
 })
@@ -141,7 +158,9 @@ test_that("interviews with no length rows are valid (LEN-01)", {
 
 test_that("add_lengths() does not modify the original design", {
   d <- make_design_with_interviews()
-  add_lengths(d, minimal_lengths_binned,
+  add_lengths(
+    d,
+    minimal_lengths_binned,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -155,7 +174,9 @@ test_that("add_lengths() does not modify the original design", {
 
 test_that("add_lengths() errors when lengths already attached", {
   d <- make_design_with_interviews()
-  d2 <- add_lengths(d, minimal_lengths_binned,
+  d2 <- add_lengths(
+    d,
+    minimal_lengths_binned,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -165,7 +186,9 @@ test_that("add_lengths() errors when lengths already attached", {
     release_format = "binned"
   )
   expect_error(
-    add_lengths(d2, minimal_lengths_binned,
+    add_lengths(
+      d2,
+      minimal_lengths_binned,
       length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
       species = species, # nolint: object_usage_linter
@@ -184,7 +207,9 @@ test_that("add_lengths() errors when no interviews attached", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   expect_error(
-    add_lengths(d, minimal_lengths_binned,
+    add_lengths(
+      d,
+      minimal_lengths_binned,
       length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
       species = species, # nolint: object_usage_linter
@@ -202,17 +227,22 @@ test_that("add_lengths() errors when no interviews attached", {
 test_that("add_lengths() errors on unmatched interview IDs (LEN-03)", {
   d <- make_design_with_interviews()
   bad <- data.frame(
-    interview_id = 999L, species = "walleye", length = "420",
-    length_type = "harvest", count = NA_integer_,
+    interview_id = 999L,
+    species = "walleye",
+    length = "420",
+    length_type = "harvest",
+    count = NA_integer_,
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, bad,
-      length_uid    = interview_id, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      bad,
+      length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
-      species       = species, # nolint: object_usage_linter
-      length        = length, # nolint: object_usage_linter
-      length_type   = length_type # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type # nolint: object_usage_linter
     ),
     regexp = "not found in design interviews"
   )
@@ -231,12 +261,14 @@ test_that("add_lengths() normalizes length_type to lowercase silently (LEN-04)",
     stringsAsFactors = FALSE
   )
   result <- expect_no_warning(
-    add_lengths(d, mixed_case,
-      length_uid    = interview_id, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      mixed_case,
+      length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
-      species       = species, # nolint: object_usage_linter
-      length        = length, # nolint: object_usage_linter
-      length_type   = length_type # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type # nolint: object_usage_linter
     )
   )
   expect_true(all(result[["lengths"]]$length_type %in% c("harvest", "release")))
@@ -245,17 +277,22 @@ test_that("add_lengths() normalizes length_type to lowercase silently (LEN-04)",
 test_that("add_lengths() errors on invalid length_type after normalization (LEN-04)", {
   d <- make_design_with_interviews()
   bad_type <- data.frame(
-    interview_id = 1L, species = "walleye", length = "420",
-    length_type = "KEPT", count = NA_integer_,
+    interview_id = 1L,
+    species = "walleye",
+    length = "420",
+    length_type = "KEPT",
+    count = NA_integer_,
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, bad_type,
-      length_uid    = interview_id, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      bad_type,
+      length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
-      species       = species, # nolint: object_usage_linter
-      length        = length, # nolint: object_usage_linter
-      length_type   = length_type # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type # nolint: object_usage_linter
     ),
     regexp = "Invalid.*length_type"
   )
@@ -264,12 +301,14 @@ test_that("add_lengths() errors on invalid length_type after normalization (LEN-
 test_that("add_lengths() errors on invalid release_format (LEN-04)", {
   d <- make_design_with_interviews()
   expect_error(
-    add_lengths(d, minimal_lengths_binned,
-      length_uid     = interview_id, # nolint: object_usage_linter
-      interview_uid  = interview_id, # nolint: object_usage_linter
-      species        = species, # nolint: object_usage_linter
-      length         = length, # nolint: object_usage_linter
-      length_type    = length_type, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      minimal_lengths_binned,
+      length_uid = interview_id, # nolint: object_usage_linter
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type, # nolint: object_usage_linter
       release_format = "grouped"
     ),
     regexp = "Invalid.*release_format"
@@ -279,17 +318,22 @@ test_that("add_lengths() errors on invalid release_format (LEN-04)", {
 test_that("add_lengths() errors when harvest length is non-numeric (LEN-04)", {
   d <- make_design_with_interviews()
   bad <- data.frame(
-    interview_id = 1L, species = "walleye", length = "big",
-    length_type = "harvest", count = NA_integer_,
+    interview_id = 1L,
+    species = "walleye",
+    length = "big",
+    length_type = "harvest",
+    count = NA_integer_,
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, bad,
-      length_uid    = interview_id, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      bad,
+      length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
-      species       = species, # nolint: object_usage_linter
-      length        = length, # nolint: object_usage_linter
-      length_type   = length_type # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type # nolint: object_usage_linter
     ),
     regexp = "numeric.*mm"
   )
@@ -298,17 +342,22 @@ test_that("add_lengths() errors when harvest length is non-numeric (LEN-04)", {
 test_that("add_lengths() errors when harvest length is <= 0 (LEN-04)", {
   d <- make_design_with_interviews()
   bad <- data.frame(
-    interview_id = 1L, species = "walleye", length = "0",
-    length_type = "harvest", count = NA_integer_,
+    interview_id = 1L,
+    species = "walleye",
+    length = "0",
+    length_type = "harvest",
+    count = NA_integer_,
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, bad,
-      length_uid    = interview_id, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      bad,
+      length_uid = interview_id, # nolint: object_usage_linter
       interview_uid = interview_id, # nolint: object_usage_linter
-      species       = species, # nolint: object_usage_linter
-      length        = length, # nolint: object_usage_linter
-      length_type   = length_type # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type # nolint: object_usage_linter
     ),
     regexp = "positive"
   )
@@ -324,12 +373,14 @@ test_that("add_lengths() errors when binned release has no count column (LEN-04)
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, no_count,
-      length_uid     = interview_id, # nolint: object_usage_linter
-      interview_uid  = interview_id, # nolint: object_usage_linter
-      species        = species, # nolint: object_usage_linter
-      length         = length, # nolint: object_usage_linter
-      length_type    = length_type, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      no_count,
+      length_uid = interview_id, # nolint: object_usage_linter
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type, # nolint: object_usage_linter
       release_format = "binned"
     ),
     regexp = "count.*required"
@@ -347,13 +398,15 @@ test_that("add_lengths() errors when binned release count is NA (LEN-04)", {
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, na_count,
-      length_uid     = interview_id, # nolint: object_usage_linter
-      interview_uid  = interview_id, # nolint: object_usage_linter
-      species        = species, # nolint: object_usage_linter
-      length         = length, # nolint: object_usage_linter
-      length_type    = length_type, # nolint: object_usage_linter
-      count          = count, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      na_count,
+      length_uid = interview_id, # nolint: object_usage_linter
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type, # nolint: object_usage_linter
+      count = count, # nolint: object_usage_linter
       release_format = "binned"
     ),
     regexp = "count.*not be NA"
@@ -371,13 +424,15 @@ test_that("add_lengths() errors when binned release count is 0 (LEN-04)", {
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, zero_count,
-      length_uid     = interview_id, # nolint: object_usage_linter
-      interview_uid  = interview_id, # nolint: object_usage_linter
-      species        = species, # nolint: object_usage_linter
-      length         = length, # nolint: object_usage_linter
-      length_type    = length_type, # nolint: object_usage_linter
-      count          = count, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      zero_count,
+      length_uid = interview_id, # nolint: object_usage_linter
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type, # nolint: object_usage_linter
+      count = count, # nolint: object_usage_linter
       release_format = "binned"
     ),
     regexp = "positive"
@@ -394,12 +449,14 @@ test_that("add_lengths() errors when individual release length is non-numeric (L
     stringsAsFactors = FALSE
   )
   expect_error(
-    add_lengths(d, bad,
-      length_uid     = interview_id, # nolint: object_usage_linter
-      interview_uid  = interview_id, # nolint: object_usage_linter
-      species        = species, # nolint: object_usage_linter
-      length         = length, # nolint: object_usage_linter
-      length_type    = length_type, # nolint: object_usage_linter
+    add_lengths(
+      d,
+      bad,
+      length_uid = interview_id, # nolint: object_usage_linter
+      interview_uid = interview_id, # nolint: object_usage_linter
+      species = species, # nolint: object_usage_linter
+      length = length, # nolint: object_usage_linter
+      length_type = length_type, # nolint: object_usage_linter
       release_format = "individual"
     ),
     regexp = "numeric.*individual"
@@ -411,7 +468,9 @@ test_that("add_lengths() errors when individual release length is non-numeric (L
 test_that("print shows Length Data section when attached (LEN-05)", {
   data(example_lengths, package = "tidycreel")
   d <- make_design_with_interviews()
-  d2 <- add_lengths(d, example_lengths,
+  d2 <- add_lengths(
+    d,
+    example_lengths,
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter

--- a/tests/testthat/test-add-sections.R
+++ b/tests/testthat/test-add-sections.R
@@ -5,7 +5,10 @@
 make_base_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04"
     )),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
@@ -57,8 +60,10 @@ test_that("add_sections() stores optional description_col name", {
   design <- make_base_design()
   secs <- make_sections_df()
 
-  result <- add_sections(design, secs,
-    section_col     = section, # nolint: object_usage_linter
+  result <- add_sections(
+    design,
+    secs,
+    section_col = section, # nolint: object_usage_linter
     description_col = description # nolint: object_usage_linter
   )
 
@@ -69,9 +74,11 @@ test_that("add_sections() stores optional area_col name", {
   design <- make_base_design()
   secs <- make_sections_df()
 
-  result <- add_sections(design, secs,
+  result <- add_sections(
+    design,
+    secs,
     section_col = section, # nolint: object_usage_linter
-    area_col    = area_ha # nolint: object_usage_linter
+    area_col = area_ha # nolint: object_usage_linter
   )
 
   expect_equal(result$section_area_col, "area_ha")
@@ -81,8 +88,10 @@ test_that("add_sections() stores optional shoreline_col name", {
   design <- make_base_design()
   secs <- make_sections_df()
 
-  result <- add_sections(design, secs,
-    section_col   = section, # nolint: object_usage_linter
+  result <- add_sections(
+    design,
+    secs,
+    section_col = section, # nolint: object_usage_linter
     shoreline_col = shoreline_km # nolint: object_usage_linter
   )
 
@@ -163,9 +172,11 @@ test_that("add_sections() errors when area_col is non-positive", {
   )
 
   expect_error(
-    add_sections(design, secs,
+    add_sections(
+      design,
+      secs,
       section_col = section, # nolint: object_usage_linter
-      area_col    = area_ha # nolint: object_usage_linter
+      area_col = area_ha # nolint: object_usage_linter
     ),
     regexp = "positive"
   )
@@ -180,8 +191,10 @@ test_that("add_sections() errors when shoreline_col is non-positive", {
   )
 
   expect_error(
-    add_sections(design, secs,
-      section_col   = section, # nolint: object_usage_linter
+    add_sections(
+      design,
+      secs,
+      section_col = section, # nolint: object_usage_linter
       shoreline_col = shoreline_km # nolint: object_usage_linter
     ),
     regexp = "positive"
@@ -242,7 +255,8 @@ test_that("add_counts() skips section validation when no sections registered", {
 
 # --- Section validation in add_interviews() ------------------------------------
 
-make_design_with_sections_and_counts <- function() { # nolint: object_length_linter
+make_design_with_sections_and_counts <- function() {
+  # nolint: object_length_linter
   design <- make_design_with_sections()
 
   counts <- data.frame(
@@ -271,9 +285,13 @@ test_that("add_interviews() passes when all section values are registered", {
 
   expect_no_error(
     suppressWarnings(
-      add_interviews(design, interviews, # nolint: object_usage_linter
-        catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-        harvest = catch_kept, trip_status = trip_status # nolint: object_usage_linter
+      add_interviews(
+        design,
+        interviews, # nolint: object_usage_linter
+        catch = catch_total,
+        effort = hours_fished, # nolint: object_usage_linter
+        harvest = catch_kept,
+        trip_status = trip_status # nolint: object_usage_linter
       )
     )
   )
@@ -295,9 +313,13 @@ test_that("add_interviews() errors on unregistered section value", {
 
   expect_error(
     suppressWarnings(
-      add_interviews(design, interviews, # nolint: object_usage_linter
-        catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-        harvest = catch_kept, trip_status = trip_status # nolint: object_usage_linter
+      add_interviews(
+        design,
+        interviews, # nolint: object_usage_linter
+        catch = catch_total,
+        effort = hours_fished, # nolint: object_usage_linter
+        harvest = catch_kept,
+        trip_status = trip_status # nolint: object_usage_linter
       )
     ),
     regexp = "MIAN"

--- a/tests/testthat/test-as-survey-design.R
+++ b/tests/testthat/test-as-survey-design.R
@@ -4,8 +4,14 @@
 make_test_calendar <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -17,8 +23,14 @@ make_test_calendar <- function() {
 make_test_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     count = c(15, 23, 18, 21, 45, 52, 48, 51),
@@ -184,8 +196,14 @@ test_that("multiple strata workflow works with as_survey_design", {
   # Create design with multiple strata
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     season = rep(c("spring", "summer"), 4)
@@ -194,8 +212,14 @@ test_that("multiple strata workflow works with as_survey_design", {
 
   counts <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     season = rep(c("spring", "summer"), 4),

--- a/tests/testthat/test-autoplot-creel-estimates.R
+++ b/tests/testthat/test-autoplot-creel-estimates.R
@@ -10,7 +10,8 @@ make_effort_est <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     design <- add_counts(design, example_counts) # nolint: object_usage_linter
@@ -23,7 +24,8 @@ make_grouped_est <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     design <- add_counts(design, example_counts) # nolint: object_usage_linter
@@ -36,13 +38,16 @@ make_cpue_est <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     design <- add_counts(design, example_counts) # nolint: object_usage_linter
     design <- add_interviews(
-      design, example_interviews, # nolint: object_usage_linter
-      catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
+      design,
+      example_interviews, # nolint: object_usage_linter
+      catch = catch_total,
+      effort = hours_fished, # nolint: object_usage_linter
       trip_status = trip_status # nolint: object_usage_linter
     )
     estimate_catch_rate(design)

--- a/tests/testthat/test-autoplot-creel-schedule.R
+++ b/tests/testthat/test-autoplot-creel-schedule.R
@@ -115,3 +115,20 @@ test_that("SCHED-PLOT-CIRC-03: schedule without circuit_id still uses day_type f
   sampled_fills <- p$data$fill_group[p$data$sampled]
   expect_true(all(sampled_fills %in% c("weekday", "weekend")))
 })
+
+test_that("SCHED-PLOT-SPECIAL-01: special-period day types get distinct colors, not unsampled grey", {
+  sched <- new_creel_schedule(data.frame(
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
+    day_type = c("weekday", "weekend", "tournament"),
+    stringsAsFactors = FALSE
+  ))
+  p <- autoplot(sched)
+  # fill_group in plot data must include "tournament" for the sampled day
+  sampled_fills <- p$data$fill_group[p$data$sampled]
+  expect_true("tournament" %in% sampled_fills)
+  # palette(n) with n = number of fill groups must give tournament a non-grey color
+  fill_scale <- Filter(function(s) "fill" %in% s$aesthetics, p$scales$scales)[[1]]
+  n_groups <- length(unique(p$data$fill_group))
+  palette_vals <- fill_scale$palette(n_groups)
+  expect_false(isTRUE(palette_vals[["tournament"]] == "#cccccc"))
+})

--- a/tests/testthat/test-bootstrap-mr.R
+++ b/tests/testthat/test-bootstrap-mr.R
@@ -1,6 +1,6 @@
 test_that("BOOT-03-chapman: estimate_angler_n Chapman bootstrap returns ci_lo_boot/ci_hi_boot", {
   set.seed(42L)
-  r   <- estimate_angler_n(M = 200L, n = 50L, m = 10L, ci_method = "bootstrap")
+  r <- estimate_angler_n(M = 200L, n = 50L, m = 10L, ci_method = "bootstrap")
   tbl <- tidy(r)
   expect_true(all(c("ci_lo_boot", "ci_hi_boot", "ci_lower", "ci_upper") %in% names(tbl)))
   expect_true(all(tbl$ci_lo_boot < tbl$estimate))
@@ -11,7 +11,7 @@ test_that("BOOT-03-chapman: estimate_angler_n Chapman bootstrap returns ci_lo_bo
 
 test_that("BOOT-03-petersen: estimate_angler_n Petersen bootstrap returns ci_lo_boot/ci_hi_boot", {
   set.seed(42L)
-  r   <- estimate_angler_n(M = 200L, n = 50L, m = 10L, method = "petersen", ci_method = "bootstrap")
+  r <- estimate_angler_n(M = 200L, n = 50L, m = 10L, method = "petersen", ci_method = "bootstrap")
   tbl <- tidy(r)
   expect_true(all(c("ci_lo_boot", "ci_hi_boot", "ci_lower", "ci_upper") %in% names(tbl)))
   expect_true(all(tbl$ci_lo_boot < tbl$estimate))
@@ -23,8 +23,8 @@ test_that("BOOT-03-schnabel: estimate_angler_n Schnabel bootstrap returns ci_lo_
   r <- estimate_angler_n(
     M = c(0L, 200L, 300L, 400L),
     n = c(50L, 50L, 50L, 50L),
-    m = c(0L,  4L,  6L,  8L),
-    method    = "schnabel",
+    m = c(0L, 4L, 6L, 8L),
+    method = "schnabel",
     ci_method = "bootstrap"
   )
   tbl <- tidy(r)
@@ -34,7 +34,7 @@ test_that("BOOT-03-schnabel: estimate_angler_n Schnabel bootstrap returns ci_lo_
 })
 
 test_that("BOOT-03-delta: estimate_angler_n default has no boot columns", {
-  r   <- estimate_angler_n(M = 200L, n = 50L, m = 10L)
+  r <- estimate_angler_n(M = 200L, n = 50L, m = 10L)
   tbl <- tidy(r)
   expect_false("ci_lo_boot" %in% names(tbl))
   expect_false("ci_hi_boot" %in% names(tbl))
@@ -44,8 +44,8 @@ test_that("BOOT-03-delta: estimate_angler_n default has no boot columns", {
 test_that("BOOT-04: estimate_mr_harvest bootstrap returns ci_lo_boot/ci_hi_boot", {
   set.seed(42L)
   angler_n <- estimate_angler_n(M = 200L, n = 50L, m = 10L, ci_method = "bootstrap")
-  result   <- estimate_mr_harvest(angler_n, harvest_rate = 0.35, ci_method = "bootstrap")
-  tbl      <- tidy(result)
+  result <- estimate_mr_harvest(angler_n, harvest_rate = 0.35, ci_method = "bootstrap")
+  tbl <- tidy(result)
   expect_true(all(c("ci_lo_boot", "ci_hi_boot", "ci_lower", "ci_upper") %in% names(tbl)))
   expect_true(all(tbl$ci_lo_boot < tbl$estimate))
   expect_true(all(tbl$estimate < tbl$ci_hi_boot))
@@ -53,8 +53,8 @@ test_that("BOOT-04: estimate_mr_harvest bootstrap returns ci_lo_boot/ci_hi_boot"
 
 test_that("BOOT-04-delta: estimate_mr_harvest default has no boot columns", {
   angler_n <- estimate_angler_n(M = 200L, n = 50L, m = 10L)
-  result   <- estimate_mr_harvest(angler_n, harvest_rate = 0.35)
-  tbl      <- tidy(result)
+  result <- estimate_mr_harvest(angler_n, harvest_rate = 0.35)
+  tbl <- tidy(result)
   expect_false("ci_lo_boot" %in% names(tbl))
 })
 

--- a/tests/testthat/test-bootstrap-snapshots.R
+++ b/tests/testthat/test-bootstrap-snapshots.R
@@ -9,8 +9,8 @@
   suppressMessages(suppressWarnings({
     d <- build_br_design_for_tests(3L, 6L, 8L, seed = 42L)
     counts <- data.frame(
-      date         = d$calendar$date,
-      day_type     = d$calendar$day_type,
+      date = d$calendar$date,
+      day_type = d$calendar$day_type,
       effort_hours = c(15, 20, 18, 22, 16, 19),
       stringsAsFactors = FALSE
     )
@@ -45,6 +45,6 @@ test_that("SNAP-BOOT-03: estimate_angler_n default output is stable", {
 
 test_that("SNAP-BOOT-04: estimate_mr_harvest default output is stable", {
   angler_n <- estimate_angler_n(M = 200L, n = 50L, m = 10L)
-  result   <- estimate_mr_harvest(angler_n, harvest_rate = 0.35)
+  result <- estimate_mr_harvest(angler_n, harvest_rate = 0.35)
   expect_snapshot(tidy(result))
 })

--- a/tests/testthat/test-bootstrap-survey.R
+++ b/tests/testthat/test-bootstrap-survey.R
@@ -7,8 +7,8 @@
   suppressMessages(suppressWarnings({
     d <- build_br_design_for_tests(4L, 8L, 12L, seed = 123L)
     counts <- data.frame(
-      date         = d$calendar$date,
-      day_type     = d$calendar$day_type,
+      date = d$calendar$date,
+      day_type = d$calendar$day_type,
       effort_hours = c(15, 20, 18, 22, 16, 19, 14, 21),
       stringsAsFactors = FALSE
     )
@@ -21,12 +21,12 @@
 test_that("BOOT-01: estimate_total_harvest bootstrap returns ci_lo_boot/ci_hi_boot", {
   d <- .make_br_harvest_boot()
   result <- suppressWarnings(estimate_total_harvest(d, ci_method = "bootstrap"))
-  tbl    <- tidy(result)
+  tbl <- tidy(result)
 
   expect_true("ci_lo_boot" %in% names(tbl))
   expect_true("ci_hi_boot" %in% names(tbl))
-  expect_true("ci_lower"   %in% names(tbl))
-  expect_true("ci_upper"   %in% names(tbl))
+  expect_true("ci_lower" %in% names(tbl))
+  expect_true("ci_upper" %in% names(tbl))
 
   expect_lt(tbl$ci_lo_boot, tbl$estimate)
   expect_gt(tbl$ci_hi_boot, tbl$estimate)
@@ -37,7 +37,7 @@ test_that("BOOT-01: estimate_total_harvest bootstrap returns ci_lo_boot/ci_hi_bo
 test_that("BOOT-01-delta: estimate_total_harvest default has no boot columns", {
   d <- .make_br_harvest_boot()
   result <- suppressWarnings(estimate_total_harvest(d))
-  tbl    <- tidy(result)
+  tbl <- tidy(result)
 
   expect_false("ci_lo_boot" %in% names(tbl))
   expect_false("ci_hi_boot" %in% names(tbl))
@@ -48,12 +48,12 @@ test_that("BOOT-01-delta: estimate_total_harvest default has no boot columns", {
 test_that("BOOT-02: estimate_total_catch bootstrap returns ci_lo_boot/ci_hi_boot", {
   d <- .make_br_harvest_boot()
   result <- suppressWarnings(estimate_total_catch(d, ci_method = "bootstrap"))
-  tbl    <- tidy(result)
+  tbl <- tidy(result)
 
   expect_true("ci_lo_boot" %in% names(tbl))
   expect_true("ci_hi_boot" %in% names(tbl))
-  expect_true("ci_lower"   %in% names(tbl))
-  expect_true("ci_upper"   %in% names(tbl))
+  expect_true("ci_lower" %in% names(tbl))
+  expect_true("ci_upper" %in% names(tbl))
 
   expect_lt(tbl$ci_lo_boot, tbl$estimate)
   expect_gt(tbl$ci_hi_boot, tbl$estimate)
@@ -64,7 +64,7 @@ test_that("BOOT-02: estimate_total_catch bootstrap returns ci_lo_boot/ci_hi_boot
 test_that("BOOT-02-delta: estimate_total_catch default has no boot columns", {
   d <- .make_br_harvest_boot()
   result <- suppressWarnings(estimate_total_catch(d))
-  tbl    <- tidy(result)
+  tbl <- tidy(result)
 
   expect_false("ci_lo_boot" %in% names(tbl))
   expect_false("ci_hi_boot" %in% names(tbl))
@@ -73,9 +73,9 @@ test_that("BOOT-02-delta: estimate_total_catch default has no boot columns", {
 # BOOT-01b: estimate_total_harvest bootstrap with by_vars (grouped path) ------
 
 test_that("BOOT-01b: estimate_total_harvest bootstrap with by_vars returns boot columns per group", {
-  d      <- .make_br_harvest_boot()
+  d <- .make_br_harvest_boot()
   result <- suppressWarnings(estimate_total_harvest(d, by = day_type, ci_method = "bootstrap"))
-  tbl    <- tidy(result)
+  tbl <- tidy(result)
 
   expect_true("ci_lo_boot" %in% names(tbl))
   expect_true("ci_hi_boot" %in% names(tbl))
@@ -87,9 +87,9 @@ test_that("BOOT-01b: estimate_total_harvest bootstrap with by_vars returns boot 
 # BOOT-02b: estimate_total_catch bootstrap with by_vars (grouped path) -------
 
 test_that("BOOT-02b: estimate_total_catch bootstrap with by_vars returns boot columns per group", {
-  d      <- .make_br_harvest_boot()
+  d <- .make_br_harvest_boot()
   result <- suppressWarnings(estimate_total_catch(d, by = day_type, ci_method = "bootstrap"))
-  tbl    <- tidy(result)
+  tbl <- tidy(result)
 
   expect_true("ci_lo_boot" %in% names(tbl))
   expect_true("ci_hi_boot" %in% names(tbl))

--- a/tests/testthat/test-compare-designs.R
+++ b/tests/testthat/test-compare-designs.R
@@ -12,12 +12,12 @@ make_est <- function(estimate, se, label = "test") {
   )
   structure(
     list(
-      estimates       = est_df,
-      method          = label,
+      estimates = est_df,
+      method = label,
       variance_method = "taylor",
-      design          = NULL,
-      conf_level      = 0.95,
-      by_vars         = NULL
+      design = NULL,
+      conf_level = 0.95,
+      by_vars = NULL
     ),
     class = "creel_estimates"
   )
@@ -35,12 +35,12 @@ make_est_grouped <- function() {
   )
   structure(
     list(
-      estimates       = est_df,
-      method          = "grouped",
+      estimates = est_df,
+      method = "grouped",
       variance_method = "taylor",
-      design          = NULL,
-      conf_level      = 0.95,
-      by_vars         = "day_type"
+      design = NULL,
+      conf_level = 0.95,
+      by_vars = "day_type"
     ),
     class = "creel_estimates"
   )
@@ -100,15 +100,24 @@ test_that("CMPD-07: has expected core columns", {
     a = make_est(100, 10),
     b = make_est(200, 20)
   ))
-  expect_true(all(c(
-    "design", "estimate", "se", "rse",
-    "ci_lower", "ci_upper", "ci_width", "n"
-  ) %in% names(res)))
+  expect_true(all(
+    c(
+      "design",
+      "estimate",
+      "se",
+      "rse",
+      "ci_lower",
+      "ci_upper",
+      "ci_width",
+      "n"
+    ) %in%
+      names(res)
+  ))
 })
 
 test_that("CMPD-08: design column matches input names", {
   res <- compare_designs(list(
-    instant  = make_est(100, 10),
+    instant = make_est(100, 10),
     busroute = make_est(200, 20)
   ))
   expect_setequal(res$design, c("instant", "busroute"))
@@ -158,7 +167,7 @@ test_that("CMPD-12: ci_width = ci_upper - ci_lower", {
 test_that("CMPD-13: grouped estimates expand correctly", {
   res <- compare_designs(list(
     grouped = make_est_grouped(),
-    single  = make_est(150, 15)
+    single = make_est(150, 15)
   ))
   # grouped has 2 rows, single has 1 -> total 3
   expect_equal(nrow(res), 3L)
@@ -167,7 +176,7 @@ test_that("CMPD-13: grouped estimates expand correctly", {
 test_that("CMPD-14: group columns retained", {
   res <- compare_designs(list(
     grp = make_est_grouped(),
-    b   = make_est(150, 15)
+    b = make_est(150, 15)
   ))
   expect_true("day_type" %in% names(res))
 })
@@ -198,9 +207,13 @@ test_that("CMPD-17: autoplot includes error bars when CI present", {
     b = make_est(200, 20)
   ))
   p <- autoplot(res)
-  layer_classes <- vapply(p$layers, function(l) {
-    class(l$geom)[1]
-  }, character(1))
+  layer_classes <- vapply(
+    p$layers,
+    function(l) {
+      class(l$geom)[1]
+    },
+    character(1)
+  )
   expect_true(any(grepl("errorbar", layer_classes, ignore.case = TRUE)))
 })
 
@@ -228,8 +241,11 @@ test_that("CMPD-20: handles missing SE gracefully (NA rse)", {
   est_no_se <- structure(
     list(
       estimates = data.frame(estimate = 100, stringsAsFactors = FALSE),
-      method = "test", variance_method = "none",
-      design = NULL, conf_level = 0.95, by_vars = NULL
+      method = "test",
+      variance_method = "none",
+      design = NULL,
+      conf_level = 0.95,
+      by_vars = NULL
     ),
     class = "creel_estimates"
   )

--- a/tests/testthat/test-compare-variance.R
+++ b/tests/testthat/test-compare-variance.R
@@ -3,7 +3,10 @@
 make_cv_design <- function(n = 40, grouped = FALSE) {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04"
     )),
     day_type = rep(c("weekday", "weekend"), each = 2),
     stringsAsFactors = FALSE
@@ -33,10 +36,12 @@ make_cv_design <- function(n = 40, grouped = FALSE) {
   interviews <- as.data.frame(base_cols, stringsAsFactors = FALSE)
 
   suppressMessages(suppressWarnings(
-    add_interviews(design, interviews,
-      catch         = catch_total,
-      effort        = hours_fished,
-      trip_status   = trip_status,
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
       trip_duration = trip_duration
     )
   ))
@@ -87,8 +92,10 @@ test_that("CV-05: diverges_flag = FALSE on uniform toy data", {
   # Taylor and bootstrap SEs should both be near 0
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02",
-      "2024-06-03", "2024-06-04"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04"
     )),
     day_type = rep(c("weekday", "weekend"), each = 2),
     stringsAsFactors = FALSE
@@ -97,8 +104,10 @@ test_that("CV-05: diverges_flag = FALSE on uniform toy data", {
   interviews <- data.frame(
     date = as.Date(rep(
       c(
-        "2024-06-01", "2024-06-02",
-        "2024-06-03", "2024-06-04"
+        "2024-06-01",
+        "2024-06-02",
+        "2024-06-03",
+        "2024-06-04"
       ),
       each = 10
     )),
@@ -109,10 +118,12 @@ test_that("CV-05: diverges_flag = FALSE on uniform toy data", {
     stringsAsFactors = FALSE
   )
   design <- suppressMessages(suppressWarnings(
-    add_interviews(design, interviews,
-      catch         = catch_total,
-      effort        = hours_fished,
-      trip_status   = trip_status,
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
       trip_duration = trip_duration
     )
   ))

--- a/tests/testthat/test-compare-variance.R
+++ b/tests/testthat/test-compare-variance.R
@@ -190,3 +190,22 @@ test_that("CV-12: compare_variance errors on invalid divergence_threshold", {
     regexp = "positive"
   )
 })
+
+# CV-13: se_taylor joined by group key, not positionally paired ----------------
+
+test_that("CV-13: grouped se_taylor in output matches original SE joined by group key", {
+  # This test guards against the positional-pairing bug:
+  # se_taylor and se_replicate must be matched by group key, not row index.
+  set.seed(42)
+  design <- make_cv_design(grouped = TRUE)
+  est <- suppressWarnings(estimate_catch_rate(design, by = day_type))
+  cmp <- suppressWarnings(compare_variance(est))
+
+  # Join compare_variance output back to original estimates on day_type
+  original_se <- est$estimates[, c("day_type", "se")]
+  compared_se <- as.data.frame(cmp)[, c("day_type", "se_taylor")]
+  joined <- merge(original_se, compared_se, by = "day_type")
+
+  # se_taylor must equal the original se for every stratum, regardless of row order
+  expect_equal(joined$se, joined$se_taylor, tolerance = 1e-10)
+})

--- a/tests/testthat/test-creel-design.R
+++ b/tests/testthat/test-creel-design.R
@@ -1357,6 +1357,48 @@ describe("Phase 47: Aerial constructor", {
     )
     expect_equal(d$design_type, "aerial")
   })
+
+  it("AIR-04: open_start stored in design$aerial$open_start", {
+    d <- creel_design(make_aerial_cal(),
+      date = date, strata = day_type,
+      survey_type = "aerial",
+      h_open = 14,
+      open_start = 5.5
+    )
+    expect_equal(d$aerial$open_start, 5.5)
+  })
+
+  it("AIR-04: open_start = NULL stored as NULL in design$aerial", {
+    d <- creel_design(make_aerial_cal(),
+      date = date, strata = day_type,
+      survey_type = "aerial",
+      h_open = 14
+    )
+    expect_null(d$aerial$open_start)
+  })
+
+  it("AIR-04: open_start = -1 aborts (not non-negative)", {
+    expect_error(
+      creel_design(make_aerial_cal(),
+        date = date, strata = day_type,
+        survey_type = "aerial",
+        h_open = 14,
+        open_start = -1
+      ),
+      regexp = "open_start"
+    )
+  })
+
+  it("AIR-04: open_start = 0 is accepted (midnight opening)", {
+    expect_no_error(
+      creel_design(make_aerial_cal(),
+        date = date, strata = day_type,
+        survey_type = "aerial",
+        h_open = 14,
+        open_start = 0
+      )
+    )
+  })
 })
 
 # ---- NA-weight diagnostics: bus-route inclusion probabilities ----------------

--- a/tests/testthat/test-creel-design.R
+++ b/tests/testthat/test-creel-design.R
@@ -288,10 +288,15 @@ make_br_cal <- function() {
 }
 
 test_that("creel_design() accepts survey_type = 'bus_route' with valid inputs", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
 
   expect_s3_class(d, "creel_design")
@@ -300,10 +305,15 @@ test_that("creel_design() accepts survey_type = 'bus_route' with valid inputs", 
 })
 
 test_that("bus_route slot contains data frame with .pi_i column", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
 
   expect_true(is.data.frame(d$bus_route$data))
@@ -312,10 +322,15 @@ test_that("bus_route slot contains data frame with .pi_i column", {
 })
 
 test_that("bus_route slot stores correct column mappings", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
 
   expect_equal(d$bus_route$site_col, "site")
@@ -325,10 +340,15 @@ test_that("bus_route slot stores correct column mappings", {
 })
 
 test_that("omitting circuit column defaults to single .default circuit", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
 
   expect_equal(d$bus_route$circuit_col, ".circuit")
@@ -343,10 +363,16 @@ test_that("circuit column is respected when provided", {
     p_period = rep(c(0.4, 0.6), each = 3),
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, circuit = route, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    circuit = route,
+    p_period = p_period
   )
 
   expect_equal(d$bus_route$circuit_col, "route")
@@ -355,13 +381,19 @@ test_that("circuit column is respected when provided", {
 
 test_that("p_period as scalar applies to all rows", {
   sf <- data.frame(
-    site = c("A", "B"), p_site = c(0.6, 0.4),
+    site = c("A", "B"),
+    p_site = c(0.6, 0.4),
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, p_period = 0.25
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    p_period = 0.25
   )
 
   expect_true(all(d$bus_route$data$.p_period == 0.25))
@@ -370,22 +402,34 @@ test_that("p_period as scalar applies to all rows", {
 
 test_that("validation fails when p_site does not sum to 1.0 within circuit", {
   sf <- data.frame(
-    site = c("A", "B"), p_site = c(0.3, 0.4), p_period = 0.5,
+    site = c("A", "B"),
+    p_site = c(0.3, 0.4),
+    p_period = 0.5,
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     class = "creel_error_invalid_input"
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     "sum to 1\\.0"
   )
@@ -400,10 +444,16 @@ test_that("validation error message includes circuit name and actual sum", {
     stringsAsFactors = FALSE
   )
   err <- tryCatch(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, circuit = route, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      circuit = route,
+      p_period = p_period
     ),
     error = function(e) conditionMessage(e)
   )
@@ -412,14 +462,21 @@ test_that("validation error message includes circuit name and actual sum", {
 
 test_that("validation fails when p_site value is zero", {
   sf <- data.frame(
-    site = c("A", "B", "C"), p_site = c(0.3, 0.0, 0.7), p_period = 0.5,
+    site = c("A", "B", "C"),
+    p_site = c(0.3, 0.0, 0.7),
+    p_period = 0.5,
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     class = "creel_error_invalid_input"
   )
@@ -427,14 +484,21 @@ test_that("validation fails when p_site value is zero", {
 
 test_that("validation fails when p_site value exceeds 1", {
   sf <- data.frame(
-    site = c("A"), p_site = c(1.1), p_period = 0.5,
+    site = c("A"),
+    p_site = c(1.1),
+    p_period = 0.5,
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     class = "creel_error_invalid_input"
   )
@@ -442,14 +506,21 @@ test_that("validation fails when p_site value exceeds 1", {
 
 test_that("validation fails when p_period value exceeds 1", {
   sf <- data.frame(
-    site = c("A", "B"), p_site = c(0.6, 0.4), p_period = c(0.5, 1.5),
+    site = c("A", "B"),
+    p_site = c(0.6, 0.4),
+    p_period = c(0.5, 1.5),
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     class = "creel_error_invalid_input"
   )
@@ -457,9 +528,14 @@ test_that("validation fails when p_period value exceeds 1", {
 
 test_that("validation fails when sampling_frame is missing for bus_route", {
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", site = site, p_site = p_site, p_period = 0.5
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      site = site,
+      p_site = p_site,
+      p_period = 0.5
     ),
     class = "creel_error_invalid_input"
   )
@@ -475,17 +551,23 @@ test_that("p_site sums within 1e-6 tolerance are accepted", {
   )
   # Should not error (sum is 1.0 within floating point)
   expect_no_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     )
   )
 })
 
 test_that("existing instantaneous designs still work with bus_route = NULL", {
   cal <- data.frame(
-    date = as.Date("2024-06-01"), day_type = "weekday",
+    date = as.Date("2024-06-01"),
+    day_type = "weekday",
     stringsAsFactors = FALSE
   )
   d <- creel_design(cal, date = date, strata = day_type)
@@ -495,10 +577,15 @@ test_that("existing instantaneous designs still work with bus_route = NULL", {
 })
 
 test_that("format.creel_design() includes Bus-Route section for bus_route designs", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
   out <- format(d)
 
@@ -509,7 +596,8 @@ test_that("format.creel_design() includes Bus-Route section for bus_route design
 
 test_that("format.creel_design() does not include Bus-Route section for instantaneous designs", {
   cal <- data.frame(
-    date = as.Date("2024-06-01"), day_type = "weekday",
+    date = as.Date("2024-06-01"),
+    day_type = "weekday",
     stringsAsFactors = FALSE
   )
   d <- creel_design(cal, date = date, strata = day_type)
@@ -519,10 +607,15 @@ test_that("format.creel_design() does not include Bus-Route section for instanta
 })
 
 test_that("get_sampling_frame() returns the stored data frame", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
   sf_out <- get_sampling_frame(d)
 
@@ -534,7 +627,8 @@ test_that("get_sampling_frame() returns the stored data frame", {
 
 test_that("get_sampling_frame() errors on non-bus-route design", {
   cal <- data.frame(
-    date = as.Date("2024-06-01"), day_type = "weekday",
+    date = as.Date("2024-06-01"),
+    day_type = "weekday",
     stringsAsFactors = FALSE
   )
   d <- creel_design(cal, date = date, strata = day_type)
@@ -568,10 +662,15 @@ test_that("golden test 1: single-circuit scalar p_period pi_i = p_site * p_perio
     p_site = c(0.20, 0.50, 0.30),
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, p_period = 0.30
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    p_period = 0.30
   )
 
   expect_equal(d$bus_route$data$.pi_i, c(0.06, 0.15, 0.09), tolerance = 1e-10)
@@ -584,20 +683,31 @@ test_that("golden test 2: single-circuit column p_period pi_i = p_site * p_perio
     p_period = c(0.25, 0.25),
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
 
   expect_equal(d$bus_route$data$.pi_i, c(0.10, 0.15), tolerance = 1e-10)
 })
 
 test_that("golden test 3: multi-circuit varying p_site and p_period", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf_2circuit(),
-    site = site, p_site = p_site, circuit = route, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf_2circuit(),
+    site = site,
+    p_site = p_site,
+    circuit = route,
+    p_period = p_period
   )
 
   expect_equal(d$bus_route$data$.pi_i, c(0.12, 0.28, 0.30, 0.20), tolerance = 1e-10)
@@ -610,10 +720,15 @@ test_that("golden test 4: boundary values p_site=1.0, p_period=1.0 -> pi_i=1.0 e
     p_period = c(1.0),
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
 
   expect_equal(d$bus_route$data$.pi_i, 1.0, tolerance = 1e-10)
@@ -629,10 +744,15 @@ test_that("p_period varying within single circuit errors with 'constant within e
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     "constant within each circuit"
   )
@@ -647,18 +767,30 @@ test_that("p_period varying within one of two circuits errors mentioning failing
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, circuit = route, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      circuit = route,
+      p_period = p_period
     ),
     "constant within each circuit"
   )
   expect_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, circuit = route, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      circuit = route,
+      p_period = p_period
     ),
     "R2"
   )
@@ -674,10 +806,16 @@ test_that("different circuits with different but uniform p_period values succeed
     stringsAsFactors = FALSE
   )
   expect_no_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, circuit = route, p_period = p_period
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      circuit = route,
+      p_period = p_period
     )
   )
 })
@@ -689,10 +827,15 @@ test_that("scalar p_period always passes uniformity check", {
     stringsAsFactors = FALSE
   )
   expect_no_error(
-    creel_design(make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf,
-      site = site, p_site = p_site, p_period = 0.45
+    creel_design(
+      make_br_cal(),
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf,
+      site = site,
+      p_site = p_site,
+      p_period = 0.45
     )
   )
 })
@@ -700,10 +843,15 @@ test_that("scalar p_period always passes uniformity check", {
 # get_inclusion_probs() unit tests ----
 
 test_that("get_inclusion_probs() returns data frame with 3 correct columns for single-circuit design", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf(),
-    site = site, p_site = p_site, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf(),
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
   out <- get_inclusion_probs(d)
 
@@ -719,10 +867,15 @@ test_that("get_inclusion_probs() returns correct pi_i values matching bus_route$
     p_site = c(0.20, 0.50, 0.30),
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, p_period = 0.30
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    p_period = 0.30
   )
   out <- get_inclusion_probs(d)
 
@@ -731,10 +884,16 @@ test_that("get_inclusion_probs() returns correct pi_i values matching bus_route$
 })
 
 test_that("get_inclusion_probs() multi-circuit returns correct site, circuit, and pi_i columns", {
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = make_br_sf_2circuit(),
-    site = site, p_site = p_site, circuit = route, p_period = p_period
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = make_br_sf_2circuit(),
+    site = site,
+    p_site = p_site,
+    circuit = route,
+    p_period = p_period
   )
   out <- get_inclusion_probs(d)
 
@@ -746,7 +905,8 @@ test_that("get_inclusion_probs() multi-circuit returns correct site, circuit, an
 
 test_that("get_inclusion_probs() on non-bus-route design errors with 'only available for bus-route'", {
   cal <- data.frame(
-    date = as.Date("2024-06-01"), day_type = "weekday",
+    date = as.Date("2024-06-01"),
+    day_type = "weekday",
     stringsAsFactors = FALSE
   )
   d <- creel_design(cal, date = date, strata = day_type)
@@ -775,10 +935,15 @@ test_that("range invariant: all pi_i values in (0,1] for edge-case probability c
     p_period = c(0.99, 0.99),
     stringsAsFactors = FALSE
   )
-  d1 <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf1,
-    site = site, p_site = p_site, p_period = p_period
+  d1 <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf1,
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
   pi_i_1 <- d1$bus_route$data$.pi_i
   expect_true(all(pi_i_1 > 0))
@@ -792,10 +957,15 @@ test_that("range invariant: all pi_i values in (0,1] for edge-case probability c
     p_period = c(0.01, 0.01),
     stringsAsFactors = FALSE
   )
-  d2 <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf2,
-    site = site, p_site = p_site, p_period = p_period
+  d2 <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf2,
+    site = site,
+    p_site = p_site,
+    p_period = p_period
   )
   pi_i_2 <- d2$bus_route$data$.pi_i
   expect_true(all(pi_i_2 > 0))
@@ -811,10 +981,15 @@ test_that("vectorization consistency: 5-site design with varying p_site and scal
     p_site = p_sites,
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_br_cal(),
-    date = date, strata = day_type,
-    survey_type = "bus_route", sampling_frame = sf,
-    site = site, p_site = p_site, p_period = p_period_val
+  d <- creel_design(
+    make_br_cal(),
+    date = date,
+    strata = day_type,
+    survey_type = "bus_route",
+    sampling_frame = sf,
+    site = site,
+    p_site = p_site,
+    p_period = p_period_val
   )
 
   expected_pi_i <- p_sites * p_period_val
@@ -872,9 +1047,11 @@ test_that("format.creel_design() shows area when area_col registered", {
     area_ha = c(100.0, 200.0),
     stringsAsFactors = FALSE
   )
-  design2 <- add_sections(design, secs,
+  design2 <- add_sections(
+    design,
+    secs,
     section_col = section, # nolint: object_usage_linter
-    area_col    = area_ha # nolint: object_usage_linter
+    area_col = area_ha # nolint: object_usage_linter
   )
   output <- format(design2)
   expect_true(any(grepl("ha", output)))
@@ -892,27 +1069,23 @@ make_enum_cal <- function() {
 
 test_that("creel_design() aborts with creel_error_invalid_survey_type for unknown survey_type", {
   expect_error(
-    creel_design(make_enum_cal(),
-      date = date, strata = day_type,
-      survey_type = "unknown_type"
-    ),
+    creel_design(make_enum_cal(), date = date, strata = day_type, survey_type = "unknown_type"),
     class = "creel_error_invalid_survey_type"
   )
 })
 
 test_that("enum guard error message names the bad survey_type value", {
   expect_error(
-    creel_design(make_enum_cal(),
-      date = date, strata = day_type,
-      survey_type = "unknown_type"
-    ),
+    creel_design(make_enum_cal(), date = date, strata = day_type, survey_type = "unknown_type"),
     "unknown_type"
   )
 })
 
 test_that("creel_design() accepts survey_type = 'ice' with effort_type and returns creel_design", {
-  d <- creel_design(make_enum_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_enum_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "ice",
     effort_type = "time_on_ice",
     p_period = 0.5
@@ -922,8 +1095,10 @@ test_that("creel_design() accepts survey_type = 'ice' with effort_type and retur
 })
 
 test_that("creel_design() accepts survey_type = 'camera' and returns creel_design", {
-  d <- creel_design(make_enum_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_enum_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "camera",
     camera_mode = "counter"
   )
@@ -932,8 +1107,10 @@ test_that("creel_design() accepts survey_type = 'camera' and returns creel_desig
 })
 
 test_that("creel_design() accepts survey_type = 'aerial' and returns creel_design", {
-  d <- creel_design(make_enum_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_enum_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "aerial",
     h_open = 14
   )
@@ -952,8 +1129,10 @@ make_ice_cal <- function() {
 }
 
 test_that("ICE-01: creel_design(ice, effort_type='time_on_ice', p_period=0.5) constructs non-NULL ice slot", {
-  d <- creel_design(make_ice_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_ice_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "ice",
     effort_type = "time_on_ice",
     p_period = 0.5
@@ -963,8 +1142,10 @@ test_that("ICE-01: creel_design(ice, effort_type='time_on_ice', p_period=0.5) co
 })
 
 test_that("ICE-01: design$ice$effort_type stores 'active_fishing_time' when supplied", {
-  d <- creel_design(make_ice_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_ice_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "ice",
     effort_type = "active_fishing_time",
     p_period = 0.5
@@ -979,8 +1160,10 @@ test_that("ICE-01: creel_design(ice) with valid sampling_frame (all p_site==1.0)
     p_period = 0.5,
     stringsAsFactors = FALSE
   )
-  d <- creel_design(make_ice_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_ice_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "ice",
     effort_type = "time_on_ice",
     sampling_frame = sf,
@@ -998,8 +1181,10 @@ test_that("ICE-01: creel_design(ice) aborts with cli_abort when any p_site != 1.
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_ice_cal(),
-      date = date, strata = day_type,
+    creel_design(
+      make_ice_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "ice",
       effort_type = "time_on_ice",
       sampling_frame = sf_bad,
@@ -1017,8 +1202,10 @@ test_that("ICE-01: p_site enforcement error message names offending row indices"
     stringsAsFactors = FALSE
   )
   expect_error(
-    creel_design(make_ice_cal(),
-      date = date, strata = day_type,
+    creel_design(
+      make_ice_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "ice",
       effort_type = "time_on_ice",
       sampling_frame = sf_bad,
@@ -1032,8 +1219,10 @@ test_that("ICE-01: p_site enforcement error message names offending row indices"
 
 test_that("ICE-02: creel_design(ice) without effort_type aborts with cli_abort", {
   expect_error(
-    creel_design(make_ice_cal(),
-      date = date, strata = day_type,
+    creel_design(
+      make_ice_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "ice",
       p_period = 0.5
     ),
@@ -1043,8 +1232,10 @@ test_that("ICE-02: creel_design(ice) without effort_type aborts with cli_abort",
 
 test_that("ICE-02: creel_design(ice) with unknown effort_type aborts with informative message", {
   expect_error(
-    creel_design(make_ice_cal(),
-      date = date, strata = day_type,
+    creel_design(
+      make_ice_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "ice",
       effort_type = "unknown_type",
       p_period = 0.5
@@ -1056,9 +1247,11 @@ test_that("ICE-02: creel_design(ice) with unknown effort_type aborts with inform
 # ICE-04: add_interviews() ice path ----
 
 make_ice_design_no_sf <- function() {
-  creel_design( # nolint: object_usage_linter
+  creel_design(
+    # nolint: object_usage_linter
     make_ice_cal(),
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "ice",
     effort_type = "time_on_ice",
     p_period = 0.5
@@ -1155,8 +1348,10 @@ make_cam_cal <- function() {
 # CAM-01: counter mode construction ----
 
 test_that("CAM-01: creel_design(camera, counter) constructs without error", {
-  d <- creel_design(make_cam_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_cam_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "camera",
     camera_mode = "counter"
   )
@@ -1167,28 +1362,24 @@ test_that("CAM-01: creel_design(camera, counter) constructs without error", {
 
 test_that("CAM-01: creel_design(camera) without camera_mode aborts with cli_abort", {
   expect_error(
-    creel_design(make_cam_cal(),
-      date = date, strata = day_type,
-      survey_type = "camera"
-    ),
+    creel_design(make_cam_cal(), date = date, strata = day_type, survey_type = "camera"),
     class = "rlang_error"
   )
 })
 
 test_that("CAM-01: camera_mode absent error message names valid values", {
   expect_error(
-    creel_design(make_cam_cal(),
-      date = date, strata = day_type,
-      survey_type = "camera"
-    ),
+    creel_design(make_cam_cal(), date = date, strata = day_type, survey_type = "camera"),
     regexp = "counter|ingress_egress"
   )
 })
 
 test_that("CAM-01: creel_design(camera, bad_mode) aborts naming the bad value", {
   expect_error(
-    creel_design(make_cam_cal(),
-      date = date, strata = day_type,
+    creel_design(
+      make_cam_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "camera",
       camera_mode = "unknown_mode"
     ),
@@ -1199,8 +1390,10 @@ test_that("CAM-01: creel_design(camera, bad_mode) aborts naming the bad value", 
 # CAM-02: ingress_egress mode construction ----
 
 test_that("CAM-02: creel_design(camera, ingress_egress) constructs without error", {
-  d <- creel_design(make_cam_cal(),
-    date = date, strata = day_type,
+  d <- creel_design(
+    make_cam_cal(),
+    date = date,
+    strata = day_type,
     survey_type = "camera",
     camera_mode = "ingress_egress"
   )
@@ -1214,21 +1407,32 @@ make_cam_timestamps <- function() {
   base_date <- as.Date("2024-06-01")
   data.frame(
     survey_date = rep(c(base_date, base_date + 1), each = 2L),
-    ingress_time = as.POSIXct(c(
-      "2024-06-01 06:00:00", "2024-06-01 09:00:00",
-      "2024-06-02 07:00:00", "2024-06-02 10:30:00"
-    ), tz = "UTC"),
-    egress_time = as.POSIXct(c(
-      "2024-06-01 08:00:00", "2024-06-01 11:00:00",
-      "2024-06-02 09:00:00", "2024-06-02 13:00:00"
-    ), tz = "UTC"),
+    ingress_time = as.POSIXct(
+      c(
+        "2024-06-01 06:00:00",
+        "2024-06-01 09:00:00",
+        "2024-06-02 07:00:00",
+        "2024-06-02 10:30:00"
+      ),
+      tz = "UTC"
+    ),
+    egress_time = as.POSIXct(
+      c(
+        "2024-06-01 08:00:00",
+        "2024-06-01 11:00:00",
+        "2024-06-02 09:00:00",
+        "2024-06-02 13:00:00"
+      ),
+      tz = "UTC"
+    ),
     stringsAsFactors = FALSE
   )
 }
 
 test_that("CAM-02: preprocess_camera_timestamps() returns data frame with date + daily_effort_hours", {
   ts <- make_cam_timestamps()
-  result <- preprocess_camera_timestamps(ts,
+  result <- preprocess_camera_timestamps(
+    ts,
     date_col = survey_date,
     ingress_col = ingress_time,
     egress_col = egress_time
@@ -1241,7 +1445,8 @@ test_that("CAM-02: preprocess_camera_timestamps() returns data frame with date +
 
 test_that("CAM-02: preprocess_camera_timestamps() aggregates hours correctly", {
   ts <- make_cam_timestamps()
-  result <- preprocess_camera_timestamps(ts,
+  result <- preprocess_camera_timestamps(
+    ts,
     date_col = survey_date,
     ingress_col = ingress_time,
     egress_col = egress_time
@@ -1257,7 +1462,8 @@ test_that("CAM-02: preprocess_camera_timestamps() warns on egress < ingress and 
   # Make one row have egress before ingress
   ts$egress_time[2L] <- ts$ingress_time[2L] - 3600
   expect_warning(
-    result <- preprocess_camera_timestamps(ts,
+    result <- preprocess_camera_timestamps(
+      ts,
       date_col = survey_date,
       ingress_col = ingress_time,
       egress_col = egress_time
@@ -1274,8 +1480,14 @@ test_that("CAM-02: preprocess_camera_timestamps() warns on egress < ingress and 
 make_aerial_cal <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4L),
     stringsAsFactors = FALSE
@@ -1284,8 +1496,10 @@ make_aerial_cal <- function() {
 
 describe("Phase 47: Aerial constructor", {
   it("AIR-01: creel_design(survey_type = 'aerial', h_open = 14) constructs; design$aerial$h_open == 14", {
-    d <- creel_design(make_aerial_cal(),
-      date = date, strata = day_type,
+    d <- creel_design(
+      make_aerial_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "aerial",
       h_open = 14
     )
@@ -1296,18 +1510,17 @@ describe("Phase 47: Aerial constructor", {
 
   it("AIR-01: creel_design(survey_type = 'aerial') without h_open aborts with cli_abort()", {
     expect_error(
-      creel_design(make_aerial_cal(),
-        date = date, strata = day_type,
-        survey_type = "aerial"
-      ),
+      creel_design(make_aerial_cal(), date = date, strata = day_type, survey_type = "aerial"),
       regexp = "h_open"
     )
   })
 
   it("AIR-01: creel_design(survey_type = 'aerial', h_open = -1) aborts with informative message", {
     expect_error(
-      creel_design(make_aerial_cal(),
-        date = date, strata = day_type,
+      creel_design(
+        make_aerial_cal(),
+        date = date,
+        strata = day_type,
         survey_type = "aerial",
         h_open = -1
       ),
@@ -1316,8 +1529,10 @@ describe("Phase 47: Aerial constructor", {
   })
 
   it("AIR-03: creel_design(survey_type = 'aerial', h_open = 14, visibility_correction = 0.85) constructs", {
-    d <- creel_design(make_aerial_cal(),
-      date = date, strata = day_type,
+    d <- creel_design(
+      make_aerial_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "aerial",
       h_open = 14,
       visibility_correction = 0.85
@@ -1327,8 +1542,10 @@ describe("Phase 47: Aerial constructor", {
 
   it("AIR-03: visibility_correction = 1.5 aborts (outside (0, 1])", {
     expect_error(
-      creel_design(make_aerial_cal(),
-        date = date, strata = day_type,
+      creel_design(
+        make_aerial_cal(),
+        date = date,
+        strata = day_type,
         survey_type = "aerial",
         h_open = 14,
         visibility_correction = 1.5
@@ -1339,8 +1556,10 @@ describe("Phase 47: Aerial constructor", {
 
   it("AIR-03: visibility_correction = 0 aborts (not > 0)", {
     expect_error(
-      creel_design(make_aerial_cal(),
-        date = date, strata = day_type,
+      creel_design(
+        make_aerial_cal(),
+        date = date,
+        strata = day_type,
         survey_type = "aerial",
         h_open = 14,
         visibility_correction = 0
@@ -1350,8 +1569,10 @@ describe("Phase 47: Aerial constructor", {
   })
 
   it("AIR-01: design$design_type == 'aerial' after construction", {
-    d <- creel_design(make_aerial_cal(),
-      date = date, strata = day_type,
+    d <- creel_design(
+      make_aerial_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "aerial",
       h_open = 14
     )
@@ -1359,8 +1580,10 @@ describe("Phase 47: Aerial constructor", {
   })
 
   it("AIR-04: open_start stored in design$aerial$open_start", {
-    d <- creel_design(make_aerial_cal(),
-      date = date, strata = day_type,
+    d <- creel_design(
+      make_aerial_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "aerial",
       h_open = 14,
       open_start = 5.5
@@ -1369,8 +1592,10 @@ describe("Phase 47: Aerial constructor", {
   })
 
   it("AIR-04: open_start = NULL stored as NULL in design$aerial", {
-    d <- creel_design(make_aerial_cal(),
-      date = date, strata = day_type,
+    d <- creel_design(
+      make_aerial_cal(),
+      date = date,
+      strata = day_type,
       survey_type = "aerial",
       h_open = 14
     )
@@ -1379,8 +1604,10 @@ describe("Phase 47: Aerial constructor", {
 
   it("AIR-04: open_start = -1 aborts (not non-negative)", {
     expect_error(
-      creel_design(make_aerial_cal(),
-        date = date, strata = day_type,
+      creel_design(
+        make_aerial_cal(),
+        date = date,
+        strata = day_type,
         survey_type = "aerial",
         h_open = 14,
         open_start = -1
@@ -1391,8 +1618,10 @@ describe("Phase 47: Aerial constructor", {
 
   it("AIR-04: open_start = 0 is accepted (midnight opening)", {
     expect_no_error(
-      creel_design(make_aerial_cal(),
-        date = date, strata = day_type,
+      creel_design(
+        make_aerial_cal(),
+        date = date,
+        strata = day_type,
         survey_type = "aerial",
         h_open = 14,
         open_start = 0
@@ -1413,9 +1642,13 @@ test_that("DIAG-WGHT-01: bus-route design with NA p_site aborts naming p_site", 
   expect_error(
     creel_design(
       make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf_na,
-      site = site, p_site = p_site, p_period = p_period
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf_na,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     regexp = "p_site"
   )
@@ -1431,9 +1664,13 @@ test_that("DIAG-WGHT-02: bus-route design with NA p_period aborts naming p_perio
   expect_error(
     creel_design(
       make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf_na,
-      site = site, p_site = p_site, p_period = p_period
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf_na,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     regexp = "p_period"
   )
@@ -1449,10 +1686,50 @@ test_that("DIAG-WGHT-03: bus-route design with p_site = 0 aborts (zero probabili
   expect_error(
     creel_design(
       make_br_cal(),
-      date = date, strata = day_type,
-      survey_type = "bus_route", sampling_frame = sf_zero,
-      site = site, p_site = p_site, p_period = p_period
+      date = date,
+      strata = day_type,
+      survey_type = "bus_route",
+      sampling_frame = sf_zero,
+      site = site,
+      p_site = p_site,
+      p_period = p_period
     ),
     regexp = "p_site"
   )
+})
+
+# T2-A: add_interviews() multi-strata join (no date-only duplication) ----
+
+test_that("T2A-01: add_interviews() joins on shared strata cols, not date alone", {
+  # Two sites per date: date-only join would duplicate each interview row.
+  cal <- data.frame(
+    date = rep(as.Date(c("2024-06-01", "2024-06-02")), each = 2),
+    day_type = rep(c("weekend", "weekday"), each = 2),
+    site = rep(c("A", "B"), times = 2),
+    .N = 10L,
+    stringsAsFactors = FALSE
+  )
+  design <- creel_design(
+    cal,
+    date = date,
+    strata = c(day_type, site)
+  )
+  interviews <- data.frame(
+    date = as.Date(c("2024-06-01", "2024-06-02")),
+    day_type = c("weekend", "weekday"),
+    site = c("A", "B"),
+    catch = c(2L, 1L),
+    effort = c(2.0, 1.5),
+    trip_status = c("complete", "complete"),
+    stringsAsFactors = FALSE
+  )
+  result <- suppressWarnings(add_interviews(
+    design,
+    interviews,
+    catch = catch,
+    effort = effort,
+    trip_status = trip_status
+  ))
+  # No duplication: one row per interview
+  expect_equal(nrow(result$interviews), nrow(interviews))
 })

--- a/tests/testthat/test-creel-estimates-age.R
+++ b/tests/testthat/test-creel-estimates-age.R
@@ -11,13 +11,17 @@ make_age_design <- function() {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  add_ages(d, example_ages, # nolint: object_usage_linter
+  add_ages(
+    d,
+    example_ages, # nolint: object_usage_linter
     age_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -33,7 +37,9 @@ make_age_design_no_ages <- function() {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -58,7 +64,8 @@ test_that("AGD-03 est_age_distribution() errors when interviews not attached", {
   d <- suppressWarnings(
     creel_design(
       tidycreel::example_calendar,
-      date = date, strata = day_type
+      date = date,
+      strata = day_type
     )
   )
   expect_error(est_age_distribution(d), "No interview survey")
@@ -93,10 +100,19 @@ test_that("AGD-07 est_age_distribution() returns creel_age_distribution S3 class
 test_that("AGD-08 est_age_distribution() returns expected columns", {
   d <- make_age_design()
   result <- est_age_distribution(d, type = "catch")
-  expect_true(all(c(
-    "age", "estimate", "se", "ci_lower", "ci_upper",
-    "percent", "cumulative_percent", "n"
-  ) %in% names(result)))
+  expect_true(all(
+    c(
+      "age",
+      "estimate",
+      "se",
+      "ci_lower",
+      "ci_upper",
+      "percent",
+      "cumulative_percent",
+      "n"
+    ) %in%
+      names(result)
+  ))
 })
 
 test_that("AGD-09 est_age_distribution() age column is integer", {
@@ -278,9 +294,15 @@ test_that("AGD-32 est_mean_age() returns expected columns", {
   d <- make_age_design()
   ad <- est_age_distribution(d, type = "catch")
   result <- est_mean_age(ad)
-  expect_true(all(c(
-    "mean_age", "mean_age_se", "mean_age_ci_lower", "mean_age_ci_upper"
-  ) %in% names(result)))
+  expect_true(all(
+    c(
+      "mean_age",
+      "mean_age_se",
+      "mean_age_ci_lower",
+      "mean_age_ci_upper"
+    ) %in%
+      names(result)
+  ))
 })
 
 test_that("AGD-33 est_mean_age() mean is between min and max observed age", {

--- a/tests/testthat/test-creel-estimates-regression-cpue.R
+++ b/tests/testthat/test-creel-estimates-regression-cpue.R
@@ -1,20 +1,19 @@
 make_simple_design <- function(n = 30L, seed = 42L) {
   set.seed(seed)
   dates <- seq.Date(as.Date("2024-06-01"), by = "day", length.out = 14L)
-  cal   <- data.frame(
-    date     = dates,
+  cal <- data.frame(
+    date = dates,
     day_type = rep(c("weekend", "weekday"), c(2L, 12L))
   )
   ints <- data.frame(
-    date         = sample(dates, n, replace = TRUE),
-    day_type     = sample(c("weekday", "weekend"), n, replace = TRUE),
+    date = sample(dates, n, replace = TRUE),
+    day_type = sample(c("weekday", "weekend"), n, replace = TRUE),
     hours_fished = round(rgamma(n, 2.5, 0.7), 2),
-    catch_total  = rnbinom(n, mu = 5, size = 0.6),
-    trip_status  = "complete"
+    catch_total = rnbinom(n, mu = 5, size = 0.6),
+    trip_status = "complete"
   )
   creel_design(cal, date = date, strata = day_type) |>
-    add_interviews(ints, catch = catch_total, effort = hours_fished,
-                   trip_status = trip_status)
+    add_interviews(ints, catch = catch_total, effort = hours_fished, trip_status = trip_status)
 }
 
 test_that("regression estimator returns creel_estimates with correct method", {
@@ -62,8 +61,8 @@ test_that("regression slope matches manual OLS (force_origin = TRUE)", {
   d <- make_simple_design(n = 50L, seed = 3L)
   r <- estimate_catch_rate(d, estimator = "regression", force_origin = TRUE)
 
-  ints   <- d$interviews
-  catch  <- as.numeric(ints[[d$catch_col]])
+  ints <- d$interviews
+  catch <- as.numeric(ints[[d$catch_col]])
   effort <- as.numeric(ints[[d$angler_effort_col]])
   manual_beta <- sum(catch * effort) / sum(effort^2)
 
@@ -128,7 +127,7 @@ test_that(".jackknife_slope_se near zero for near-perfect linear data", {
 # ── compare_cpue_estimators ───────────────────────────────────────────────────
 
 test_that("compare_cpue_estimators returns cpue_comparison tibble", {
-  d    <- make_simple_design(n = 40L)
+  d <- make_simple_design(n = 40L)
   comp <- compare_cpue_estimators(d)
   expect_s3_class(comp, "cpue_comparison")
   expect_true("cpue_method" %in% names(comp))
@@ -136,14 +135,14 @@ test_that("compare_cpue_estimators returns cpue_comparison tibble", {
 })
 
 test_that("compare_cpue_estimators includes rom and regression", {
-  d    <- make_simple_design(n = 40L)
+  d <- make_simple_design(n = 40L)
   comp <- compare_cpue_estimators(d)
   expect_true("rom" %in% comp$cpue_method)
   expect_true("regression" %in% comp$cpue_method)
 })
 
 test_that("compare_cpue_estimators grouped returns group columns", {
-  d    <- make_simple_design(n = 60L, seed = 20L)
+  d <- make_simple_design(n = 60L, seed = 20L)
   comp <- compare_cpue_estimators(d, by = day_type)
   expect_true("day_type" %in% names(comp))
 })
@@ -155,8 +154,8 @@ test_that("compare_cpue_estimators conf_level validation", {
 
 test_that("autoplot.cpue_comparison returns ggplot", {
   skip_if_not_installed("ggplot2")
-  d    <- make_simple_design(n = 40L)
+  d <- make_simple_design(n = 40L)
   comp <- compare_cpue_estimators(d)
-  p    <- autoplot(comp)
+  p <- autoplot(comp)
   expect_s3_class(p, "ggplot")
 })

--- a/tests/testthat/test-creel-estimates.R
+++ b/tests/testthat/test-creel-estimates.R
@@ -71,7 +71,10 @@ test_that("new_creel_estimates() creates creel_estimates S3 object", {
 
   expect_s3_class(result, "creel_estimates")
   expect_type(result, "list")
-  expect_named(result, c("estimates", "method", "variance_method", "design", "conf_level", "by_vars", "effort_target"))
+  expect_named(
+    result,
+    c("estimates", "method", "variance_method", "design", "conf_level", "by_vars", "effort_target")
+  )
 })
 
 test_that("new_creel_estimates() uses correct defaults", {
@@ -201,7 +204,15 @@ make_mor_test_design <- function(n_incomplete = 30, n_complete = 0) {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 test_that("creel_estimates_mor has correct class structure", {

--- a/tests/testthat/test-creel-schema.R
+++ b/tests/testthat/test-creel-schema.R
@@ -73,8 +73,8 @@ test_that("error message includes the table name (e.g., 'interviews table')", {
 test_that("validate_creel_schema() passes for camera type with only counts columns", {
   s <- creel_schema(
     survey_type = "camera",
-    date_col    = "SurveyDate",
-    count_col   = "AnglerCount"
+    date_col = "SurveyDate",
+    count_col = "AnglerCount"
   )
   expect_no_error(validate_creel_schema(s))
 })

--- a/tests/testthat/test-creel-summaries-cws-hws.R
+++ b/tests/testthat/test-creel-summaries-cws-hws.R
@@ -3,14 +3,17 @@
 
 # Fixtures ----
 
-make_design_with_catch_for_cws <- function() { # nolint: object_length_linter
+make_design_with_catch_for_cws <- function() {
+  # nolint: object_length_linter
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   data(example_catch, package = "tidycreel")
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -19,7 +22,9 @@ make_design_with_catch_for_cws <- function() { # nolint: object_length_linter
     angler_type = angler_type, # nolint: object_usage_linter
     n_anglers = n_anglers # nolint: object_usage_linter
   ))
-  add_catch(d, example_catch, # nolint: object_usage_linter
+  add_catch(
+    d,
+    example_catch, # nolint: object_usage_linter
     catch_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -34,7 +39,9 @@ make_design_no_catch <- function() {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -117,8 +124,12 @@ test_that("add_interviews() without n_anglers emits cli_inform about assumption"
   data(example_interviews, package = "tidycreel")
   d <- suppressWarnings(creel_design(example_calendar, date = date, strata = day_type))
   expect_message(
-    suppressWarnings(add_interviews(d, example_interviews,
-      catch = catch_total, effort = hours_fished, harvest = catch_kept,
+    suppressWarnings(add_interviews(
+      d,
+      example_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      harvest = catch_kept,
       trip_status = trip_status
     )),
     "assuming 1 angler"
@@ -129,8 +140,12 @@ test_that("add_interviews() always sets angler_effort_col on returned design", {
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   d <- suppressWarnings(creel_design(example_calendar, date = date, strata = day_type))
-  d2 <- suppressWarnings(add_interviews(d, example_interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept,
+  d2 <- suppressWarnings(add_interviews(
+    d,
+    example_interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
     trip_status = trip_status
   ))
   expect_equal(d2[["angler_effort_col"]], ".angler_effort")
@@ -141,8 +156,12 @@ test_that("add_interviews() with n_anglers=1 produces .angler_effort == effort",
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   d <- suppressWarnings(creel_design(example_calendar, date = date, strata = day_type))
-  d2 <- suppressWarnings(add_interviews(d, example_interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept,
+  d2 <- suppressWarnings(add_interviews(
+    d,
+    example_interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
     trip_status = trip_status
   ))
   ae <- d2[["interviews"]][[".angler_effort"]]
@@ -154,9 +173,14 @@ test_that("add_interviews() with n_anglers column produces .angler_effort = effo
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   d <- suppressWarnings(creel_design(example_calendar, date = date, strata = day_type))
-  d2 <- suppressWarnings(add_interviews(d, example_interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept,
-    trip_status = trip_status, n_anglers = n_anglers # nolint: object_usage_linter
+  d2 <- suppressWarnings(add_interviews(
+    d,
+    example_interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    n_anglers = n_anglers # nolint: object_usage_linter
   ))
   ae <- d2[["interviews"]][[".angler_effort"]]
   ef <- d2[["interviews"]][[d2[["effort_col"]]]]
@@ -183,8 +207,12 @@ test_that("summarize_cws_rates() errors when species_sought_col is NULL", {
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   d <- suppressWarnings(creel_design(example_calendar, date = date, strata = day_type))
-  d2 <- suppressWarnings(add_interviews(d, example_interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept,
+  d2 <- suppressWarnings(add_interviews(
+    d,
+    example_interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
     trip_status = trip_status # no species_sought
   ))
   expect_error(summarize_cws_rates(d2), "species_sought")
@@ -269,7 +297,8 @@ test_that("summarize_hws_rates() mean_rate <= summarize_cws_rates() mean_rate (h
   merged <- merge(
     cws[, c("species_sought", "mean_rate")],
     hws[, c("species_sought", "mean_rate")],
-    by = "species_sought", suffixes = c("_cws", "_hws")
+    by = "species_sought",
+    suffixes = c("_cws", "_hws")
   )
   expect_true(all(merged[["mean_rate_hws"]] <= merged[["mean_rate_cws"]] + 1e-10))
 })

--- a/tests/testthat/test-creel-summaries-geographic.R
+++ b/tests/testthat/test-creel-summaries-geographic.R
@@ -4,15 +4,14 @@
 
 make_boat_composition_design <- function() {
   counts_df <- data.frame(
-    date          = as.Date(c("2024-05-01", "2024-05-04",
-                              "2024-06-01", "2024-06-08")),
-    day_type      = c("weekday", "weekend", "weekday", "weekend"),
-    angler_boats  = c(3L, 2L, 4L, 1L),
+    date = as.Date(c("2024-05-01", "2024-05-04", "2024-06-01", "2024-06-08")),
+    day_type = c("weekday", "weekend", "weekday", "weekend"),
+    angler_boats = c(3L, 2L, 4L, 1L),
     non_ang_boats = c(1L, 2L, 1L, 3L),
-    count         = c(10L, 12L, 9L, 8L)
+    count = c(10L, 12L, 9L, 8L)
   )
   cal <- data.frame(
-    date     = counts_df$date,
+    date = counts_df$date,
     day_type = counts_df$day_type
   )
   d <- suppressWarnings(
@@ -24,11 +23,12 @@ make_boat_composition_design <- function() {
 }
 
 make_boat_composition_schema <- function(
-    ab_col = "angler_boats",
-    nb_col = "non_ang_boats") {
+  ab_col = "angler_boats",
+  nb_col = "non_ang_boats"
+) {
   creel_schema(
-    survey_type       = "instantaneous",
-    angler_boats_col  = ab_col,
+    survey_type = "instantaneous",
+    angler_boats_col = ab_col,
     non_ang_boats_col = nb_col
   )
 }
@@ -86,7 +86,7 @@ test_that("summarize_boat_composition() aborts when design is not creel_design",
 test_that("summarize_boat_composition() aborts when design$counts is NULL", {
   # Build a design without add_counts()
   cal <- data.frame(
-    date     = as.Date("2024-05-01"),
+    date = as.Date("2024-05-01"),
     day_type = "weekday"
   )
   d_no_counts <- suppressWarnings(
@@ -102,7 +102,7 @@ test_that("summarize_boat_composition() aborts when design$counts is NULL", {
 test_that("summarize_boat_composition() aborts when schema$angler_boats_col is NULL", {
   d <- make_boat_composition_design()
   s_no_ab <- creel_schema(
-    survey_type       = "instantaneous",
+    survey_type = "instantaneous",
     non_ang_boats_col = "non_ang_boats"
   )
   expect_error(
@@ -114,7 +114,7 @@ test_that("summarize_boat_composition() aborts when schema$angler_boats_col is N
 test_that("summarize_boat_composition() aborts when schema$non_ang_boats_col is NULL", {
   d <- make_boat_composition_design()
   s_no_nb <- creel_schema(
-    survey_type      = "instantaneous",
+    survey_type = "instantaneous",
     angler_boats_col = "angler_boats"
   )
   expect_error(
@@ -145,17 +145,19 @@ make_zip_design <- function() {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   suppressWarnings(
-    add_interviews(d, ints, # nolint: object_usage_linter
-      catch         = catch_total,   # nolint: object_usage_linter
-      effort        = hours_fished,  # nolint: object_usage_linter
-      harvest       = catch_kept,    # nolint: object_usage_linter
-      trip_status   = trip_status,   # nolint: object_usage_linter
+    add_interviews(
+      d,
+      ints, # nolint: object_usage_linter
+      catch = catch_total, # nolint: object_usage_linter
+      effort = hours_fished, # nolint: object_usage_linter
+      harvest = catch_kept, # nolint: object_usage_linter
+      trip_status = trip_status, # nolint: object_usage_linter
       trip_duration = trip_duration, # nolint: object_usage_linter
-      angler_type   = angler_type,   # nolint: object_usage_linter
+      angler_type = angler_type, # nolint: object_usage_linter
       angler_method = angler_method, # nolint: object_usage_linter
       species_sought = species_sought, # nolint: object_usage_linter
-      n_anglers     = n_anglers,     # nolint: object_usage_linter
-      refused       = refused        # nolint: object_usage_linter
+      n_anglers = n_anglers, # nolint: object_usage_linter
+      refused = refused # nolint: object_usage_linter
     )
   )
 }
@@ -207,7 +209,7 @@ test_that("summarize_by_zip() Unknown row n matches NA count in interviews", {
 
 test_that("summarize_by_zip() aborts when interviews not attached", {
   cal <- data.frame(
-    date     = as.Date("2024-05-01"),
+    date = as.Date("2024-05-01"),
     day_type = "weekday"
   )
   d_no_int <- suppressWarnings(
@@ -227,17 +229,19 @@ test_that("summarize_by_zip() aborts when ii_ZipCode not in interviews", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
-      catch         = catch_total,   # nolint: object_usage_linter
-      effort        = hours_fished,  # nolint: object_usage_linter
-      harvest       = catch_kept,    # nolint: object_usage_linter
-      trip_status   = trip_status,   # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
+      catch = catch_total, # nolint: object_usage_linter
+      effort = hours_fished, # nolint: object_usage_linter
+      harvest = catch_kept, # nolint: object_usage_linter
+      trip_status = trip_status, # nolint: object_usage_linter
       trip_duration = trip_duration, # nolint: object_usage_linter
-      angler_type   = angler_type,   # nolint: object_usage_linter
+      angler_type = angler_type, # nolint: object_usage_linter
       angler_method = angler_method, # nolint: object_usage_linter
       species_sought = species_sought, # nolint: object_usage_linter
-      n_anglers     = n_anglers,     # nolint: object_usage_linter
-      refused       = refused        # nolint: object_usage_linter
+      n_anglers = n_anglers, # nolint: object_usage_linter
+      refused = refused # nolint: object_usage_linter
     )
   )
   expect_error(
@@ -302,17 +306,19 @@ test_that("summarize_by_county() aborts when ii_ZipCode not in interviews", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
-      catch         = catch_total,   # nolint: object_usage_linter
-      effort        = hours_fished,  # nolint: object_usage_linter
-      harvest       = catch_kept,    # nolint: object_usage_linter
-      trip_status   = trip_status,   # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
+      catch = catch_total, # nolint: object_usage_linter
+      effort = hours_fished, # nolint: object_usage_linter
+      harvest = catch_kept, # nolint: object_usage_linter
+      trip_status = trip_status, # nolint: object_usage_linter
       trip_duration = trip_duration, # nolint: object_usage_linter
-      angler_type   = angler_type,   # nolint: object_usage_linter
+      angler_type = angler_type, # nolint: object_usage_linter
       angler_method = angler_method, # nolint: object_usage_linter
       species_sought = species_sought, # nolint: object_usage_linter
-      n_anglers     = n_anglers,     # nolint: object_usage_linter
-      refused       = refused        # nolint: object_usage_linter
+      n_anglers = n_anglers, # nolint: object_usage_linter
+      refused = refused # nolint: object_usage_linter
     )
   )
   expect_error(

--- a/tests/testthat/test-creel-summaries-length-freq.R
+++ b/tests/testthat/test-creel-summaries-length-freq.R
@@ -2,20 +2,25 @@
 
 # Fixtures ----
 
-make_design_with_lengths <- function() { # nolint: object_length_linter
+make_design_with_lengths <- function() {
+  # nolint: object_length_linter
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   data(example_lengths, package = "tidycreel")
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  add_lengths(d, example_lengths, # nolint: object_usage_linter
+  add_lengths(
+    d,
+    example_lengths, # nolint: object_usage_linter
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -26,13 +31,16 @@ make_design_with_lengths <- function() { # nolint: object_length_linter
   )
 }
 
-make_design_no_lengths <- function() { # nolint: object_length_linter
+make_design_no_lengths <- function() {
+  # nolint: object_length_linter
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -182,7 +190,9 @@ test_that("bin_width = 25: walleye harvest bins span 25mm", {
   d <- make_design_with_lengths()
   result <- summarize_length_freq(
     d,
-    type = "harvest", by = species, bin_width = 25 # nolint: object_usage_linter
+    type = "harvest",
+    by = species,
+    bin_width = 25 # nolint: object_usage_linter
   )
   walleye <- result[result$species == "walleye", ]
   bins <- as.character(walleye[["length_bin"]])
@@ -203,7 +213,9 @@ test_that("release bins reflect midpoints of original bin labels", {
   d <- make_design_with_lengths()
   result <- summarize_length_freq(
     d,
-    type = "release", by = species, bin_width = 1 # nolint: object_usage_linter
+    type = "release",
+    by = species,
+    bin_width = 1 # nolint: object_usage_linter
   )
   # walleye midpoints: 375 and 425; with bin_width=1 each fish is at 375 or 425
   walleye <- result[result$species == "walleye", ]
@@ -218,7 +230,9 @@ test_that("release N is expanded from count: walleye 'count=2' bin has N=2", {
   d <- make_design_with_lengths()
   result <- summarize_length_freq(
     d,
-    type = "release", by = species, bin_width = 1 # nolint: object_usage_linter
+    type = "release",
+    by = species,
+    bin_width = 1 # nolint: object_usage_linter
   )
   walleye <- result[result$species == "walleye", ]
   # "350-400" midpoint=375, count=2 -> expect a bin at 375 with N=2

--- a/tests/testthat/test-creel-summaries.R
+++ b/tests/testthat/test-creel-summaries.R
@@ -2,7 +2,8 @@
 
 # --- Shared fixtures -----------------------------------------------------------
 
-make_design_with_extended_interviews <- function() { # nolint: object_length_linter
+make_design_with_extended_interviews <- function() {
+  # nolint: object_length_linter
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   # Inject one refusal for USUM-01 coverage (example_interviews has all refused=FALSE)
@@ -10,8 +11,11 @@ make_design_with_extended_interviews <- function() { # nolint: object_length_lin
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  suppressWarnings( # nolint: object_usage_linter
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+  suppressWarnings(
+    # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -29,12 +33,14 @@ make_design_with_extended_interviews <- function() { # nolint: object_length_lin
 make_design_with_catch <- function() {
   data(example_catch, package = "tidycreel")
   d <- make_design_with_extended_interviews()
-  add_catch(d, example_catch, # nolint: object_usage_linter
-    catch_uid     = interview_id, # nolint: object_usage_linter
+  add_catch(
+    d,
+    example_catch, # nolint: object_usage_linter
+    catch_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
-    species       = species, # nolint: object_usage_linter
-    count         = count, # nolint: object_usage_linter
-    catch_type    = catch_type # nolint: object_usage_linter
+    species = species, # nolint: object_usage_linter
+    count = count, # nolint: object_usage_linter
+    catch_type = catch_type # nolint: object_usage_linter
   )
 }
 
@@ -83,7 +89,9 @@ test_that("summarize_refusals() errors when refused_col is NULL", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -130,7 +138,9 @@ test_that("summarize_by_day_type() works without optional Phase 28 fields", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -174,7 +184,9 @@ test_that("summarize_by_angler_type() errors when angler_type_col is NULL", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -218,7 +230,9 @@ test_that("summarize_by_method() errors when angler_method_col is NULL", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -262,7 +276,9 @@ test_that("summarize_by_species_sought() errors when species_sought_col is NULL"
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -314,7 +330,9 @@ test_that("summarize_successful_parties() errors when angler_type_col is NULL", 
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -367,7 +385,9 @@ test_that("summarize_by_trip_length() errors when trip_duration_col is NULL", {
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
   d2 <- suppressWarnings(
-    add_interviews(d, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter

--- a/tests/testthat/test-creel-validation.R
+++ b/tests/testthat/test-creel-validation.R
@@ -183,3 +183,16 @@ test_that("new_creel_validation() rejects non-character context", {
     "character"
   )
 })
+
+# VALID-EMPTY: empty results data frame must not silently pass ----------------
+
+test_that("VALID-EMPTY-01: new_creel_validation with 0-row results is NOT passed", {
+  empty_df <- data.frame(
+    check = character(0),
+    status = character(0),
+    message = character(0),
+    stringsAsFactors = FALSE
+  )
+  obj <- new_creel_validation(empty_df, tier = 1L, context = "empty test")
+  expect_false(obj$passed)
+})

--- a/tests/testthat/test-design-validator.R
+++ b/tests/testthat/test-design-validator.R
@@ -344,3 +344,35 @@ describe("check_completeness() — QUAL-01", {
     )
   })
 })
+
+# VALID-ORDER: validate_design must handle reordered named vectors correctly ---
+
+test_that("VALID-ORDER-01: reordered ybar_h/s2_h/n_proposed give same result as canonical order", {
+  N_h_canon <- c(weekday = 65L, weekend = 28L)
+  ybar_h_canon <- c(weekday = 50, weekend = 60)
+  s2_h_canon <- c(weekday = 400, weekend = 500)
+  n_proposed_canon <- c(weekday = 10L, weekend = 5L)
+
+  # Reorder inputs — names swapped, should be re-keyed internally
+  N_h_reord <- c(weekend = 28L, weekday = 65L)
+  ybar_h_reord <- c(weekend = 60, weekday = 50)
+  s2_h_reord <- c(weekend = 500, weekday = 400)
+  n_proposed_reord <- c(weekend = 5L, weekday = 10L)
+
+  r_canon <- validate_design(
+    N_h = N_h_canon, ybar_h = ybar_h_canon,
+    s2_h = s2_h_canon, n_proposed = n_proposed_canon,
+    cv_target = 0.20
+  )
+  r_reord <- validate_design(
+    N_h = N_h_reord, ybar_h = ybar_h_reord,
+    s2_h = s2_h_reord, n_proposed = n_proposed_reord,
+    cv_target = 0.20
+  )
+
+  # Results should match when keyed by stratum name
+  r_canon_keyed <- r_canon$results[order(r_canon$results$stratum), ]
+  r_reord_keyed <- r_reord$results[order(r_reord$results$stratum), ]
+  expect_equal(r_canon_keyed$status, r_reord_keyed$status)
+  expect_equal(r_canon_keyed$cv_actual, r_reord_keyed$cv_actual)
+})

--- a/tests/testthat/test-design-validator.R
+++ b/tests/testthat/test-design-validator.R
@@ -22,7 +22,9 @@ make_design_with_interviews <- function() {
   )
   d2 <- suppressWarnings(add_counts(d, example_counts)) # nolint: object_usage_linter
   suppressWarnings(
-    add_interviews(d2, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d2,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -42,7 +44,9 @@ make_design_with_refusals <- function() {
   )
   d2 <- suppressWarnings(add_counts(d, example_counts)) # nolint: object_usage_linter
   suppressWarnings(
-    add_interviews(d2, example_interviews, # nolint: object_usage_linter
+    add_interviews(
+      d2,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       harvest = catch_kept, # nolint: object_usage_linter
@@ -55,31 +59,54 @@ make_design_with_refusals <- function() {
 make_aerial_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
   aerial_counts <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend"
     ),
     n_counted = c(39L, 32L, 29L, 35L, 28L, 45L, 52L),
     stringsAsFactors = FALSE
   )
   d <- suppressWarnings(
-    creel_design(cal, # nolint: object_usage_linter
-      date = date, strata = day_type, # nolint: object_usage_linter
-      survey_type = "aerial", h_open = 14
+    creel_design(
+      cal, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
+      survey_type = "aerial",
+      h_open = 14
     )
   )
   suppressWarnings(add_counts(d, aerial_counts)) # nolint: object_usage_linter
@@ -88,30 +115,52 @@ make_aerial_design <- function() {
 make_camera_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
   camera_counts <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend"
     ),
     ingress_count = c(48L, 55L, 43L, 50L, 37L, 62L, 70L),
     stringsAsFactors = FALSE
   )
   d <- suppressWarnings(
-    creel_design(cal, # nolint: object_usage_linter
-      date = date, strata = day_type, # nolint: object_usage_linter
+    creel_design(
+      cal, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "camera",
       camera_mode = "counter"
     )
@@ -136,15 +185,19 @@ make_ice_design <- function() {
     stringsAsFactors = FALSE
   )
   d <- suppressWarnings(
-    creel_design(cal, # nolint: object_usage_linter
-      date = date, strata = day_type, # nolint: object_usage_linter
+    creel_design(
+      cal, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "ice",
       effort_type = "time_on_ice",
       p_period = 0.5
     )
   )
   suppressMessages(suppressWarnings(
-    add_interviews(d, interviews, # nolint: object_usage_linter
+    add_interviews(
+      d,
+      interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       trip_status = trip_status, # nolint: object_usage_linter
@@ -172,8 +225,11 @@ N_PROPOSED_MIXED <- c(weekday = 10L, weekend = 1L) # weekday pass, weekend warn/
 describe("validate_design() — VALID-01", {
   it("returns an object of class creel_design_report", {
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_PASS, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_PASS,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
     expect_s3_class(r, "creel_design_report")
   })
@@ -181,10 +237,14 @@ describe("validate_design() — VALID-01", {
   it("$results tibble has required columns", {
     # columns: stratum, status, n_proposed, n_required, cv_actual, cv_target, message
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_PASS, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_PASS,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
-    expect_named(r$results,
+    expect_named(
+      r$results,
       c("stratum", "status", "n_proposed", "n_required", "cv_actual", "cv_target", "message"),
       ignore.order = FALSE
     )
@@ -193,30 +253,41 @@ describe("validate_design() — VALID-01", {
 
   it("stratum with n_proposed >= n_required gets status == 'pass'", {
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_PASS, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_PASS,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
     expect_true(all(r$results$status == "pass"))
   })
 
   it("stratum with n_proposed < n_required gets status 'fail' or 'warn'", {
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_FAIL, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_FAIL,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
     expect_true(all(r$results$status %in% c("fail", "warn")))
   })
 
   it("cv_actual matches cv_from_n() output exactly (no duplicate formula)", {
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_PASS, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_PASS,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
     # Check weekday stratum cv_actual matches direct cv_from_n() call
     expected_cv_weekday <- cv_from_n(
       "effort",
       n = N_PROPOSED_PASS[["weekday"]], # nolint: object_name_linter
-      N_h = N_H["weekday"], ybar_h = YBAR_H["weekday"], s2_h = S2_H["weekday"] # nolint: object_name_linter
+      N_h = N_H["weekday"],
+      ybar_h = YBAR_H["weekday"],
+      s2_h = S2_H["weekday"] # nolint: object_name_linter
     )
     expect_equal(
       r$results$cv_actual[r$results$stratum == "weekday"],
@@ -226,16 +297,22 @@ describe("validate_design() — VALID-01", {
 
   it("$passed is TRUE when all strata pass", {
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_PASS, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_PASS,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
     expect_true(r$passed)
   })
 
   it("$passed is FALSE when any stratum fails", {
     r <- validate_design(
-      N_h = N_H, ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-      n_proposed = N_PROPOSED_FAIL, cv_target = CV_TARGET # nolint: object_name_linter
+      N_h = N_H,
+      ybar_h = YBAR_H,
+      s2_h = S2_H, # nolint: object_name_linter
+      n_proposed = N_PROPOSED_FAIL,
+      cv_target = CV_TARGET # nolint: object_name_linter
     )
     expect_false(r$passed)
   })
@@ -243,8 +320,11 @@ describe("validate_design() — VALID-01", {
   it("non-data-frame sampling_frame input triggers cli_abort()", {
     expect_error(
       validate_design(
-        N_h = "not_a_vector", ybar_h = YBAR_H, s2_h = S2_H, # nolint: object_name_linter
-        n_proposed = N_PROPOSED_PASS, cv_target = CV_TARGET # nolint: object_name_linter
+        N_h = "not_a_vector",
+        ybar_h = YBAR_H,
+        s2_h = S2_H, # nolint: object_name_linter
+        n_proposed = N_PROPOSED_PASS,
+        cv_target = CV_TARGET # nolint: object_name_linter
       )
     )
   })
@@ -360,13 +440,17 @@ test_that("VALID-ORDER-01: reordered ybar_h/s2_h/n_proposed give same result as 
   n_proposed_reord <- c(weekend = 5L, weekday = 10L)
 
   r_canon <- validate_design(
-    N_h = N_h_canon, ybar_h = ybar_h_canon,
-    s2_h = s2_h_canon, n_proposed = n_proposed_canon,
+    N_h = N_h_canon,
+    ybar_h = ybar_h_canon,
+    s2_h = s2_h_canon,
+    n_proposed = n_proposed_canon,
     cv_target = 0.20
   )
   r_reord <- validate_design(
-    N_h = N_h_reord, ybar_h = ybar_h_reord,
-    s2_h = s2_h_reord, n_proposed = n_proposed_reord,
+    N_h = N_h_reord,
+    ybar_h = ybar_h_reord,
+    s2_h = s2_h_reord,
+    n_proposed = n_proposed_reord,
     cv_target = 0.20
   )
 

--- a/tests/testthat/test-est-biomass.R
+++ b/tests/testthat/test-est-biomass.R
@@ -10,13 +10,17 @@ make_ld_grouped <- function() {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  d <- add_lengths(d, example_lengths, # nolint: object_usage_linter
+  d <- add_lengths(
+    d,
+    example_lengths, # nolint: object_usage_linter
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -36,13 +40,17 @@ make_ld_ungrouped <- function() {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_lumber
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  d <- add_lengths(d, example_lengths, # nolint: object_usage_linter
+  d <- add_lengths(
+    d,
+    example_lengths, # nolint: object_usage_linter
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -96,16 +104,20 @@ test_that("est_biomass() returns creel_biomass data.frame", {
 test_that("est_biomass() returns expected columns (grouped)", {
   ld <- make_ld_grouped()
   result <- est_biomass(ld, a = 0.01, b = 3)
-  expected_cols <- c("species", "biomass_estimate", "biomass_se",
-                     "biomass_ci_lower", "biomass_ci_upper")
+  expected_cols <- c(
+    "species",
+    "biomass_estimate",
+    "biomass_se",
+    "biomass_ci_lower",
+    "biomass_ci_upper"
+  )
   expect_true(all(expected_cols %in% names(result)))
 })
 
 test_that("est_biomass() returns expected columns (ungrouped)", {
   ld <- make_ld_ungrouped()
   result <- est_biomass(ld, a = 0.01, b = 3)
-  expected_cols <- c("biomass_estimate", "biomass_se",
-                     "biomass_ci_lower", "biomass_ci_upper")
+  expected_cols <- c("biomass_estimate", "biomass_se", "biomass_ci_lower", "biomass_ci_upper")
   expect_true(all(expected_cols %in% names(result)))
   expect_false("species" %in% names(result))
 })
@@ -149,8 +161,12 @@ test_that("est_biomass() biomass_estimate matches manual W = a * L_mid^b * N_h s
     l_mid <- (rows$bin_lower + rows$bin_upper) / 2
     expected_biomass <- sum(a * l_mid^b * rows$estimate)
     actual_biomass <- result$biomass_estimate[result$species == sp]
-    expect_equal(actual_biomass, expected_biomass, tolerance = 1e-9,
-                 label = paste("biomass for species", sp))
+    expect_equal(
+      actual_biomass,
+      expected_biomass,
+      tolerance = 1e-9,
+      label = paste("biomass for species", sp)
+    )
   }
 })
 
@@ -166,8 +182,7 @@ test_that("est_biomass() biomass_se matches delta method sqrt(sum(w^2 * se^2))",
     w_h <- a * l_mid^b
     expected_se <- sqrt(sum(w_h^2 * rows$se^2))
     actual_se <- result$biomass_se[result$species == sp]
-    expect_equal(actual_se, expected_se, tolerance = 1e-9,
-                 label = paste("SE for species", sp))
+    expect_equal(actual_se, expected_se, tolerance = 1e-9, label = paste("SE for species", sp))
   }
 })
 

--- a/tests/testthat/test-est-compliance.R
+++ b/tests/testthat/test-est-compliance.R
@@ -8,13 +8,17 @@ make_ld <- function(by_species = TRUE) {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  d <- add_lengths(d, example_lengths, # nolint: object_usage_linter
+  d <- add_lengths(
+    d,
+    example_lengths, # nolint: object_usage_linter
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -64,18 +68,31 @@ test_that("est_compliance() returns creel_compliance data.frame", {
 test_that("est_compliance() returns expected columns (grouped)", {
   ld <- make_ld()
   result <- est_compliance(ld, min_length = 300)
-  expected_cols <- c("species", "min_length", "n_legal_est", "n_total_est",
-                     "compliance_prop", "compliance_se",
-                     "compliance_ci_lower", "compliance_ci_upper")
+  expected_cols <- c(
+    "species",
+    "min_length",
+    "n_legal_est",
+    "n_total_est",
+    "compliance_prop",
+    "compliance_se",
+    "compliance_ci_lower",
+    "compliance_ci_upper"
+  )
   expect_true(all(expected_cols %in% names(result)))
 })
 
 test_that("est_compliance() returns expected columns (ungrouped)", {
   ld <- make_ld(by_species = FALSE)
   result <- est_compliance(ld, min_length = 300)
-  expected_cols <- c("min_length", "n_legal_est", "n_total_est",
-                     "compliance_prop", "compliance_se",
-                     "compliance_ci_lower", "compliance_ci_upper")
+  expected_cols <- c(
+    "min_length",
+    "n_legal_est",
+    "n_total_est",
+    "compliance_prop",
+    "compliance_se",
+    "compliance_ci_lower",
+    "compliance_ci_upper"
+  )
   expect_true(all(expected_cols %in% names(result)))
   expect_false("species" %in% names(result))
 })
@@ -116,8 +133,12 @@ test_that("est_compliance() matches manual P = sum(I_h * N_h) / sum(N_h)", {
     legal <- rows$bin_lower >= min_l
     expected_p <- sum(rows$estimate[legal]) / sum(rows$estimate)
     actual_p <- result$compliance_prop[result$species == sp]
-    expect_equal(actual_p, expected_p, tolerance = 1e-9,
-                 label = paste("compliance_prop for species", sp))
+    expect_equal(
+      actual_p,
+      expected_p,
+      tolerance = 1e-9,
+      label = paste("compliance_prop for species", sp)
+    )
   }
 })
 
@@ -129,8 +150,12 @@ test_that("est_compliance() n_total_est matches sum(estimate)", {
     rows <- ld[ld$species == sp, ]
     expected_total <- sum(rows$estimate)
     actual_total <- result$n_total_est[result$species == sp]
-    expect_equal(actual_total, expected_total, tolerance = 1e-9,
-                 label = paste("n_total_est for species", sp))
+    expect_equal(
+      actual_total,
+      expected_total,
+      tolerance = 1e-9,
+      label = paste("n_total_est for species", sp)
+    )
   }
 })
 
@@ -143,8 +168,12 @@ test_that("est_compliance() n_legal_est + n_illegal_est = n_total_est", {
     rows <- ld[ld$species == sp, ]
     illegal_est <- sum(rows$estimate[rows$bin_lower < min_l])
     row <- result[result$species == sp, ]
-    expect_equal(row$n_legal_est + illegal_est, row$n_total_est, tolerance = 1e-9,
-                 label = paste("legal + illegal = total for species", sp))
+    expect_equal(
+      row$n_legal_est + illegal_est,
+      row$n_total_est,
+      tolerance = 1e-9,
+      label = paste("legal + illegal = total for species", sp)
+    )
   }
 })
 

--- a/tests/testthat/test-est-effort-camera.R
+++ b/tests/testthat/test-est-effort-camera.R
@@ -4,16 +4,22 @@
 make_camera_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
   )
   suppressWarnings(
-    creel_design(cal,
-      date = date, strata = day_type, # nolint
-      survey_type = "camera", camera_mode = "counter"
+    creel_design(
+      cal,
+      date = date,
+      strata = day_type, # nolint
+      survey_type = "camera",
+      camera_mode = "counter"
     )
   )
 }
@@ -21,8 +27,11 @@ make_camera_design <- function() {
 make_camera_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend"),
     ingress_count = c(48L, 55L, 43L, 80L, 75L),
@@ -34,8 +43,11 @@ make_camera_counts <- function() {
 make_interviews <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend"),
     hours_fished = c(3.5, 2.0, 4.0, 2.5, 3.0),
@@ -109,8 +121,10 @@ test_that("CEST-07: raw mode returns creel_estimates", {
 test_that("CEST-08: raw mode has expected columns", {
   d <- make_design_with_counts()
   res <- suppressWarnings(est_effort_camera(d, h_open = 14))
-  expect_true(all(c("estimate", "se", "ci_lower", "ci_upper", "n") %in%
-    names(res$estimates)))
+  expect_true(all(
+    c("estimate", "se", "ci_lower", "ci_upper", "n") %in%
+      names(res$estimates)
+  ))
 })
 
 test_that("CEST-09: ratio mode returns creel_estimates", {
@@ -126,8 +140,10 @@ test_that("CEST-10: ratio mode has expected columns", {
   res <- suppressWarnings(
     est_effort_camera(d, interviews = make_interviews())
   )
-  expect_true(all(c("estimate", "se", "ci_lower", "ci_upper", "n") %in%
-    names(res$estimates)))
+  expect_true(all(
+    c("estimate", "se", "ci_lower", "ci_upper", "n") %in%
+      names(res$estimates)
+  ))
 })
 
 # Numeric correctness ---------------------------------------------------------
@@ -199,16 +215,22 @@ test_that("CEST-18: higher conf_level gives wider CI", {
 test_that("CEST-19: non-camera design type produces a cli warning", {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02",
-      "2024-06-03", "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend")
   )
   d <- suppressWarnings(creel_design(cal, date = date, strata = day_type)) # nolint
   counts <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02",
-      "2024-06-03", "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend"),
     count = c(10L, 12L, 14L, 20L, 22L)

--- a/tests/testthat/test-est-length-distribution.R
+++ b/tests/testthat/test-est-length-distribution.R
@@ -2,7 +2,8 @@
 
 # Fixtures ----
 
-make_design_with_lengths_for_est <- function() { # nolint: object_length_linter
+make_design_with_lengths_for_est <- function() {
+  # nolint: object_length_linter
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
   data(example_lengths, package = "tidycreel")
@@ -10,13 +11,17 @@ make_design_with_lengths_for_est <- function() { # nolint: object_length_linter
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  add_lengths(d, example_lengths, # nolint: object_usage_linter
+  add_lengths(
+    d,
+    example_lengths, # nolint: object_usage_linter
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -27,14 +32,17 @@ make_design_with_lengths_for_est <- function() { # nolint: object_length_linter
   )
 }
 
-make_design_no_lengths_for_est <- function() { # nolint: object_length_linter
+make_design_no_lengths_for_est <- function() {
+  # nolint: object_length_linter
   data(example_calendar, package = "tidycreel")
   data(example_interviews, package = "tidycreel")
 
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -85,10 +93,21 @@ test_that("est_length_distribution() returns classed data.frame", {
 test_that("est_length_distribution() returns expected columns", {
   d <- make_design_with_lengths_for_est()
   result <- est_length_distribution(d, type = "catch")
-  expect_true(all(c(
-    "length_bin", "bin_lower", "bin_upper", "estimate", "se",
-    "ci_lower", "ci_upper", "percent", "cumulative_percent", "n"
-  ) %in% names(result)))
+  expect_true(all(
+    c(
+      "length_bin",
+      "bin_lower",
+      "bin_upper",
+      "estimate",
+      "se",
+      "ci_lower",
+      "ci_upper",
+      "percent",
+      "cumulative_percent",
+      "n"
+    ) %in%
+      names(result)
+  ))
 })
 
 test_that("est_length_distribution() length_bin is ordered", {

--- a/tests/testthat/test-est-mean-length.R
+++ b/tests/testthat/test-est-mean-length.R
@@ -8,13 +8,17 @@ make_ld <- function(by_species = TRUE) {
   d <- suppressWarnings(
     creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   )
-  d <- suppressWarnings(add_interviews(d, example_interviews, # nolint: object_usage_linter
+  d <- suppressWarnings(add_interviews(
+    d,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
-  d <- add_lengths(d, example_lengths, # nolint: object_usage_linter
+  d <- add_lengths(
+    d,
+    example_lengths, # nolint: object_usage_linter
     length_uid = interview_id, # nolint: object_usage_linter
     interview_uid = interview_id, # nolint: object_usage_linter
     species = species, # nolint: object_usage_linter
@@ -56,16 +60,25 @@ test_that("est_mean_length() returns creel_mean_length data.frame", {
 test_that("est_mean_length() returns expected columns (grouped)", {
   ld <- make_ld()
   result <- est_mean_length(ld)
-  expected_cols <- c("species", "mean_length", "mean_length_se",
-                     "mean_length_ci_lower", "mean_length_ci_upper")
+  expected_cols <- c(
+    "species",
+    "mean_length",
+    "mean_length_se",
+    "mean_length_ci_lower",
+    "mean_length_ci_upper"
+  )
   expect_true(all(expected_cols %in% names(result)))
 })
 
 test_that("est_mean_length() returns expected columns (ungrouped)", {
   ld <- make_ld(by_species = FALSE)
   result <- est_mean_length(ld)
-  expected_cols <- c("mean_length", "mean_length_se",
-                     "mean_length_ci_lower", "mean_length_ci_upper")
+  expected_cols <- c(
+    "mean_length",
+    "mean_length_se",
+    "mean_length_ci_lower",
+    "mean_length_ci_upper"
+  )
   expect_true(all(expected_cols %in% names(result)))
   expect_false("species" %in% names(result))
 })
@@ -104,8 +117,7 @@ test_that("est_mean_length() matches manual sum(L_mid * N) / sum(N)", {
     l_mid <- (rows$bin_lower + rows$bin_upper) / 2
     expected <- sum(l_mid * rows$estimate) / sum(rows$estimate)
     actual <- result$mean_length[result$species == sp]
-    expect_equal(actual, expected, tolerance = 1e-9,
-                 label = paste("mean_length for species", sp))
+    expect_equal(actual, expected, tolerance = 1e-9, label = paste("mean_length for species", sp))
   }
 })
 
@@ -120,8 +132,12 @@ test_that("est_mean_length() SE matches delta method (1/N) * sqrt(sum((L-mean)^2
     mean_l <- sum(l_mid * rows$estimate) / n_total
     expected_se <- sqrt(sum((l_mid - mean_l)^2 * rows$se^2)) / n_total
     actual_se <- result$mean_length_se[result$species == sp]
-    expect_equal(actual_se, expected_se, tolerance = 1e-9,
-                 label = paste("mean_length_se for species", sp))
+    expect_equal(
+      actual_se,
+      expected_se,
+      tolerance = 1e-9,
+      label = paste("mean_length_se for species", sp)
+    )
   }
 })
 

--- a/tests/testthat/test-estimate-angler-n.R
+++ b/tests/testthat/test-estimate-angler-n.R
@@ -1,22 +1,24 @@
 # Chapman reference values
-M_c <- 200L; n_c <- 50L; m_c <- 10L
+M_c <- 200L
+n_c <- 50L
+m_c <- 10L
 N_hat_c <- ((M_c + 1) * (n_c + 1)) / (m_c + 1) - 1
-var_N_c  <- ((M_c + 1) * (n_c + 1) * (M_c - m_c) * (n_c - m_c)) /
-              ((m_c + 2) * (m_c + 1)^2)
-se_N_c   <- sqrt(var_N_c)
+var_N_c <- ((M_c + 1) * (n_c + 1) * (M_c - m_c) * (n_c - m_c)) /
+  ((m_c + 2) * (m_c + 1)^2)
+se_N_c <- sqrt(var_N_c)
 
 # Petersen reference values
-N_hat_p <- (M_c * n_c) / m_c    # 200*50/10 = 1000
+N_hat_p <- (M_c * n_c) / m_c # 200*50/10 = 1000
 
 # Schnabel reference values (sum_m = 18 < 50 => Poisson CI branch)
 M_s <- c(0L, 47L, 91L, 131L)
 n_s <- c(50L, 50L, 50L, 50L)
-m_s <- c(0L,  4L,  6L,  8L)
-sum_Mn_s <- sum(M_s * n_s)   # 0+2350+4550+6550 = 13450
-sum_m_s  <- sum(m_s)         # 0+4+6+8 = 18
-N_hat_s  <- sum_Mn_s / sum_m_s  # 747.222...
+m_s <- c(0L, 4L, 6L, 8L)
+sum_Mn_s <- sum(M_s * n_s) # 0+2350+4550+6550 = 13450
+sum_m_s <- sum(m_s) # 0+4+6+8 = 18
+N_hat_s <- sum_Mn_s / sum_m_s # 747.222...
 se_inv_s <- sqrt(sum_m_s / sum_Mn_s^2)
-se_N_s   <- N_hat_s^2 * se_inv_s
+se_N_s <- N_hat_s^2 * se_inv_s
 
 # --- MR-01: Chapman estimator ---
 
@@ -100,9 +102,9 @@ test_that("Test M: Schnabel Poisson CI branch fires when sum(m) < 50 (ci_lower <
 })
 
 test_that("Test N: Schnabel normal CI branch fires when sum(m) >= 50", {
-  M_s2 <- c(0L,  100L, 200L, 300L, 400L)
+  M_s2 <- c(0L, 100L, 200L, 300L, 400L)
   n_s2 <- c(100L, 100L, 100L, 100L, 100L)
-  m_s2 <- c(0L,   10L,  12L,  14L,  16L)   # sum(m) = 52 >= 50
+  m_s2 <- c(0L, 10L, 12L, 14L, 16L) # sum(m) = 52 >= 50
   expect_true(sum(m_s2) >= 50L)
   result <- estimate_angler_n(M = M_s2, n = n_s2, m = m_s2, method = "schnabel")
   expect_true(result$estimates$ci_lower < result$estimates$estimate)
@@ -174,7 +176,10 @@ test_that("Test X: Schnabel warns and returns ci_hi = Inf when lo_m = 0", {
   # sum_m = 1 => qpois(0.025, 1) = 0 => lo_m = 0 => ci_hi = Inf
   expect_warning(
     result <- estimate_angler_n(
-      M = c(0L, 10L), n = c(5L, 5L), m = c(0L, 1L), method = "schnabel"
+      M = c(0L, 10L),
+      n = c(5L, 5L),
+      m = c(0L, 1L),
+      method = "schnabel"
     ),
     regexp = "ci_hi set to Inf"
   )

--- a/tests/testthat/test-estimate-catch-rate.R
+++ b/tests/testthat/test-estimate-catch-rate.R
@@ -5,17 +5,36 @@
 #' Produces a creel_design with sections "North", "Central", "South" and
 #' interview data for all three sections. 12-date calendar, 8-10 interviews
 #' per section with varying catch/effort across sections.
-make_3section_design_with_interviews <- function() { # nolint: object_length_linter
+make_3section_design_with_interviews <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -34,14 +53,44 @@ make_3section_design_with_interviews <- function() { # nolint: object_length_lin
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
       # North: weekday ~15-25, weekend ~20-28
-      20, 22, 18, 25, 15, 24,
-      21, 26, 23, 28, 20, 27,
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
       # Central: weekday ~30-45, weekend ~35-48
-      35, 38, 32, 42, 30, 45,
-      37, 44, 40, 48, 35, 46,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
       # South: weekday ~5-12, weekend ~6-13
-      8, 10, 5, 12, 6, 11,
-      7, 9, 6, 13, 8, 10
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -54,70 +103,210 @@ make_3section_design_with_interviews <- function() { # nolint: object_length_lin
   interviews <- data.frame(
     date = as.Date(c(
       # North (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
       # Central (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21",
       # South (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14"
     )),
     day_type = c(
       # North
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
       # Central
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
       # South
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central", "South"), each = 9),
     catch_total = c(
       # North: ~1 fish/hr
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
       # Central: ~1.5 fish/hr
-      5, 6, 5, 7, 6, 5, 7, 8, 6,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6,
       # South: ~2.5 fish/hr
-      10, 12, 9, 11, 10, 12, 13, 11, 10
+      10,
+      12,
+      9,
+      11,
+      10,
+      12,
+      13,
+      11,
+      10
     ),
     hours_fished = c(
       # North: 2-3 hrs
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central: 3-4 hrs
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South: 4-5 hrs
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     catch_kept = c(
       # North
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
       # Central
-      3, 4, 3, 5, 4, 3, 5, 6, 4,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4,
       # South
-      7, 9, 6, 8, 7, 9, 10, 8, 7
+      7,
+      9,
+      6,
+      8,
+      7,
+      9,
+      10,
+      8,
+      7
     ),
     trip_status = rep("complete", 27),
     trip_duration = c(
       # North
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -125,17 +314,36 @@ make_3section_design_with_interviews <- function() { # nolint: object_length_lin
 #'
 #' Registered sections: "North", "Central", "South".
 #' Interview data contains only "North" and "Central" rows — "South" is absent.
-make_section_design_with_missing_interview_section <- function() { # nolint: object_length_linter
+make_section_design_with_missing_interview_section <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -152,9 +360,42 @@ make_section_design_with_missing_interview_section <- function() { # nolint: obj
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -163,44 +404,139 @@ make_section_design_with_missing_interview_section <- function() { # nolint: obj
   # Only North and Central interviews — South absent
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4
     ),
     trip_status = rep("complete", 18),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -208,8 +544,14 @@ make_section_design_with_missing_interview_section <- function() { # nolint: obj
 make_test_calendar_cpue <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -224,34 +566,190 @@ make_test_interviews <- function() {
   data.frame(
     date = as.Date(c(
       # Weekday interviews (20 total, spread across 4 dates)
-      rep("2024-06-01", 5), rep("2024-06-02", 5),
-      rep("2024-06-03", 5), rep("2024-06-04", 5),
+      rep("2024-06-01", 5),
+      rep("2024-06-02", 5),
+      rep("2024-06-03", 5),
+      rep("2024-06-04", 5),
       # Weekend interviews (20 total, spread across 4 dates)
-      rep("2024-06-08", 5), rep("2024-06-09", 5),
-      rep("2024-06-15", 5), rep("2024-06-16", 5)
+      rep("2024-06-08", 5),
+      rep("2024-06-09", 5),
+      rep("2024-06-15", 5),
+      rep("2024-06-16", 5)
     )),
     catch_total = c(
       # Weekday catch (realistic variation)
-      2, 5, 3, 1, 4, 6, 2, 3, 5, 7, 4, 2, 3, 6, 5, 4, 2, 3, 5, 6,
+      2,
+      5,
+      3,
+      1,
+      4,
+      6,
+      2,
+      3,
+      5,
+      7,
+      4,
+      2,
+      3,
+      6,
+      5,
+      4,
+      2,
+      3,
+      5,
+      6,
       # Weekend catch (higher on average)
-      8, 10, 6, 9, 7, 11, 8, 10, 9, 12, 7, 8, 10, 11, 9, 8, 7, 9, 10, 11
+      8,
+      10,
+      6,
+      9,
+      7,
+      11,
+      8,
+      10,
+      9,
+      12,
+      7,
+      8,
+      10,
+      11,
+      9,
+      8,
+      7,
+      9,
+      10,
+      11
     ),
     hours_fished = c(
       # Weekday effort (2-5 hours)
-      2.5, 4.0, 3.5, 2.0, 3.0, 5.0, 2.5, 3.5, 4.5, 5.0, 3.5, 2.5, 3.0, 4.5, 4.0, 3.5, 2.5, 3.0, 4.0, 4.5,
+      2.5,
+      4.0,
+      3.5,
+      2.0,
+      3.0,
+      5.0,
+      2.5,
+      3.5,
+      4.5,
+      5.0,
+      3.5,
+      2.5,
+      3.0,
+      4.5,
+      4.0,
+      3.5,
+      2.5,
+      3.0,
+      4.0,
+      4.5,
       # Weekend effort (3-6 hours)
-      4.0, 5.5, 3.5, 5.0, 4.5, 6.0, 4.5, 5.5, 5.0, 6.0, 4.0, 4.5, 5.5, 5.5, 5.0, 4.5, 4.0, 5.0, 5.5, 5.5
+      4.0,
+      5.5,
+      3.5,
+      5.0,
+      4.5,
+      6.0,
+      4.5,
+      5.5,
+      5.0,
+      6.0,
+      4.0,
+      4.5,
+      5.5,
+      5.5,
+      5.0,
+      4.5,
+      4.0,
+      5.0,
+      5.5,
+      5.5
     ),
     catch_kept = c(
       # Kept fish (always <= catch_total)
-      2, 4, 3, 1, 3, 5, 2, 2, 4, 6, 3, 2, 2, 5, 4, 3, 2, 2, 4, 5,
-      5, 8, 5, 7, 6, 9, 6, 8, 7, 10, 5, 6, 8, 9, 7, 6, 5, 7, 8, 9
+      2,
+      4,
+      3,
+      1,
+      3,
+      5,
+      2,
+      2,
+      4,
+      6,
+      3,
+      2,
+      2,
+      5,
+      4,
+      3,
+      2,
+      2,
+      4,
+      5,
+      5,
+      8,
+      5,
+      7,
+      6,
+      9,
+      6,
+      8,
+      7,
+      10,
+      5,
+      6,
+      8,
+      9,
+      7,
+      6,
+      5,
+      7,
+      8,
+      9
     ),
     trip_status = rep("complete", 40),
     trip_duration = c(
       # Trip durations matching hours_fished
-      2.5, 4.0, 3.5, 2.0, 3.0, 5.0, 2.5, 3.5, 4.5, 5.0, 3.5, 2.5, 3.0, 4.5, 4.0, 3.5, 2.5, 3.0, 4.0, 4.5,
-      4.0, 5.5, 3.5, 5.0, 4.5, 6.0, 4.5, 5.5, 5.0, 6.0, 4.0, 4.5, 5.5, 5.5, 5.0, 4.5, 4.0, 5.0, 5.5, 5.5
+      2.5,
+      4.0,
+      3.5,
+      2.0,
+      3.0,
+      5.0,
+      2.5,
+      3.5,
+      4.5,
+      5.0,
+      3.5,
+      2.5,
+      3.0,
+      4.5,
+      4.0,
+      3.5,
+      2.5,
+      3.0,
+      4.0,
+      4.5,
+      4.0,
+      5.5,
+      3.5,
+      5.0,
+      4.5,
+      6.0,
+      4.5,
+      5.5,
+      5.0,
+      6.0,
+      4.0,
+      4.5,
+      5.5,
+      5.5,
+      5.0,
+      4.5,
+      4.0,
+      5.0,
+      5.5,
+      5.5
     ),
     stringsAsFactors = FALSE
   )
@@ -262,7 +760,15 @@ make_cpue_design <- function() {
   cal <- make_test_calendar_cpue()
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
   interviews <- make_test_interviews()
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 #' Create small design with n interviews
@@ -293,15 +799,27 @@ make_small_cpue_design <- function(n, n_incomplete = 0) {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 #' Create unbalanced design (one stratum < 10)
 make_unbalanced_cpue_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
@@ -311,7 +829,9 @@ make_unbalanced_cpue_design <- function() {
   # 15 weekday interviews, only 5 weekend interviews
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 5), rep("2024-06-02", 5), rep("2024-06-03", 5),
+      rep("2024-06-01", 5),
+      rep("2024-06-02", 5),
+      rep("2024-06-03", 5),
       rep("2024-06-08", 5)
     )),
     catch_total = c(2, 3, 4, 5, 6, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12),
@@ -322,7 +842,15 @@ make_unbalanced_cpue_design <- function() {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 # Basic behavior tests ----
@@ -657,7 +1185,9 @@ test_that("full workflow with example_calendar and example_interviews produces v
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
 
   # Add interviews
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
@@ -683,7 +1213,9 @@ test_that("grouped workflow with example data errors due to sample size", {
 
   # Create design and add interviews
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
@@ -705,7 +1237,9 @@ test_that("result from example data has reasonable CPUE values", {
 
   # Create design and add interviews
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
@@ -731,14 +1265,114 @@ test_that("estimate_catch_rate with zero-effort interviews issues warning and ex
   # Create interviews with 2 zero-effort rows
   interviews <- data.frame(
     date = as.Date(rep(c("2024-06-01", "2024-06-02", "2024-06-03"), each = 10)),
-    catch_total = c(2, 3, 4, 5, 6, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 2, 3, 4, 5, 6, 3, 4, 5, 6, 7, 0, 0, 6, 7, 8),
-    hours_fished = c(2, 3, 4, 5, 3, 3, 4, 5, 3, 4, 4, 5, 3, 4, 5, 2, 3, 4, 5, 3, 3, 4, 5, 3, 4, 0, 0, 3, 4, 5),
+    catch_total = c(
+      2,
+      3,
+      4,
+      5,
+      6,
+      3,
+      4,
+      5,
+      6,
+      7,
+      4,
+      5,
+      6,
+      7,
+      8,
+      2,
+      3,
+      4,
+      5,
+      6,
+      3,
+      4,
+      5,
+      6,
+      7,
+      0,
+      0,
+      6,
+      7,
+      8
+    ),
+    hours_fished = c(
+      2,
+      3,
+      4,
+      5,
+      3,
+      3,
+      4,
+      5,
+      3,
+      4,
+      4,
+      5,
+      3,
+      4,
+      5,
+      2,
+      3,
+      4,
+      5,
+      3,
+      3,
+      4,
+      5,
+      3,
+      4,
+      0,
+      0,
+      3,
+      4,
+      5
+    ),
     trip_status = rep("complete", 30),
-    trip_duration = c(2, 3, 4, 5, 3, 3, 4, 5, 3, 4, 4, 5, 3, 4, 5, 2, 3, 4, 5, 3, 3, 4, 5, 3, 4, 2, 2, 3, 4, 5),
+    trip_duration = c(
+      2,
+      3,
+      4,
+      5,
+      3,
+      3,
+      4,
+      5,
+      3,
+      4,
+      4,
+      5,
+      3,
+      4,
+      5,
+      2,
+      3,
+      4,
+      5,
+      3,
+      3,
+      4,
+      5,
+      3,
+      4,
+      2,
+      2,
+      3,
+      4,
+      5
+    ),
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Expect warning about zero-effort interviews
   expect_warning(
@@ -770,7 +1404,14 @@ test_that("estimate_catch_rate with all-zero effort errors due to sample size th
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Should error due to n < 10 after filtering out all zero-effort
   expect_error(
@@ -783,8 +1424,14 @@ test_that("estimate_catch_rate grouped with zero-effort interviews excludes them
   # Create synthetic data with some zero-effort interviews in grouped estimation
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4)
   )
@@ -792,32 +1439,101 @@ test_that("estimate_catch_rate grouped with zero-effort interviews excludes them
   # Create interviews with sufficient samples per group but some zero-effort
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 6), rep("2024-06-02", 6),
-      rep("2024-06-08", 6), rep("2024-06-09", 6)
+      rep("2024-06-01", 6),
+      rep("2024-06-02", 6),
+      rep("2024-06-08", 6),
+      rep("2024-06-09", 6)
     )),
     catch_total = c(
-      2, 3, 4, 5, 6, 0, # weekday - one zero-catch with zero-effort
-      3, 4, 5, 6, 7, 8, # weekday
-      7, 8, 9, 10, 11, 0, # weekend - one zero-catch with zero-effort
-      8, 9, 10, 11, 12, 13 # weekend
+      2,
+      3,
+      4,
+      5,
+      6,
+      0, # weekday - one zero-catch with zero-effort
+      3,
+      4,
+      5,
+      6,
+      7,
+      8, # weekday
+      7,
+      8,
+      9,
+      10,
+      11,
+      0, # weekend - one zero-catch with zero-effort
+      8,
+      9,
+      10,
+      11,
+      12,
+      13 # weekend
     ),
     hours_fished = c(
-      2, 3, 4, 5, 3, 0, # weekday - one zero-effort
-      3, 4, 5, 3, 4, 5,
-      4, 5, 3, 5, 4, 0, # weekend - one zero-effort
-      4, 5, 5, 6, 5, 6
+      2,
+      3,
+      4,
+      5,
+      3,
+      0, # weekday - one zero-effort
+      3,
+      4,
+      5,
+      3,
+      4,
+      5,
+      4,
+      5,
+      3,
+      5,
+      4,
+      0, # weekend - one zero-effort
+      4,
+      5,
+      5,
+      6,
+      5,
+      6
     ),
     trip_status = rep("complete", 24),
     trip_duration = c(
-      2, 3, 4, 5, 3, 1, # weekday
-      3, 4, 5, 3, 4, 5,
-      4, 5, 3, 5, 4, 1, # weekend
-      4, 5, 5, 6, 5, 6
+      2,
+      3,
+      4,
+      5,
+      3,
+      1, # weekday
+      3,
+      4,
+      5,
+      3,
+      4,
+      5,
+      4,
+      5,
+      3,
+      5,
+      4,
+      1, # weekend
+      4,
+      5,
+      5,
+      6,
+      5,
+      6
     )
   )
 
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Grouped estimation should warn about zero-effort and exclude them
   expect_warning(
@@ -837,7 +1553,8 @@ test_that("estimate_catch_rate grouped by day_type with variance = 'bootstrap' w
   design <- make_cpue_design()
 
   set.seed(12345)
-  result <- suppressWarnings( # nolint: object_usage_linter
+  result <- suppressWarnings(
+    # nolint: object_usage_linter
     estimate_catch_rate(design, by = day_type, variance = "bootstrap") # nolint: object_usage_linter
   )
 
@@ -878,15 +1595,29 @@ make_mor_design <- function(n_complete = 15, n_incomplete = 25) {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 # Helper: create grouped design with incomplete trips in both groups
 make_mor_grouped_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -896,8 +1627,10 @@ make_mor_grouped_design <- function() {
   # 40 interviews: 20 weekday (10 complete, 10 incomplete), 20 weekend (10 complete, 10 incomplete)
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 10), rep("2024-06-02", 10),
-      rep("2024-06-08", 10), rep("2024-06-09", 10)
+      rep("2024-06-01", 10),
+      rep("2024-06-02", 10),
+      rep("2024-06-08", 10),
+      rep("2024-06-09", 10)
     )),
     day_type = rep(c("weekday", "weekday", "weekend", "weekend"), each = 10),
     catch_total = rep(c(2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 4),
@@ -908,7 +1641,15 @@ make_mor_grouped_design <- function() {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 # Basic MOR functionality tests ----
@@ -940,18 +1681,33 @@ test_that("estimator='mor' supports all variance methods", {
   design <- make_mor_design(n_complete = 10, n_incomplete = 30)
 
   # Test taylor
-  result_taylor <- estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", variance = "taylor") # nolint: object_usage_linter
+  result_taylor <- estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor",
+    variance = "taylor"
+  ) # nolint: object_usage_linter
   expect_equal(result_taylor$variance_method, "taylor")
   expect_true(is.numeric(result_taylor$estimates$estimate))
 
   # Test bootstrap
   set.seed(12345)
-  result_bootstrap <- estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", variance = "bootstrap") # nolint: object_usage_linter
+  result_bootstrap <- estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor",
+    variance = "bootstrap"
+  ) # nolint: object_usage_linter
   expect_equal(result_bootstrap$variance_method, "bootstrap")
   expect_true(is.numeric(result_bootstrap$estimates$estimate))
 
   # Test jackknife
-  result_jackknife <- estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", variance = "jackknife") # nolint: object_usage_linter
+  result_jackknife <- estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor",
+    variance = "jackknife"
+  ) # nolint: object_usage_linter
   expect_equal(result_jackknife$variance_method, "jackknife")
   expect_true(is.numeric(result_jackknife$estimates$estimate))
 })
@@ -994,7 +1750,14 @@ test_that("error when estimator='mor' and trip_status missing", {
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Manually remove trip_status_col to simulate missing field
   design$trip_status_col <- NULL
@@ -1084,7 +1847,8 @@ test_that("estimator='mor' matches manual survey::svymean calculation", {
   )
 
   # Calculate mean of individual catch/effort ratios
-  incomplete_interviews$cpue_ratio <- incomplete_interviews$catch_total / incomplete_interviews$hours_fished
+  incomplete_interviews$cpue_ratio <- incomplete_interviews$catch_total /
+    incomplete_interviews$hours_fished
   incomplete_svy <- survey::svydesign(
     ids = ~1,
     data = incomplete_interviews
@@ -1175,14 +1939,26 @@ make_truncation_test_design <- function(n_above, n_below, threshold) {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 test_that("default truncate_at=0.5 filters trips below threshold", {
   # Create design with 25 trips >= 0.5h, 5 trips < 0.5h
   design <- make_truncation_test_design(n_above = 25, n_below = 5, threshold = 0.5)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor"
+  )) # nolint: object_usage_linter
 
   # Should use only the 25 trips >= 0.5h
   expect_equal(result$estimates$n, 25)
@@ -1192,7 +1968,12 @@ test_that("custom truncate_at filters correctly", {
   # Create design with 20 trips >= 1.0h, 10 trips < 1.0h
   design <- make_truncation_test_design(n_above = 20, n_below = 10, threshold = 1.0)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = 1.0)) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor",
+    truncate_at = 1.0
+  )) # nolint: object_usage_linter
 
   # Should use only the 20 trips >= 1.0h
   expect_equal(result$estimates$n, 20)
@@ -1202,7 +1983,12 @@ test_that("truncate_at=NULL uses all trips", {
   # Create design with 15 trips >= 0.5h, 15 trips < 0.5h
   design <- make_truncation_test_design(n_above = 15, n_below = 15, threshold = 0.5)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = NULL)) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor",
+    truncate_at = NULL
+  )) # nolint: object_usage_linter
 
   # Should use all 30 trips (no truncation)
   expect_equal(result$estimates$n, 30)
@@ -1212,7 +1998,11 @@ test_that("truncated sample count stored in metadata", {
   # Create design with 25 trips >= 0.5h, 5 trips < 0.5h
   design <- make_truncation_test_design(n_above = 25, n_below = 5, threshold = 0.5)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor"
+  )) # nolint: object_usage_linter
 
   # Should have truncation metadata stored
   expect_true(!is.null(result$mor_n_truncated))
@@ -1268,7 +2058,12 @@ test_that("MOR with truncation matches manual survey::svymean", {
   design <- make_truncation_test_design(n_above = 25, n_below = 5, threshold = 0.5)
 
   # tidycreel MOR with truncation
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = 0.5)) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor",
+    truncate_at = 0.5
+  )) # nolint: object_usage_linter
 
   # Manual calculation: filter to incomplete AND >= 0.5h
   truncated_interviews <- design$interviews[
@@ -1283,7 +2078,8 @@ test_that("MOR with truncation matches manual survey::svymean", {
   )
 
   # Compute individual ratios
-  truncated_interviews$cpue_ratio <- truncated_interviews$catch_total / truncated_interviews$hours_fished
+  truncated_interviews$cpue_ratio <- truncated_interviews$catch_total /
+    truncated_interviews$hours_fished
 
   # Rebuild survey design with ratio column
   truncated_svy <- survey::svydesign(
@@ -1305,7 +2101,12 @@ test_that("MOR stores truncation metadata when trips excluded", {
   design <- make_truncation_test_design(n_above = 25, n_below = 5, threshold = 0.5)
 
   result <- suppressWarnings(
-    suppressMessages(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = 0.5))
+    suppressMessages(estimate_catch_rate(
+      design,
+      use_trips = "incomplete",
+      estimator = "mor",
+      truncate_at = 0.5
+    ))
   )
 
   # Should store truncation metadata
@@ -1317,7 +2118,12 @@ test_that("MOR stores zero truncation when all trips above threshold", {
   design <- make_truncation_test_design(n_above = 30, n_below = 0, threshold = 0.5)
 
   result <- suppressWarnings(
-    suppressMessages(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = 0.5))
+    suppressMessages(estimate_catch_rate(
+      design,
+      use_trips = "incomplete",
+      estimator = "mor",
+      truncate_at = 0.5
+    ))
   )
 
   # Should store zero truncation
@@ -1337,7 +2143,12 @@ test_that("MOR truncation metadata NULL when truncate_at = NULL", {
   design <- make_truncation_test_design(n_above = 25, n_below = 5, threshold = 0.5)
 
   result <- suppressWarnings(
-    suppressMessages(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = NULL))
+    suppressMessages(estimate_catch_rate(
+      design,
+      use_trips = "incomplete",
+      estimator = "mor",
+      truncate_at = NULL
+    ))
   )
 
   # Should have NULL truncate_at
@@ -1349,7 +2160,12 @@ test_that("MOR print output shows truncation details", {
   design <- make_truncation_test_design(n_above = 25, n_below = 5, threshold = 0.5)
 
   result <- suppressWarnings(
-    suppressMessages(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = 0.5))
+    suppressMessages(estimate_catch_rate(
+      design,
+      use_trips = "incomplete",
+      estimator = "mor",
+      truncate_at = 0.5
+    ))
   )
 
   # Capture print output
@@ -1365,7 +2181,12 @@ test_that("MOR print output shows zero truncation details", {
   design <- make_truncation_test_design(n_above = 30, n_below = 0, threshold = 0.5)
 
   result <- suppressWarnings(
-    suppressMessages(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor", truncate_at = 0.5))
+    suppressMessages(estimate_catch_rate(
+      design,
+      use_trips = "incomplete",
+      estimator = "mor",
+      truncate_at = 0.5
+    ))
   )
 
   # Capture print output
@@ -1405,7 +2226,15 @@ make_use_trips_design <- function(n_complete = 20, n_incomplete = 20) {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 # Default behavior tests ----
@@ -1450,7 +2279,11 @@ test_that("use_trips='complete' explicitly filters to complete trips", {
 test_that("use_trips='incomplete' filters to incomplete trips", {
   design <- make_use_trips_design(n_complete = 10, n_incomplete = 35)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor"
+  )) # nolint: object_usage_linter
 
   expect_equal(result$estimates$n, 35)
 })
@@ -1458,7 +2291,11 @@ test_that("use_trips='incomplete' filters to incomplete trips", {
 test_that("use_trips='incomplete' uses mean-of-ratios estimator", {
   design <- make_use_trips_design(n_complete = 10, n_incomplete = 30)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor"
+  )) # nolint: object_usage_linter
 
   expect_equal(result$method, "mean-of-ratios-cpue")
 })
@@ -1466,7 +2303,11 @@ test_that("use_trips='incomplete' uses mean-of-ratios estimator", {
 test_that("use_trips='incomplete' returns creel_estimates_mor class", {
   design <- make_use_trips_design(n_complete = 10, n_incomplete = 30)
 
-  result <- suppressWarnings(estimate_catch_rate(design, use_trips = "incomplete", estimator = "mor")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    use_trips = "incomplete",
+    estimator = "mor"
+  )) # nolint: object_usage_linter
 
   expect_s3_class(result, "creel_estimates_mor")
   expect_s3_class(result, "creel_estimates")
@@ -1493,7 +2334,14 @@ test_that("use_trips parameter ignored when trip_status not provided", {
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Manually remove trip_status_col to simulate data from before Phase 13
   design$trip_status_col <- NULL
@@ -1523,7 +2371,14 @@ test_that("no errors when trip_status absent and use_trips specified", {
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Manually remove trip_status_col to simulate old data
   design$trip_status_col <- NULL
@@ -1625,8 +2480,14 @@ test_that("use_trips='complete' with estimator='mor' allows estimation", {
 make_grouped_use_trips_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -1636,8 +2497,10 @@ make_grouped_use_trips_design <- function() {
   # 40 interviews: 20 weekday (10 complete, 10 incomplete), 20 weekend (10 complete, 10 incomplete)
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 10), rep("2024-06-02", 10),
-      rep("2024-06-08", 10), rep("2024-06-09", 10)
+      rep("2024-06-01", 10),
+      rep("2024-06-02", 10),
+      rep("2024-06-08", 10),
+      rep("2024-06-09", 10)
     )),
     day_type = rep(c("weekday", "weekday", "weekend", "weekend"), each = 10),
     catch_total = rep(c(2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 4),
@@ -1648,7 +2511,15 @@ make_grouped_use_trips_design <- function() {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 test_that("grouped estimation with use_trips='complete' uses complete trips only", {
@@ -1664,7 +2535,12 @@ test_that("grouped estimation with use_trips='complete' uses complete trips only
 test_that("grouped estimation with use_trips='incomplete' uses incomplete trips only", {
   design <- make_grouped_use_trips_design()
 
-  result <- suppressWarnings(estimate_catch_rate(design, by = day_type, use_trips = "incomplete", estimator = "mor")) # nolint: object_usage_linter
+  result <- suppressWarnings(estimate_catch_rate(
+    design,
+    by = day_type,
+    use_trips = "incomplete",
+    estimator = "mor"
+  )) # nolint: object_usage_linter
 
   # Each group should have 10 incomplete trips
   expect_equal(nrow(result$estimates), 2)
@@ -2000,16 +2876,25 @@ test_that("grouped estimation warns per-group when below threshold", {
     hours_fished = rep(c(2.0, 3.0, 4.0, 2.5), 75),
     trip_status = c(
       # Group A: 10 complete, 140 incomplete
-      rep("incomplete", 140), rep("complete", 10),
+      rep("incomplete", 140),
+      rep("complete", 10),
       # Group B: 20 complete, 130 incomplete
-      rep("incomplete", 130), rep("complete", 20)
+      rep("incomplete", 130),
+      rep("complete", 20)
     ),
     trip_duration = rep(c(2.0, 3.0, 4.0, 2.5), 75),
     species = rep(c("A", "B"), each = 150),
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Should warn (at least once for group A)
   expect_warning(
@@ -2035,16 +2920,25 @@ test_that("grouped estimation warning fires for specific low group only", {
     hours_fished = rep(c(2.0, 3.0, 4.0, 2.5), 50),
     trip_status = c(
       # Group A: 10 complete, 90 incomplete (10% - at threshold)
-      rep("incomplete", 90), rep("complete", 10),
+      rep("incomplete", 90),
+      rep("complete", 10),
       # Group B: 50 complete, 50 incomplete (50%)
-      rep("incomplete", 50), rep("complete", 50)
+      rep("incomplete", 50),
+      rep("complete", 50)
     ),
     trip_duration = rep(c(2.0, 3.0, 4.0, 2.5), 50),
     species = rep(c("A", "B"), each = 100),
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Capture warnings
   warnings <- character()
@@ -2078,16 +2972,25 @@ test_that("grouped estimation no warnings when all groups >= threshold", {
     hours_fished = rep(c(2.0, 3.0, 4.0, 2.5), 50),
     trip_status = c(
       # Group A: 20 complete, 80 incomplete
-      rep("incomplete", 80), rep("complete", 20),
+      rep("incomplete", 80),
+      rep("complete", 20),
       # Group B: 20 complete, 80 incomplete
-      rep("incomplete", 80), rep("complete", 20)
+      rep("incomplete", 80),
+      rep("complete", 20)
     ),
     trip_duration = rep(c(2.0, 3.0, 4.0, 2.5), 50),
     species = rep(c("A", "B"), each = 100),
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Capture warnings
   warnings <- character()
@@ -2120,16 +3023,25 @@ test_that("grouped estimation respects package option threshold", {
     hours_fished = rep(c(2.0, 3.0, 4.0, 2.5), 75),
     trip_status = c(
       # Group A: 10 complete, 140 incomplete (6.7%)
-      rep("incomplete", 140), rep("complete", 10),
+      rep("incomplete", 140),
+      rep("complete", 10),
       # Group B: 10 complete, 140 incomplete (6.7%)
-      rep("incomplete", 140), rep("complete", 10)
+      rep("incomplete", 140),
+      rep("complete", 10)
     ),
     trip_duration = rep(c(2.0, 3.0, 4.0, 2.5), 75),
     species = rep(c("A", "B"), each = 150),
     stringsAsFactors = FALSE
   )
 
-  design <- add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Set threshold to 5% (6.7% > 5%, should not warn)
   withr::local_options(tidycreel.min_complete_pct = 0.05)
@@ -2212,7 +3124,9 @@ test_that("end-to-end integration: realistic scenario with low complete trips", 
     trip_duration = runif(200, min = 0.5, max = 6)
   )
 
-  design <- add_interviews(design, interviews,
+  design <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
@@ -2326,31 +3240,58 @@ test_that("RATE-03-catch-error: missing_sections='error' triggers cli_abort for 
 
 # ICE-04: estimate_catch_rate() ice compatibility ----
 
-make_ice_catch_rate_design <- function() { # nolint: object_length_linter
+make_ice_catch_rate_design <- function() {
+  # nolint: object_length_linter
   # 10 days — 6 weekday, 4 weekend — ensures each stratum has >= 5 interviews
   # and total >= 10 complete trips (minimum for catch rate estimation)
   cal <- data.frame(
     date = as.Date(c(
-      "2024-01-10", "2024-01-11", "2024-01-12", "2024-01-13", "2024-01-14",
-      "2024-01-15", "2024-01-16", "2024-01-17", "2024-01-18", "2024-01-19"
+      "2024-01-10",
+      "2024-01-11",
+      "2024-01-12",
+      "2024-01-13",
+      "2024-01-14",
+      "2024-01-15",
+      "2024-01-16",
+      "2024-01-17",
+      "2024-01-18",
+      "2024-01-19"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekday", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "ice",
     effort_type = "time_on_ice",
     p_period = 0.5
   )
   interviews_df <- data.frame(
     date = as.Date(c(
-      "2024-01-10", "2024-01-11", "2024-01-12", "2024-01-13", "2024-01-14",
-      "2024-01-15", "2024-01-16", "2024-01-17", "2024-01-18", "2024-01-19"
+      "2024-01-10",
+      "2024-01-11",
+      "2024-01-12",
+      "2024-01-13",
+      "2024-01-14",
+      "2024-01-15",
+      "2024-01-16",
+      "2024-01-17",
+      "2024-01-18",
+      "2024-01-19"
     )),
     n_counted = c(10L, 8L, 12L, 9L, 7L, 11L, 6L, 14L, 8L, 10L),
     n_interviewed = c(3L, 2L, 4L, 3L, 2L, 3L, 2L, 4L, 2L, 3L),
@@ -2359,7 +3300,8 @@ make_ice_catch_rate_design <- function() { # nolint: object_length_linter
     trip_status = rep("complete", 10L),
     stringsAsFactors = FALSE
   )
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
     design,
     interviews_df,
     catch = walleye_catch, # nolint: object_usage_linter
@@ -2388,9 +3330,11 @@ make_camera_catch_rate_design <- function() {
   dates <- unique(cal$date)[1:4]
   day_types <- cal$day_type[match(dates, cal$date)]
 
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "camera",
     camera_mode = "counter"
   )
@@ -2411,8 +3355,10 @@ make_camera_catch_rate_design <- function() {
     walleye_kept = c(1L, 1L, 0L, 0L, 2L, 0L, 1L, 0L, 2L, 0L, 1L, 1L),
     stringsAsFactors = FALSE
   )
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
@@ -2448,9 +3394,11 @@ make_aerial_catch_rate_design <- function() {
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "aerial",
     h_open = 14
   )
@@ -2466,13 +3414,32 @@ make_aerial_catch_rate_design <- function() {
     date = rep(as.Date(c("2024-07-01", "2024-07-02", "2024-07-03", "2024-07-04")), each = 4),
     day_type = rep(c("weekday", "weekday", "weekend", "weekend"), each = 4),
     trip_status = rep("complete", 16),
-    hours_fished = c(2.5, 3.0, 1.5, 4.0, 2.0, 3.5, 1.0, 2.5, 3.0, 4.5, 2.0, 3.5, 4.0, 3.0, 2.5, 1.5),
+    hours_fished = c(
+      2.5,
+      3.0,
+      1.5,
+      4.0,
+      2.0,
+      3.5,
+      1.0,
+      2.5,
+      3.0,
+      4.5,
+      2.0,
+      3.5,
+      4.0,
+      3.0,
+      2.5,
+      1.5
+    ),
     walleye = c(0L, 1L, 2L, 0L, 1L, 0L, 3L, 1L, 0L, 2L, 1L, 0L, 3L, 1L, 0L, 2L),
     walleye_kept = c(0L, 1L, 1L, 0L, 1L, 0L, 2L, 1L, 0L, 1L, 1L, 0L, 2L, 1L, 0L, 1L),
     stringsAsFactors = FALSE
   )
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
@@ -2506,8 +3473,12 @@ test_that("EDGE-CR-01: estimate_catch_rate() with all-zero catch returns estimat
   interviews_zero <- example_interviews
   interviews_zero$walleye_catch <- 0L
   d <- suppressWarnings(
-    add_interviews(d, interviews_zero,
-      catch = walleye_catch, effort = hours_fished, trip_status = trip_status
+    add_interviews(
+      d,
+      interviews_zero,
+      catch = walleye_catch,
+      effort = hours_fished,
+      trip_status = trip_status
     )
   )
   result <- suppressWarnings(estimate_catch_rate(d))
@@ -2517,12 +3488,15 @@ test_that("EDGE-CR-01: estimate_catch_rate() with all-zero catch returns estimat
 
 # ---- M013 S01: mortr estimator and targeted argument -------------------------
 
-make_mortr_design <- function(n_complete = 20, n_incomplete = 30,
-                              zero_catch_fraction = 0) {
+make_mortr_design <- function(n_complete = 20, n_incomplete = 30, zero_catch_fraction = 0) {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = rep(c("weekday", "weekend"), each = 3),
     stringsAsFactors = FALSE
@@ -2552,8 +3526,10 @@ make_mortr_design <- function(n_complete = 20, n_incomplete = 30,
   interviews <- data.frame(
     date = as.Date(rep(
       c(
-        "2024-06-01", "2024-06-02",
-        "2024-06-03", "2024-06-04"
+        "2024-06-01",
+        "2024-06-02",
+        "2024-06-03",
+        "2024-06-04"
       ),
       length.out = n_total
     )),
@@ -2568,7 +3544,9 @@ make_mortr_design <- function(n_complete = 20, n_incomplete = 30,
   )
 
   suppressMessages(suppressWarnings(
-    add_interviews(design, interviews,
+    add_interviews(
+      design,
+      interviews,
       catch = catch_total,
       effort = hours_fished,
       trip_status = trip_status,
@@ -2628,9 +3606,7 @@ test_that("M013-MORTR-05: mortr is backward-compat with 'mor' + truncate_at", {
     estimate_catch_rate(design, estimator = "mor", truncate_at = 0.5)
   )
   # Same estimate value; method name differs
-  expect_equal(res_mortr$estimates$estimate, res_mor$estimates$estimate,
-    tolerance = 1e-8
-  )
+  expect_equal(res_mortr$estimates$estimate, res_mor$estimates$estimate, tolerance = 1e-8)
   expect_equal(
     res_mortr$method,
     "mean-of-ratios-truncated-cpue"
@@ -2641,16 +3617,10 @@ test_that("M013-MORTR-05: mortr is backward-compat with 'mor' + truncate_at", {
 test_that("M013-TARGETED-01: targeted=FALSE excludes zero-catch trips", {
   design <- make_mortr_design(zero_catch_fraction = 0.5)
   result_targeted_true <- suppressWarnings(
-    estimate_catch_rate(design,
-      estimator = "mor",
-      truncate_at = NULL, targeted = TRUE
-    )
+    estimate_catch_rate(design, estimator = "mor", truncate_at = NULL, targeted = TRUE)
   )
   result_targeted_false <- suppressWarnings(
-    estimate_catch_rate(design,
-      estimator = "mor",
-      truncate_at = NULL, targeted = FALSE
-    )
+    estimate_catch_rate(design, estimator = "mor", truncate_at = NULL, targeted = FALSE)
   )
   # FALSE removes zero-catch trips -> smaller n
   expect_lt(
@@ -2662,10 +3632,7 @@ test_that("M013-TARGETED-01: targeted=FALSE excludes zero-catch trips", {
 test_that("M013-TARGETED-02: targeted=FALSE emits cli_warn with exclusion count", {
   design <- make_mortr_design(zero_catch_fraction = 0.5)
   expect_warning(
-    estimate_catch_rate(design,
-      estimator = "mor",
-      truncate_at = NULL, targeted = FALSE
-    ),
+    estimate_catch_rate(design, estimator = "mor", truncate_at = NULL, targeted = FALSE),
     regexp = "zero-catch"
   )
 })
@@ -2673,10 +3640,7 @@ test_that("M013-TARGETED-02: targeted=FALSE emits cli_warn with exclusion count"
 test_that("M013-TARGETED-03: targeted=TRUE (default) emits warn when >70% zero-catch", {
   design <- make_mortr_design(n_incomplete = 40, zero_catch_fraction = 0.8)
   expect_warning(
-    estimate_catch_rate(design,
-      estimator = "mor",
-      truncate_at = NULL, targeted = TRUE
-    ),
+    estimate_catch_rate(design, estimator = "mor", truncate_at = NULL, targeted = TRUE),
     regexp = "non-targeted|zero catch"
   )
 })
@@ -2685,10 +3649,7 @@ test_that("M013-TARGETED-04: targeted=FALSE with all zero-catch aborts", {
   design <- make_mortr_design(zero_catch_fraction = 1.0)
   expect_error(
     suppressWarnings(
-      estimate_catch_rate(design,
-        estimator = "mor",
-        truncate_at = NULL, targeted = FALSE
-      )
+      estimate_catch_rate(design, estimator = "mor", truncate_at = NULL, targeted = FALSE)
     ),
     regexp = "No trips remain"
   )
@@ -2700,12 +3661,10 @@ test_that("M013-TARGETED-05: targeted=TRUE default preserves backward compatibil
     estimate_catch_rate(design, estimator = "mor", truncate_at = NULL)
   )
   result_targeted <- suppressWarnings(
-    estimate_catch_rate(design,
-      estimator = "mor",
-      truncate_at = NULL, targeted = TRUE
-    )
+    estimate_catch_rate(design, estimator = "mor", truncate_at = NULL, targeted = TRUE)
   )
-  expect_equal(result_default$estimates$estimate,
+  expect_equal(
+    result_default$estimates$estimate,
     result_targeted$estimates$estimate,
     tolerance = 1e-8
   )
@@ -2730,9 +3689,12 @@ make_roving_design <- function(n_complete = 15, n_incomplete = 35) {
     stringsAsFactors = FALSE
   )
   suppressWarnings(suppressMessages(add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     interview_type = "roving"
   )))
 }
@@ -2799,9 +3761,12 @@ test_that("ROVING-06: access design is unaffected by roving logic", {
     stringsAsFactors = FALSE
   )
   d_access <- suppressWarnings(suppressMessages(add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration,
     interview_type = "access"
   )))
   result <- suppressMessages(estimate_catch_rate(d_access))
@@ -2827,8 +3792,10 @@ test_that("ROVING-06b: roving auto-route succeeds when trip_duration_col is NULL
     stringsAsFactors = FALSE
   )
   d <- suppressWarnings(suppressMessages(add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
     trip_status = trip_status,
     interview_type = "roving"
     # no trip_duration: trip_duration_col = NULL
@@ -2857,9 +3824,12 @@ test_that("ROVING-07: use_trips='all' valid for access design too", {
     stringsAsFactors = FALSE
   )
   d <- suppressWarnings(suppressMessages(add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )))
   result <- suppressWarnings(suppressMessages(estimate_catch_rate(d, use_trips = "all")))
   expect_s3_class(result, "creel_estimates")

--- a/tests/testthat/test-estimate-effort-aerial-glmm.R
+++ b/tests/testthat/test-estimate-effort-aerial-glmm.R
@@ -6,7 +6,8 @@ make_aerial_glmm_design <- function() {
   data("example_aerial_glmm_counts", envir = environment())
   aerial_cal <- unique(example_aerial_glmm_counts[, c("date", "day_type")]) # nolint: object_usage_linter
   aerial_cal <- aerial_cal[order(aerial_cal$date), ]
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     aerial_cal,
     date = date,
     strata = day_type, # nolint: object_usage_linter
@@ -95,8 +96,14 @@ test_that("result$method is 'aerial_glmm_total'", {
 test_that("cli_abort() fires when design_type is not 'aerial'", {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-10", "2024-06-11", "2024-06-17", "2024-06-18"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-11",
+      "2024-06-17",
+      "2024-06-18"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -133,7 +140,8 @@ test_that("GLMM-05: fixed open_start suppresses data-derived window message", {
   aerial_cal <- aerial_cal[order(aerial_cal$date), ]
   design <- creel_design(
     aerial_cal,
-    date = date, strata = day_type,
+    date = date,
+    strata = day_type,
     survey_type = "aerial",
     h_open = 14,
     open_start = 5.0
@@ -171,7 +179,8 @@ test_that("GLMM-05: fixed open_start yields finite estimate", {
   aerial_cal <- aerial_cal[order(aerial_cal$date), ]
   design <- creel_design(
     aerial_cal,
-    date = date, strata = day_type,
+    date = date,
+    strata = day_type,
     survey_type = "aerial",
     h_open = 14,
     open_start = 5.0

--- a/tests/testthat/test-estimate-effort-aerial-glmm.R
+++ b/tests/testthat/test-estimate-effort-aerial-glmm.R
@@ -123,3 +123,60 @@ test_that("rlang::check_installed fires an rlang_error for a non-existent packag
     class = "rlang_error"
   )
 })
+
+# GLMM-05: open_start integration window ----
+
+test_that("GLMM-05: fixed open_start suppresses data-derived window message", {
+  skip_if_not_installed("lme4")
+  data("example_aerial_glmm_counts", envir = environment())
+  aerial_cal <- unique(example_aerial_glmm_counts[, c("date", "day_type")])
+  aerial_cal <- aerial_cal[order(aerial_cal$date), ]
+  design <- creel_design(
+    aerial_cal,
+    date = date, strata = day_type,
+    survey_type = "aerial",
+    h_open = 14,
+    open_start = 5.0
+  )
+  design <- add_counts(design, example_aerial_glmm_counts)
+  msgs <- character(0)
+  withCallingHandlers(
+    estimate_effort_aerial_glmm(design, time_col = time_of_flight),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_false(any(grepl("derived from data", msgs, fixed = TRUE)))
+})
+
+test_that("GLMM-05: missing open_start emits data-derived window message", {
+  skip_if_not_installed("lme4")
+  design <- make_aerial_glmm_design()
+  msgs <- character(0)
+  withCallingHandlers(
+    estimate_effort_aerial_glmm(design, time_col = time_of_flight),
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_true(any(grepl("derived from data", msgs, fixed = TRUE)))
+})
+
+test_that("GLMM-05: fixed open_start yields finite estimate", {
+  skip_if_not_installed("lme4")
+  data("example_aerial_glmm_counts", envir = environment())
+  aerial_cal <- unique(example_aerial_glmm_counts[, c("date", "day_type")])
+  aerial_cal <- aerial_cal[order(aerial_cal$date), ]
+  design <- creel_design(
+    aerial_cal,
+    date = date, strata = day_type,
+    survey_type = "aerial",
+    h_open = 14,
+    open_start = 5.0
+  )
+  design <- add_counts(design, example_aerial_glmm_counts)
+  result <- suppressMessages(estimate_effort_aerial_glmm(design, time_col = time_of_flight))
+  expect_true(is.finite(result$estimates$estimate))
+})

--- a/tests/testthat/test-estimate-effort.R
+++ b/tests/testthat/test-estimate-effort.R
@@ -4,8 +4,14 @@
 make_test_calendar <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -17,8 +23,14 @@ make_test_calendar <- function() {
 make_test_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     effort_hours = c(15, 23, 18, 21, 45, 52, 48, 51),
@@ -38,8 +50,14 @@ make_test_design_with_counts <- function() {
 make_partial_sample_design_with_counts <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -61,18 +79,37 @@ make_partial_sample_design_with_counts <- function() {
 #' Produces a creel_design with sections "North", "Central", "South".
 #' Each section has counts across both "weekday" and "weekend" strata
 #' with 2 PSUs (dates) per stratum per section (12 dates total, 36 count rows).
-make_3section_design_with_counts <- function() { # nolint: object_length_linter
+make_3section_design_with_counts <- function() {
+  # nolint: object_length_linter
   # 12-date calendar: 6 weekday + 6 weekend (2 per stratum per section)
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -92,14 +129,44 @@ make_3section_design_with_counts <- function() { # nolint: object_length_linter
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
       # North: weekday ~15-25, weekend ~20-28
-      20, 22, 18, 25, 15, 24,
-      21, 26, 23, 28, 20, 27,
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
       # Central: weekday ~30-45, weekend ~35-48
-      35, 38, 32, 42, 30, 45,
-      37, 44, 40, 48, 35, 46,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
       # South: weekday ~5-12, weekend ~6-13
-      8, 10, 5, 12, 6, 11,
-      7, 9, 6, 13, 8, 10
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -111,17 +178,36 @@ make_3section_design_with_counts <- function() { # nolint: object_length_linter
 #'
 #' Registered sections: "North", "Central", "South".
 #' Counts data contains only "North" and "Central" rows — "South" is absent.
-make_section_design_with_missing_section <- function() { # nolint: object_length_linter
+make_section_design_with_missing_section <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -140,11 +226,31 @@ make_section_design_with_missing_section <- function() { # nolint: object_length
     section = rep(c("North", "Central"), each = nrow(cal)),
     effort_hours = c(
       # North
-      20, 22, 18, 25, 15, 24,
-      21, 26, 23, 28, 20, 27,
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
       # Central
-      35, 38, 32, 42, 30, 45,
-      37, 44, 40, 48, 35, 46
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46
     ),
     stringsAsFactors = FALSE
   )
@@ -269,8 +375,14 @@ test_that("estimate_effort errors when count data has no numeric column", {
   # Create counts with only character/factor columns (no numeric count variable)
   bad_counts <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     description = rep("no fishing", 8)
@@ -429,10 +541,22 @@ make_test_design_with_groups <- function() {
   # Create calendar with 16 dates across 2 day_types and 2 periods
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-10", "2024-06-11",
-      "2024-06-15", "2024-06-16", "2024-06-17", "2024-06-18",
-      "2024-06-22", "2024-06-23", "2024-06-24", "2024-06-25"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-10",
+      "2024-06-11",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-17",
+      "2024-06-18",
+      "2024-06-22",
+      "2024-06-23",
+      "2024-06-24",
+      "2024-06-25"
     )),
     day_type = rep(c("weekday", "weekend"), each = 8),
     period = rep(c("morning", "afternoon"), 8),
@@ -447,8 +571,22 @@ make_test_design_with_groups <- function() {
     day_type = cal$day_type,
     period = cal$period,
     effort_hours = c(
-      15, 23, 18, 21, 22, 19, 20, 24, # weekday
-      45, 52, 48, 51, 50, 47, 49, 53 # weekend
+      15,
+      23,
+      18,
+      21,
+      22,
+      19,
+      20,
+      24, # weekday
+      45,
+      52,
+      48,
+      51,
+      50,
+      47,
+      49,
+      53 # weekend
     ),
     stringsAsFactors = FALSE
   )
@@ -605,8 +743,12 @@ test_that("format.creel_estimates shows Jackknife for jackknife method", {
 test_that("estimate_effort with by = warns on sparse groups", {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekday", "weekend", "weekend")
   )
@@ -983,7 +1125,8 @@ make_br_effort_design <- function() {
     p_site = c(0.4, 0.6),
     p_period = c(0.5, 0.5)
   )
-  creel_design( # nolint: object_usage_linter
+  creel_design(
+    # nolint: object_usage_linter
     cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
@@ -1015,7 +1158,9 @@ make_br_effort_interviews <- function() {
 
 test_that("estimate_effort dispatches to bus-route estimator for bus_route design", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1029,7 +1174,9 @@ test_that("estimate_effort dispatches to bus-route estimator for bus_route desig
 
 test_that("bus-route effort results carry effort_target metadata", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1042,7 +1189,9 @@ test_that("bus-route effort results carry effort_target metadata", {
 
 test_that("bus-route effort estimate matches Eq. 19.4 sum(e_i / pi_i)", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1058,7 +1207,9 @@ test_that("bus-route effort estimate matches Eq. 19.4 sum(e_i / pi_i)", {
 
 test_that("bus-route estimate has site_contributions attribute", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1073,7 +1224,9 @@ test_that("bus-route estimate has site_contributions attribute", {
 
 test_that("get_site_contributions returns tibble with correct columns", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1117,7 +1270,9 @@ test_that("get_site_contributions errors when site_contributions attribute absen
 
 test_that("verbose=TRUE prints bus-route dispatch message for bus_route design", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1132,7 +1287,9 @@ test_that("verbose=TRUE prints bus-route dispatch message for bus_route design",
 
 test_that("verbose=FALSE (default) produces no dispatch message", {
   design <- make_br_effort_design()
-  d <- add_interviews(design, make_br_effort_interviews(),
+  d <- add_interviews(
+    design,
+    make_br_effort_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1155,7 +1312,8 @@ test_that("estimate_effort by=circuit returns proportion column for bus-route", 
     p_site = c(0.4, 0.6, 0.5, 0.5),
     p_period = c(0.5, 0.5, 0.5, 0.5)
   )
-  design2 <- creel_design( # nolint: object_usage_linter
+  design2 <- creel_design(
+    # nolint: object_usage_linter
     cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
@@ -1177,7 +1335,9 @@ test_that("estimate_effort by=circuit returns proportion column for bus-route", 
     n_counted = c(5L, 10L, 4L, 8L),
     n_interviewed = c(3L, 5L, 2L, 4L)
   )
-  d2 <- add_interviews(design2, interviews2,
+  d2 <- add_interviews(
+    design2,
+    interviews2,
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1203,7 +1363,9 @@ test_that("zero-effort site (n_counted=0, n_interviewed=0) contributes 0 to esti
     n_counted = c(5L, 0L),
     n_interviewed = c(3L, 0L)
   )
-  d <- add_interviews(design, interviews_zero,
+  d <- add_interviews(
+    design,
+    interviews_zero,
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1336,8 +1498,10 @@ make_pope_progressive_design <- function() {
     stringsAsFactors = FALSE
   )
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
-  add_counts( # nolint: object_usage_linter
-    design, cts,
+  add_counts(
+    # nolint: object_usage_linter
+    design,
+    cts,
     count_type = "progressive",
     circuit_time = 2,
     period_length_col = shift_hours # nolint: object_usage_linter
@@ -1413,7 +1577,8 @@ test_that("SECT-03a: missing section produces NA row with data_available=FALSE a
   # Capture warnings: outer handler sees all; muffles survey pkg warnings
   warns <- character(0)
   result <- withCallingHandlers(
-    estimate_effort( # nolint: object_usage_linter
+    estimate_effort(
+      # nolint: object_usage_linter
       design,
       aggregate_sections = TRUE,
       missing_sections = "warn"
@@ -1435,7 +1600,8 @@ test_that("SECT-03a: missing section produces NA row with data_available=FALSE a
 test_that("SECT-03b: missing_sections='error' aborts with cli_abort when section absent", {
   design <- make_section_design_with_missing_section()
   expect_error(
-    estimate_effort( # nolint: object_usage_linter
+    estimate_effort(
+      # nolint: object_usage_linter
       design,
       missing_sections = "error"
     ),
@@ -1474,8 +1640,10 @@ make_ice_design <- function(effort_type = "time_on_ice") {
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
   )
-  creel_design(cal, # nolint: object_usage_linter
-    date = date, strata = day_type, # nolint: object_usage_linter
+  creel_design(
+    cal, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "ice",
     effort_type = effort_type,
     p_period = 0.5
@@ -1498,7 +1666,9 @@ make_ice_interviews <- function() {
 
 test_that("ICE-01: estimate_effort on ice design dispatches without error", {
   design <- make_ice_design()
-  d <- suppressMessages(add_interviews(design, make_ice_interviews(),
+  d <- suppressMessages(add_interviews(
+    design,
+    make_ice_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1511,7 +1681,9 @@ test_that("ICE-01: estimate_effort on ice design dispatches without error", {
 
 test_that("ICE-01: ice effort results carry effort_target metadata", {
   design <- make_ice_design()
-  d <- suppressMessages(add_interviews(design, make_ice_interviews(),
+  d <- suppressMessages(add_interviews(
+    design,
+    make_ice_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1524,7 +1696,9 @@ test_that("ICE-01: ice effort results carry effort_target metadata", {
 
 test_that("ICE-01: estimate_effort on ice(time_on_ice) returns column total_effort_hr_on_ice", {
   design <- make_ice_design(effort_type = "time_on_ice")
-  d <- suppressMessages(add_interviews(design, make_ice_interviews(),
+  d <- suppressMessages(add_interviews(
+    design,
+    make_ice_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1537,7 +1711,9 @@ test_that("ICE-01: estimate_effort on ice(time_on_ice) returns column total_effo
 
 test_that("ICE-02: estimate_effort on ice(active_fishing_time) returns column total_effort_hr_active", {
   design <- make_ice_design(effort_type = "active_fishing_time")
-  d <- suppressMessages(add_interviews(design, make_ice_interviews(),
+  d <- suppressMessages(add_interviews(
+    design,
+    make_ice_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1550,7 +1726,9 @@ test_that("ICE-02: estimate_effort on ice(active_fishing_time) returns column to
 
 test_that("ICE-03: estimate_effort(by=shelter_mode) on ice design returns grouped estimates", {
   design <- make_ice_design()
-  d <- suppressMessages(add_interviews(design, make_ice_interviews(),
+  d <- suppressMessages(add_interviews(
+    design,
+    make_ice_interviews(),
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -1567,8 +1745,12 @@ test_that("ICE-03: estimate_effort(by=shelter_mode) on ice design returns groupe
 make_cam_effort_cal <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-04", "2024-06-05", "2024-06-06"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
     stringsAsFactors = FALSE
@@ -1578,8 +1760,12 @@ make_cam_effort_cal <- function() {
 make_cam_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-04", "2024-06-05", "2024-06-06"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
     angler_count = c(12L, 15L, 10L, 20L, 18L, 14L),
@@ -1588,8 +1774,10 @@ make_cam_counts <- function() {
 }
 
 make_cam_design_counter <- function() {
-  creel_design(make_cam_effort_cal(), # nolint: object_usage_linter
-    date = date, strata = day_type, # nolint: object_usage_linter
+  creel_design(
+    make_cam_effort_cal(), # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "camera",
     camera_mode = "counter"
   )
@@ -1611,8 +1799,12 @@ test_that("CAM-01: counter-mode camera + add_counts() + estimate_effort() return
 make_cam_daily_effort <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-04", "2024-06-05", "2024-06-06"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
     daily_effort_hours = c(4.0, 5.5, 3.0, 6.0, 4.5, 5.0),
@@ -1621,8 +1813,10 @@ make_cam_daily_effort <- function() {
 }
 
 test_that("CAM-02: ingress-egress camera with preprocessed daily_effort_hours flows through estimate_effort()", {
-  design <- creel_design(make_cam_effort_cal(), # nolint: object_usage_linter
-    date = date, strata = day_type, # nolint: object_usage_linter
+  design <- creel_design(
+    make_cam_effort_cal(), # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "camera",
     camera_mode = "ingress_egress"
   )
@@ -1638,14 +1832,22 @@ test_that("CAM-02: ingress-egress camera with preprocessed daily_effort_hours fl
 make_cam_counts_with_gap <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-04", "2024-06-05", "2024-06-06"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
     angler_count = c(12L, NA_integer_, 10L, 20L, 18L, 14L),
     camera_status = c(
-      "operational", "offline", "operational",
-      "operational", "operational", "operational"
+      "operational",
+      "offline",
+      "operational",
+      "operational",
+      "operational",
+      "operational"
     ),
     stringsAsFactors = FALSE
   )
@@ -1666,13 +1868,20 @@ test_that("CAM-03: filtering camera_status == 'operational' before add_counts() 
 make_aerial_design <- function(h_open = 14, visibility_correction = NULL) {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4L),
     stringsAsFactors = FALSE
   )
-  creel_design(cal, # nolint: object_usage_linter
+  creel_design(
+    cal, # nolint: object_usage_linter
     date = date,
     strata = day_type, # nolint: object_usage_linter
     survey_type = "aerial",
@@ -1684,8 +1893,14 @@ make_aerial_design <- function(h_open = 14, visibility_correction = NULL) {
 make_aerial_counts <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4L),
     n_counted = c(5L, 8L, 6L, 7L, 12L, 15L, 11L, 13L),
@@ -1743,8 +1958,14 @@ describe("Phase 47: Aerial effort", {
   })
 
   it("AIR-03: visibility_correction = 0.85 produces effort / 0.85 relative to v = 1", {
-    d_no_v <- add_counts(make_aerial_design(h_open = 14, visibility_correction = NULL), make_aerial_counts()) # nolint: object_usage_linter
-    d_v085 <- add_counts(make_aerial_design(h_open = 14, visibility_correction = 0.85), make_aerial_counts()) # nolint: object_usage_linter
+    d_no_v <- add_counts(
+      make_aerial_design(h_open = 14, visibility_correction = NULL),
+      make_aerial_counts()
+    ) # nolint: object_usage_linter
+    d_v085 <- add_counts(
+      make_aerial_design(h_open = 14, visibility_correction = 0.85),
+      make_aerial_counts()
+    ) # nolint: object_usage_linter
     result_no_v <- suppressWarnings(estimate_effort(d_no_v))
     result_v085 <- suppressWarnings(estimate_effort(d_v085))
     expect_equal(
@@ -1755,8 +1976,14 @@ describe("Phase 47: Aerial effort", {
   })
 
   it("AIR-03: SE with visibility_correction = 0.85 equals SE without correction / 0.85", {
-    d_no_v <- add_counts(make_aerial_design(h_open = 14, visibility_correction = NULL), make_aerial_counts()) # nolint: object_usage_linter
-    d_v085 <- add_counts(make_aerial_design(h_open = 14, visibility_correction = 0.85), make_aerial_counts()) # nolint: object_usage_linter
+    d_no_v <- add_counts(
+      make_aerial_design(h_open = 14, visibility_correction = NULL),
+      make_aerial_counts()
+    ) # nolint: object_usage_linter
+    d_v085 <- add_counts(
+      make_aerial_design(h_open = 14, visibility_correction = 0.85),
+      make_aerial_counts()
+    ) # nolint: object_usage_linter
     result_no_v <- suppressWarnings(estimate_effort(d_no_v))
     result_v085 <- suppressWarnings(estimate_effort(d_v085))
     expect_equal(
@@ -1771,9 +1998,9 @@ describe("Phase 47: Aerial effort", {
 
 test_that("EDGE-01: all-zero count stratum returns numeric estimate without error", {
   counts <- data.frame(
-    date     = as.Date(c("2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09")),
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09")),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
-    count    = c(0L, 0L, 5L, 8L)
+    count = c(0L, 0L, 5L, 8L)
   )
   cal <- unique(counts[, c("date", "day_type")])
   d <- creel_design(cal, date = date, strata = day_type, survey_type = "instantaneous")
@@ -1788,9 +2015,9 @@ test_that("EDGE-01: all-zero count stratum returns numeric estimate without erro
 
 test_that("EDGE-02: all-NA count column emits cli_warn and returns NA estimate", {
   counts <- data.frame(
-    date     = as.Date(c("2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09")),
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09")),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
-    count    = NA_integer_
+    count = NA_integer_
   )
   cal <- unique(counts[, c("date", "day_type")])
   d <- creel_design(cal, date = date, strata = day_type, survey_type = "instantaneous")
@@ -1814,9 +2041,9 @@ test_that("EDGE-02: all-NA count column emits cli_warn and returns NA estimate",
 
 test_that("EDGE-03: single sampled day per stratum raises creel_error_single_psu naming the stratum", {
   counts <- data.frame(
-    date     = as.Date(c("2024-06-01", "2024-06-08")),
+    date = as.Date(c("2024-06-01", "2024-06-08")),
     day_type = c("weekday", "weekend"),
-    count    = c(10L, 15L)
+    count = c(10L, 15L)
   )
   cal <- unique(counts[, c("date", "day_type")])
   d <- creel_design(cal, date = date, strata = day_type, survey_type = "instantaneous")
@@ -1829,9 +2056,9 @@ test_that("EDGE-03: single sampled day per stratum raises creel_error_single_psu
 
 test_that("EDGE-04: single sampled day error message names the stratum", {
   counts <- data.frame(
-    date     = as.Date(c("2024-06-01", "2024-06-08")),
+    date = as.Date(c("2024-06-01", "2024-06-08")),
     day_type = c("weekday", "weekend"),
-    count    = c(10L, 15L)
+    count = c(10L, 15L)
   )
   cal <- unique(counts[, c("date", "day_type")])
   d <- creel_design(cal, date = date, strata = day_type, survey_type = "instantaneous")

--- a/tests/testthat/test-estimate-exploitation-rate.R
+++ b/tests/testthat/test-estimate-exploitation-rate.R
@@ -1,10 +1,10 @@
 test_that("Test A: point estimate matches manual formula (C*m)/(T*n)", {
   result <- estimate_exploitation_rate(
-    T      = 200L,
-    C      = 450.0,
-    se_C   = 42.0,
-    n      = 180L,
-    m      = 15L,
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
     conf_level = 0.95
   )
   expect_equal(result$estimates$estimate, (450 * 15) / (200 * 180), tolerance = 1e-10)
@@ -12,28 +12,28 @@ test_that("Test A: point estimate matches manual formula (C*m)/(T*n)", {
 
 test_that("Test B: SE equals delta-method formula", {
   result <- estimate_exploitation_rate(
-    T      = 200L,
-    C      = 450.0,
-    se_C   = 42.0,
-    n      = 180L,
-    m      = 15L,
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
     conf_level = 0.95
   )
-  p_hat   <- 15 / 180
-  r_hat   <- 450 / 200
-  var_p   <- p_hat * (1 - p_hat) / 180
-  var_r   <- 42^2 / 200^2
+  p_hat <- 15 / 180
+  r_hat <- 450 / 200
+  var_p <- p_hat * (1 - p_hat) / 180
+  var_r <- 42^2 / 200^2
   expected_se <- sqrt(r_hat^2 * var_p + p_hat^2 * var_r)
   expect_equal(result$estimates$se, expected_se, tolerance = 1e-10)
 })
 
 test_that("Test C: CI lower <= estimate <= CI upper", {
   result <- estimate_exploitation_rate(
-    T      = 200L,
-    C      = 450.0,
-    se_C   = 42.0,
-    n      = 180L,
-    m      = 15L,
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
     conf_level = 0.95
   )
   expect_true(result$estimates$ci_lower <= result$estimates$estimate)
@@ -42,11 +42,11 @@ test_that("Test C: CI lower <= estimate <= CI upper", {
 
 test_that("Test D: return value has class creel_estimates with method exploitation-rate", {
   result <- estimate_exploitation_rate(
-    T      = 200L,
-    C      = 450.0,
-    se_C   = 42.0,
-    n      = 180L,
-    m      = 15L,
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
     conf_level = 0.95
   )
   expect_s3_class(result, "creel_estimates")
@@ -83,21 +83,31 @@ test_that("Test H: u_hat > 1 fires warning", {
 
 test_that("Test I: conf_level=0.90 gives narrower CI than conf_level=0.95", {
   result_95 <- estimate_exploitation_rate(
-    T = 200L, C = 450.0, se_C = 42.0, n = 180L, m = 15L, conf_level = 0.95
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
+    conf_level = 0.95
   )
   result_90 <- estimate_exploitation_rate(
-    T = 200L, C = 450.0, se_C = 42.0, n = 180L, m = 15L, conf_level = 0.90
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
+    conf_level = 0.90
   )
   expect_true(result_90$estimates$ci_upper < result_95$estimates$ci_upper)
 })
 
 test_that("Test J: estimates tibble has correct column names", {
   result <- estimate_exploitation_rate(
-    T      = 200L,
-    C      = 450.0,
-    se_C   = 42.0,
-    n      = 180L,
-    m      = 15L,
+    T = 200L,
+    C = 450.0,
+    se_C = 42.0,
+    n = 180L,
+    m = 15L,
     conf_level = 0.95
   )
   expect_named(result$estimates, c("estimate", "se", "ci_lower", "ci_upper", "n", "T", "C", "m"))
@@ -107,11 +117,11 @@ test_that("Test J: estimates tibble has correct column names", {
 
 strata_df <- data.frame(
   stratum = c("weekday", "weekend"),
-  T_h     = c(120L, 80L),
-  C_h     = c(280.0, 170.0),
-  se_C_h  = c(28.0, 22.0),
-  n_h     = c(110L, 70L),
-  m_h     = c(9L, 6L)
+  T_h = c(120L, 80L),
+  C_h = c(280.0, 170.0),
+  se_C_h = c(28.0, 22.0),
+  n_h = c(110L, 70L),
+  m_h = c(9L, 6L)
 )
 
 # Manual values:
@@ -120,8 +130,8 @@ strata_df <- data.frame(
 #   agg u   = (120*0.18939 + 80*0.18214)/(120+80) = 0.18657...
 
 u_weekday <- (280 * 9) / (120 * 110)
-u_weekend  <- (170 * 6) / (80 * 70)
-u_agg      <- (120 * u_weekday + 80 * u_weekend) / (120 + 80)
+u_weekend <- (170 * 6) / (80 * 70)
+u_agg <- (120 * u_weekday + 80 * u_weekend) / (120 + 80)
 
 test_that("Test K: stratified returns 3 rows (2 strata + .overall)", {
   result <- estimate_exploitation_rate(strata = strata_df, by = "stratum")

--- a/tests/testthat/test-estimate-harvest-rate.R
+++ b/tests/testthat/test-estimate-harvest-rate.R
@@ -1169,3 +1169,45 @@ test_that("RATE-03-harvest: missing section produces NA row + cli_warn for estim
   expect_false(south_row$data_available)
   expect_true(is.na(south_row$estimate))
 })
+
+# Species-level HPUE dispatch ----
+
+test_that("HPUE-SPECIES-01: by=species returns creel_estimates with hpue-species method", {
+  design <- suppressMessages(suppressWarnings(
+    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 30L, n_species = 2L, seed = 42L)
+  ))
+  result <- suppressMessages(suppressWarnings(estimate_harvest_rate(design, by = species)))
+  expect_s3_class(result, "creel_estimates")
+  expect_equal(result$method, "ratio-of-means-hpue-species")
+})
+
+test_that("HPUE-SPECIES-02: by=species result has one row per species with species column", {
+  design <- suppressMessages(suppressWarnings(
+    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 30L, n_species = 3L, seed = 7L)
+  ))
+  result <- suppressMessages(suppressWarnings(estimate_harvest_rate(design, by = species)))
+  expect_true("species" %in% names(result$estimates))
+  expect_equal(nrow(result$estimates), 3L)
+})
+
+test_that("HPUE-SPECIES-03: by=c(day_type, species) groups by interview var + species", {
+  design <- suppressMessages(suppressWarnings(
+    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 40L, n_species = 2L, seed = 99L)
+  ))
+  result <- suppressMessages(suppressWarnings(
+    estimate_harvest_rate(design, by = c(day_type, species))
+  ))
+  expect_s3_class(result, "creel_estimates")
+  expect_true("species" %in% names(result$estimates))
+  expect_true("day_type" %in% names(result$estimates))
+})
+
+test_that("HPUE-SPECIES-04: all estimate/se/ci columns present in species result", {
+  design <- suppressMessages(suppressWarnings(
+    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 30L, n_species = 2L, seed = 42L)
+  ))
+  result <- suppressMessages(suppressWarnings(estimate_harvest_rate(design, by = species)))
+  expected_cols <- c("species", "estimate", "se", "ci_lower", "ci_upper")
+  expect_true(all(expected_cols %in% names(result$estimates)))
+  expect_true(all(is.finite(result$estimates$estimate)))
+})

--- a/tests/testthat/test-estimate-harvest-rate.R
+++ b/tests/testthat/test-estimate-harvest-rate.R
@@ -4,17 +4,36 @@
 #'
 #' Sections: "North", "Central", "South". All three sections have interview data.
 #' Duplicated from test-estimate-catch-rate.R for self-contained test file.
-make_3section_design_with_interviews <- function() { # nolint: object_length_linter
+make_3section_design_with_interviews <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -31,9 +50,42 @@ make_3section_design_with_interviews <- function() { # nolint: object_length_lin
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -41,70 +93,229 @@ make_3section_design_with_interviews <- function() { # nolint: object_length_lin
 
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central", "South"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6,
-      10, 12, 9, 11, 10, 12, 13, 11, 10
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6,
+      10,
+      12,
+      9,
+      11,
+      10,
+      12,
+      13,
+      11,
+      10
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4,
-      7, 9, 6, 8, 7, 9, 10, 8, 7
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4,
+      7,
+      9,
+      6,
+      8,
+      7,
+      9,
+      10,
+      8,
+      7
     ),
     trip_status = rep("complete", 27),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
 #' Create 3-section design with "South" absent from interview data
 #'
 #' Duplicated from test-estimate-catch-rate.R for self-contained test file.
-make_section_design_with_missing_interview_section <- function() { # nolint: object_length_linter
+make_section_design_with_missing_interview_section <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -121,9 +332,42 @@ make_section_design_with_missing_interview_section <- function() { # nolint: obj
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -131,44 +375,139 @@ make_section_design_with_missing_interview_section <- function() { # nolint: obj
 
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4
     ),
     trip_status = rep("complete", 18),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -176,8 +515,14 @@ make_section_design_with_missing_interview_section <- function() { # nolint: obj
 make_test_calendar_harvest <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -192,34 +537,158 @@ make_test_interviews_harvest <- function() {
   data.frame(
     date = as.Date(c(
       # Weekday interviews (16 total, spread across 4 dates)
-      rep("2024-06-01", 4), rep("2024-06-02", 4),
-      rep("2024-06-03", 4), rep("2024-06-04", 4),
+      rep("2024-06-01", 4),
+      rep("2024-06-02", 4),
+      rep("2024-06-03", 4),
+      rep("2024-06-04", 4),
       # Weekend interviews (16 total, spread across 4 dates)
-      rep("2024-06-08", 4), rep("2024-06-09", 4),
-      rep("2024-06-15", 4), rep("2024-06-16", 4)
+      rep("2024-06-08", 4),
+      rep("2024-06-09", 4),
+      rep("2024-06-15", 4),
+      rep("2024-06-16", 4)
     )),
     catch_total = c(
       # Weekday catch (realistic variation)
-      2, 5, 3, 1, 4, 6, 2, 3, 5, 7, 4, 2, 3, 6, 5, 4,
+      2,
+      5,
+      3,
+      1,
+      4,
+      6,
+      2,
+      3,
+      5,
+      7,
+      4,
+      2,
+      3,
+      6,
+      5,
+      4,
       # Weekend catch (higher on average)
-      8, 10, 6, 9, 7, 11, 8, 10, 9, 12, 7, 8, 10, 11, 9, 8
+      8,
+      10,
+      6,
+      9,
+      7,
+      11,
+      8,
+      10,
+      9,
+      12,
+      7,
+      8,
+      10,
+      11,
+      9,
+      8
     ),
     hours_fished = c(
       # Weekday effort (2-5 hours)
-      2.5, 4.0, 3.5, 2.0, 3.0, 5.0, 2.5, 3.5, 4.5, 5.0, 3.5, 2.5, 3.0, 4.5, 4.0, 3.5,
+      2.5,
+      4.0,
+      3.5,
+      2.0,
+      3.0,
+      5.0,
+      2.5,
+      3.5,
+      4.5,
+      5.0,
+      3.5,
+      2.5,
+      3.0,
+      4.5,
+      4.0,
+      3.5,
       # Weekend effort (3-6 hours)
-      4.0, 5.5, 3.5, 5.0, 4.5, 6.0, 4.5, 5.5, 5.0, 6.0, 4.0, 4.5, 5.5, 5.5, 5.0, 4.5
+      4.0,
+      5.5,
+      3.5,
+      5.0,
+      4.5,
+      6.0,
+      4.5,
+      5.5,
+      5.0,
+      6.0,
+      4.0,
+      4.5,
+      5.5,
+      5.5,
+      5.0,
+      4.5
     ),
     catch_kept = c(
       # Kept fish (always <= catch_total)
-      2, 4, 3, 1, 3, 5, 2, 2, 4, 6, 3, 2, 2, 5, 4, 3,
-      5, 8, 5, 7, 6, 9, 6, 8, 7, 10, 5, 6, 8, 9, 7, 6
+      2,
+      4,
+      3,
+      1,
+      3,
+      5,
+      2,
+      2,
+      4,
+      6,
+      3,
+      2,
+      2,
+      5,
+      4,
+      3,
+      5,
+      8,
+      5,
+      7,
+      6,
+      9,
+      6,
+      8,
+      7,
+      10,
+      5,
+      6,
+      8,
+      9,
+      7,
+      6
     ),
     trip_status = rep(c("complete", "incomplete"), 16),
     trip_duration = c(
       # Trip durations matching hours_fished
-      2.5, 4.0, 3.5, 2.0, 3.0, 5.0, 2.5, 3.5, 4.5, 5.0, 3.5, 2.5, 3.0, 4.5, 4.0, 3.5,
-      4.0, 5.5, 3.5, 5.0, 4.5, 6.0, 4.5, 5.5, 5.0, 6.0, 4.0, 4.5, 5.5, 5.5, 5.0, 4.5
+      2.5,
+      4.0,
+      3.5,
+      2.0,
+      3.0,
+      5.0,
+      2.5,
+      3.5,
+      4.5,
+      5.0,
+      3.5,
+      2.5,
+      3.0,
+      4.5,
+      4.0,
+      3.5,
+      4.0,
+      5.5,
+      3.5,
+      5.0,
+      4.5,
+      6.0,
+      4.5,
+      5.5,
+      5.0,
+      6.0,
+      4.0,
+      4.5,
+      5.5,
+      5.5,
+      5.0,
+      4.5
     ),
     stringsAsFactors = FALSE
   )
@@ -230,7 +699,15 @@ make_harvest_design <- function() {
   cal <- make_test_calendar_harvest()
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
   interviews <- make_test_interviews_harvest()
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 #' Create design without harvest column
@@ -239,7 +716,14 @@ make_design_without_harvest <- function() {
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
   interviews <- make_test_interviews_harvest()
   # Omit harvest parameter
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 #' Create small design with n interviews including harvest
@@ -263,15 +747,27 @@ make_small_harvest_design <- function(n) {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 #' Create unbalanced design (one stratum < 10)
 make_unbalanced_harvest_design <- function() {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
@@ -281,7 +777,9 @@ make_unbalanced_harvest_design <- function() {
   # 15 weekday interviews, only 5 weekend interviews
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 5), rep("2024-06-02", 5), rep("2024-06-03", 5),
+      rep("2024-06-01", 5),
+      rep("2024-06-02", 5),
+      rep("2024-06-03", 5),
       rep("2024-06-08", 5)
     )),
     catch_total = c(2, 3, 4, 5, 6, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12),
@@ -292,7 +790,15 @@ make_unbalanced_harvest_design <- function() {
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, harvest = catch_kept, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 # Basic behavior tests ----
@@ -639,13 +1145,22 @@ test_that("RATE-69-release: estimate_release_rate defaults to use_trips = 'compl
   data("example_catch", package = "tidycreel")
 
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   )
-  design <- add_catch(design, example_catch, # nolint: object_usage_linter
-    catch_uid = interview_id, interview_uid = interview_id,
-    species = species, count = count, catch_type = catch_type
+  design <- add_catch(
+    design,
+    example_catch, # nolint: object_usage_linter
+    catch_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    count = count,
+    catch_type = catch_type
   )
 
   has_incomplete <- any(design$interviews$trip_status == "incomplete")
@@ -706,7 +1221,12 @@ test_that("estimate_harvest_rate grouped + bootstrap variance compose correctly"
 
   # use_trips = "all": grouped bootstrap mechanics need >= 10 interviews/group
   # Should work (may warn about small n per group, but should not error)
-  result <- suppressWarnings(estimate_harvest_rate(design, by = day_type, variance = "bootstrap", use_trips = "all")) # nolint: object_usage_linter object_length_linter line_length_linter
+  result <- suppressWarnings(estimate_harvest_rate(
+    design,
+    by = day_type,
+    variance = "bootstrap",
+    use_trips = "all"
+  )) # nolint: object_usage_linter object_length_linter line_length_linter
 
   expect_s3_class(result, "creel_estimates")
   expect_equal(result$variance_method, "bootstrap")
@@ -725,7 +1245,9 @@ test_that("estimate_harvest_rate works end-to-end with example_calendar and exam
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
 
   # Add interviews with harvest = catch_kept
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     harvest = catch_kept,
     effort = hours_fished,
@@ -756,7 +1278,9 @@ test_that("HPUE <= CPUE with example data (harvest is subset of catch)", {
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
 
   # Add interviews
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     harvest = catch_kept,
     effort = hours_fished,
@@ -781,7 +1305,9 @@ test_that("grouped harvest estimation with example data handles small groups app
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
 
   # Add interviews
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     harvest = catch_kept,
     effort = hours_fished,
@@ -885,8 +1411,14 @@ test_that("estimate_harvest_rate grouped with zero-effort interviews excludes th
   # Create synthetic data with some zero-effort interviews in grouped estimation
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4)
   )
@@ -894,38 +1426,128 @@ test_that("estimate_harvest_rate grouped with zero-effort interviews excludes th
   # Create interviews with sufficient samples per group but some zero-effort
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 6), rep("2024-06-02", 6),
-      rep("2024-06-08", 6), rep("2024-06-09", 6)
+      rep("2024-06-01", 6),
+      rep("2024-06-02", 6),
+      rep("2024-06-08", 6),
+      rep("2024-06-09", 6)
     )),
     catch_total = c(
-      2, 3, 4, 5, 6, 0,
-      3, 4, 5, 6, 7, 8,
-      7, 8, 9, 10, 11, 0,
-      8, 9, 10, 11, 12, 13
+      2,
+      3,
+      4,
+      5,
+      6,
+      0,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      7,
+      8,
+      9,
+      10,
+      11,
+      0,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13
     ),
     catch_kept = c(
-      2, 3, 4, 5, 5, 0,
-      3, 4, 5, 6, 6, 7,
-      6, 7, 8, 9, 10, 0,
-      7, 8, 9, 10, 11, 12
+      2,
+      3,
+      4,
+      5,
+      5,
+      0,
+      3,
+      4,
+      5,
+      6,
+      6,
+      7,
+      6,
+      7,
+      8,
+      9,
+      10,
+      0,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12
     ),
     hours_fished = c(
-      2, 3, 4, 5, 3, 0, # one zero-effort
-      3, 4, 5, 3, 4, 5,
-      4, 5, 3, 5, 4, 0, # one zero-effort
-      4, 5, 5, 6, 5, 6
+      2,
+      3,
+      4,
+      5,
+      3,
+      0, # one zero-effort
+      3,
+      4,
+      5,
+      3,
+      4,
+      5,
+      4,
+      5,
+      3,
+      5,
+      4,
+      0, # one zero-effort
+      4,
+      5,
+      5,
+      6,
+      5,
+      6
     ),
     trip_status = rep("complete", 24),
     trip_duration = c(
-      2, 3, 4, 5, 3, 1,
-      3, 4, 5, 3, 4, 5,
-      4, 5, 3, 5, 4, 1,
-      4, 5, 5, 6, 5, 6
+      2,
+      3,
+      4,
+      5,
+      3,
+      1,
+      3,
+      4,
+      5,
+      3,
+      4,
+      5,
+      4,
+      5,
+      3,
+      5,
+      4,
+      1,
+      4,
+      5,
+      5,
+      6,
+      5,
+      6
     )
   )
 
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, catch = catch_total, harvest = catch_kept, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Grouped estimation should warn about zero-effort and exclude them
   expect_warning(
@@ -943,8 +1565,14 @@ test_that("estimate_harvest_rate grouped with NA harvest excludes them with warn
   # Create synthetic data with some NA harvest interviews in grouped estimation
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4)
   )
@@ -952,38 +1580,128 @@ test_that("estimate_harvest_rate grouped with NA harvest excludes them with warn
   # Create interviews with sufficient samples per group but some NA harvest
   interviews <- data.frame(
     date = as.Date(c(
-      rep("2024-06-01", 6), rep("2024-06-02", 6),
-      rep("2024-06-08", 6), rep("2024-06-09", 6)
+      rep("2024-06-01", 6),
+      rep("2024-06-02", 6),
+      rep("2024-06-08", 6),
+      rep("2024-06-09", 6)
     )),
     catch_total = c(
-      2, 3, 4, 5, 6, 7,
-      3, 4, 5, 6, 7, 8,
-      7, 8, 9, 10, 11, 12,
-      8, 9, 10, 11, 12, 13
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13
     ),
     catch_kept = c(
-      2, 3, 4, 5, 5, NA, # one NA harvest
-      3, 4, 5, 6, 6, 7,
-      6, 7, 8, 9, 10, NA, # one NA harvest
-      7, 8, 9, 10, 11, 12
+      2,
+      3,
+      4,
+      5,
+      5,
+      NA, # one NA harvest
+      3,
+      4,
+      5,
+      6,
+      6,
+      7,
+      6,
+      7,
+      8,
+      9,
+      10,
+      NA, # one NA harvest
+      7,
+      8,
+      9,
+      10,
+      11,
+      12
     ),
     hours_fished = c(
-      2, 3, 4, 5, 3, 4,
-      3, 4, 5, 3, 4, 5,
-      4, 5, 3, 5, 4, 5,
-      4, 5, 5, 6, 5, 6
+      2,
+      3,
+      4,
+      5,
+      3,
+      4,
+      3,
+      4,
+      5,
+      3,
+      4,
+      5,
+      4,
+      5,
+      3,
+      5,
+      4,
+      5,
+      4,
+      5,
+      5,
+      6,
+      5,
+      6
     ),
     trip_status = rep("complete", 24),
     trip_duration = c(
-      2, 3, 4, 5, 3, 4,
-      3, 4, 5, 3, 4, 5,
-      4, 5, 3, 5, 4, 5,
-      4, 5, 5, 6, 5, 6
+      2,
+      3,
+      4,
+      5,
+      3,
+      4,
+      3,
+      4,
+      5,
+      3,
+      4,
+      5,
+      4,
+      5,
+      3,
+      5,
+      4,
+      5,
+      4,
+      5,
+      5,
+      6,
+      5,
+      6
     )
   )
 
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, catch = catch_total, harvest = catch_kept, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 
   # Grouped estimation should warn about NA harvest and exclude them
   expect_warning(
@@ -1015,7 +1733,8 @@ make_br_harvest_design <- function() {
     date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04")),
     day_type = "weekday"
   )
-  creel_design( # nolint: object_usage_linter
+  creel_design(
+    # nolint: object_usage_linter
     calendar = cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
@@ -1039,8 +1758,12 @@ make_br_harvest_interviews <- function(design, trip_status_col = FALSE) {
   # H_hat = sum = 135.833...
   interviews_df <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-01", "2024-06-02"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-01",
+      "2024-06-02"
     )),
     site = c("A", "A", "B", "B", "C", "C"),
     circuit = "c1",
@@ -1054,12 +1777,16 @@ make_br_harvest_interviews <- function(design, trip_status_col = FALSE) {
   if (trip_status_col) {
     # Spread incomplete trips across 2 dates to satisfy survey PSU requirement
     interviews_df$trip_status <- c(
-      "complete", "incomplete",
-      "complete", "incomplete",
-      "complete", "complete"
+      "complete",
+      "incomplete",
+      "complete",
+      "incomplete",
+      "complete",
+      "complete"
     )
   }
-  add_interviews( # nolint: object_usage_linter
+  add_interviews(
+    # nolint: object_usage_linter
     design,
     interviews_df,
     effort = hours_fished, # nolint: object_usage_linter
@@ -1081,8 +1808,13 @@ test_that("estimate_harvest_rate() Eq. 19.5: H_hat = sum(h_i/pi_i) matches hand-
   d <- make_br_harvest_interviews(make_br_harvest_design())
   result <- estimate_harvest_rate(d)
   # H_hat = 37.5 + 75.0 + 2.5 + 0 + 12.5 + 8.333... = 135.833...
-  expected_h_hat <- (2 * 3) / 0.16 + (4 * 3) / 0.16 + (1 * 1) / 0.40 +
-    (0 * 1) / 0.24 + (3 * 1) / 0.24 + (2 * 1) / 0.24
+  expected_h_hat <- (2 * 3) /
+    0.16 +
+    (4 * 3) / 0.16 +
+    (1 * 1) / 0.40 +
+    (0 * 1) / 0.24 +
+    (3 * 1) / 0.24 +
+    (2 * 1) / 0.24
   expect_equal(result$estimates$estimate, expected_h_hat, tolerance = 1e-6)
 })
 
@@ -1174,7 +1906,12 @@ test_that("RATE-03-harvest: missing section produces NA row + cli_warn for estim
 
 test_that("HPUE-SPECIES-01: by=species returns creel_estimates with hpue-species method", {
   design <- suppressMessages(suppressWarnings(
-    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 30L, n_species = 2L, seed = 42L)
+    build_multistrata_multispecies_design_for_tests(
+      n_days = 10L,
+      n_interviews = 30L,
+      n_species = 2L,
+      seed = 42L
+    )
   ))
   result <- suppressMessages(suppressWarnings(estimate_harvest_rate(design, by = species)))
   expect_s3_class(result, "creel_estimates")
@@ -1183,7 +1920,12 @@ test_that("HPUE-SPECIES-01: by=species returns creel_estimates with hpue-species
 
 test_that("HPUE-SPECIES-02: by=species result has one row per species with species column", {
   design <- suppressMessages(suppressWarnings(
-    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 30L, n_species = 3L, seed = 7L)
+    build_multistrata_multispecies_design_for_tests(
+      n_days = 10L,
+      n_interviews = 30L,
+      n_species = 3L,
+      seed = 7L
+    )
   ))
   result <- suppressMessages(suppressWarnings(estimate_harvest_rate(design, by = species)))
   expect_true("species" %in% names(result$estimates))
@@ -1192,7 +1934,12 @@ test_that("HPUE-SPECIES-02: by=species result has one row per species with speci
 
 test_that("HPUE-SPECIES-03: by=c(day_type, species) groups by interview var + species", {
   design <- suppressMessages(suppressWarnings(
-    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 40L, n_species = 2L, seed = 99L)
+    build_multistrata_multispecies_design_for_tests(
+      n_days = 10L,
+      n_interviews = 40L,
+      n_species = 2L,
+      seed = 99L
+    )
   ))
   result <- suppressMessages(suppressWarnings(
     estimate_harvest_rate(design, by = c(day_type, species))
@@ -1204,7 +1951,12 @@ test_that("HPUE-SPECIES-03: by=c(day_type, species) groups by interview var + sp
 
 test_that("HPUE-SPECIES-04: all estimate/se/ci columns present in species result", {
   design <- suppressMessages(suppressWarnings(
-    build_multistrata_multispecies_design_for_tests(n_days = 10L, n_interviews = 30L, n_species = 2L, seed = 42L)
+    build_multistrata_multispecies_design_for_tests(
+      n_days = 10L,
+      n_interviews = 30L,
+      n_species = 2L,
+      seed = 42L
+    )
   ))
   result <- suppressMessages(suppressWarnings(estimate_harvest_rate(design, by = species)))
   expected_cols <- c("species", "estimate", "se", "ci_lower", "ci_upper")

--- a/tests/testthat/test-estimate-mr-harvest.R
+++ b/tests/testthat/test-estimate-mr-harvest.R
@@ -1,6 +1,6 @@
 # Build a shared angler_n result for harvest tests
 angler_result <- estimate_angler_n(M = 200L, n = 50L, m = 10L)
-rate           <- 0.35
+rate <- 0.35
 
 # --- MR-06: estimate_mr_harvest() delta-method harvest estimator ---
 

--- a/tests/testthat/test-estimate-species.R
+++ b/tests/testthat/test-estimate-species.R
@@ -9,17 +9,36 @@
 # ---------------------------------------------------------------------------
 
 #' Create 3-section design with interview data for release rate section tests
-make_3section_design_with_interviews_rel <- function() { # nolint: object_length_linter
+make_3section_design_with_interviews_rel <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -36,9 +55,42 @@ make_3section_design_with_interviews_rel <- function() { # nolint: object_length
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -46,45 +98,180 @@ make_3section_design_with_interviews_rel <- function() { # nolint: object_length
 
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central", "South"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6,
-      10, 12, 9, 11, 10, 12, 13, 11, 10
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6,
+      10,
+      12,
+      9,
+      11,
+      10,
+      12,
+      13,
+      11,
+      10
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4,
-      7, 9, 6, 8, 7, 9, 10, 8, 7
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4,
+      7,
+      9,
+      6,
+      8,
+      7,
+      9,
+      10,
+      8,
+      7
     ),
     trip_status = rep("complete", 27),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
@@ -92,10 +279,15 @@ make_3section_design_with_interviews_rel <- function() { # nolint: object_length
   # Add catch data for release rate
   interviews$interview_id <- seq_len(nrow(interviews))
 
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   # Build simple catch data: each interview has one "released" row
@@ -107,25 +299,49 @@ make_3section_design_with_interviews_rel <- function() { # nolint: object_length
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, catch_df,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    catch_df,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
 #' Create 3-section design with South absent from interview data (for release rate tests)
-make_section_design_missing_interview_section_rel <- function() { # nolint: object_length_linter
+make_section_design_missing_interview_section_rel <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -142,9 +358,42 @@ make_section_design_missing_interview_section_rel <- function() { # nolint: obje
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -153,45 +402,140 @@ make_section_design_missing_interview_section_rel <- function() { # nolint: obje
   # Only North and Central
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4
     ),
     trip_status = rep("complete", 18),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
   interviews$interview_id <- seq_len(nrow(interviews))
 
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    harvest = catch_kept, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   catch_df <- data.frame(
@@ -202,10 +546,15 @@ make_section_design_missing_interview_section_rel <- function() { # nolint: obje
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, catch_df,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    catch_df,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
@@ -214,42 +563,71 @@ make_section_design_missing_interview_section_rel <- function() { # nolint: obje
 # ---------------------------------------------------------------------------
 
 make_test_design_with_catch <- function(include_harvest = FALSE) {
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     example_calendar, # nolint: object_usage_linter
-    date = date, strata = day_type # nolint: object_usage_linter
+    date = date,
+    strata = day_type # nolint: object_usage_linter
   )
   design <- suppressMessages(add_counts(design, example_counts)) # nolint: object_usage_linter
   if (include_harvest) {
-    design <- suppressMessages(add_interviews( # nolint: object_usage_linter
-      design, example_interviews, # nolint: object_usage_linter
-      catch = catch_total, harvest = catch_kept, effort = hours_fished, # nolint: object_usage_linter
-      trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+    design <- suppressMessages(add_interviews(
+      # nolint: object_usage_linter
+      design,
+      example_interviews, # nolint: object_usage_linter
+      catch = catch_total,
+      harvest = catch_kept,
+      effort = hours_fished, # nolint: object_usage_linter
+      trip_status = trip_status,
+      trip_duration = trip_duration # nolint: object_usage_linter
     ))
   } else {
-    design <- suppressMessages(add_interviews( # nolint: object_usage_linter
-      design, example_interviews, # nolint: object_usage_linter
-      catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-      trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+    design <- suppressMessages(add_interviews(
+      # nolint: object_usage_linter
+      design,
+      example_interviews, # nolint: object_usage_linter
+      catch = catch_total,
+      effort = hours_fished, # nolint: object_usage_linter
+      trip_status = trip_status,
+      trip_duration = trip_duration # nolint: object_usage_linter
     ))
   }
-  suppressMessages(add_catch( # nolint: object_usage_linter
-    design, example_catch, # nolint: object_usage_linter
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressMessages(add_catch(
+    # nolint: object_usage_linter
+    design,
+    example_catch, # nolint: object_usage_linter
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
 #' Design with >= 10 interviews per stratum — required for per-stratum
 #' product estimation (estimate_total_*() with by = species).
-make_test_design_with_catch_adequate <- function(include_harvest = FALSE) { # nolint: object_length_linter
+make_test_design_with_catch_adequate <- function(include_harvest = FALSE) {
+  # nolint: object_length_linter
   set.seed(99)
   # 8 weekday + 8 weekend dates
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10", "2024-06-11", "2024-06-12",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16",
-      "2024-06-22", "2024-06-23", "2024-06-29", "2024-06-30"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-11",
+      "2024-06-12",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-22",
+      "2024-06-23",
+      "2024-06-29",
+      "2024-06-30"
     )),
     day_type = c(rep("weekday", 8), rep("weekend", 8)),
     stringsAsFactors = FALSE
@@ -277,67 +655,94 @@ make_test_design_with_catch_adequate <- function(include_harvest = FALSE) { # no
   )
   # species catch (3 species: bass, panfish, walleye)
   # Build caught/released/harvested so that harvested + released <= caught
-  catch_df <- do.call(rbind, lapply(c("bass", "panfish", "walleye"), function(sp) {
-    n_caught <- sample(2:5, 24, replace = TRUE)
-    n_released <- floor(n_caught * runif(24, 0, 0.5))
-    n_harvested <- if (include_harvest) pmin(n_caught - n_released, sample(0:2, 24, replace = TRUE)) else integer(24)
-    rows <- data.frame(
-      interview_id = seq_len(24),
-      species = sp,
-      count = n_caught,
-      catch_type = "caught",
-      stringsAsFactors = FALSE
-    )
-    rows_r <- data.frame(
-      interview_id = seq_len(24),
-      species = sp,
-      count = n_released,
-      catch_type = "released",
-      stringsAsFactors = FALSE
-    )
-    if (include_harvest) {
-      rows_h <- data.frame(
+  catch_df <- do.call(
+    rbind,
+    lapply(c("bass", "panfish", "walleye"), function(sp) {
+      n_caught <- sample(2:5, 24, replace = TRUE)
+      n_released <- floor(n_caught * runif(24, 0, 0.5))
+      n_harvested <- if (include_harvest) {
+        pmin(n_caught - n_released, sample(0:2, 24, replace = TRUE))
+      } else {
+        integer(24)
+      }
+      rows <- data.frame(
         interview_id = seq_len(24),
         species = sp,
-        count = n_harvested,
-        catch_type = "harvested",
+        count = n_caught,
+        catch_type = "caught",
         stringsAsFactors = FALSE
       )
-      rbind(rows, rows_r, rows_h)
-    } else {
-      rbind(rows, rows_r)
-    }
-  }))
+      rows_r <- data.frame(
+        interview_id = seq_len(24),
+        species = sp,
+        count = n_released,
+        catch_type = "released",
+        stringsAsFactors = FALSE
+      )
+      if (include_harvest) {
+        rows_h <- data.frame(
+          interview_id = seq_len(24),
+          species = sp,
+          count = n_harvested,
+          catch_type = "harvested",
+          stringsAsFactors = FALSE
+        )
+        rbind(rows, rows_r, rows_h)
+      } else {
+        rbind(rows, rows_r)
+      }
+    })
+  )
 
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
   design <- suppressMessages(add_counts(design, counts)) # nolint: object_usage_linter
   if (include_harvest) {
-    design <- suppressMessages(add_interviews(design, interviews, # nolint: object_usage_linter
-      catch = catch_total, harvest = catch_kept, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+    design <- suppressMessages(add_interviews(
+      design,
+      interviews, # nolint: object_usage_linter
+      catch = catch_total,
+      harvest = catch_kept,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ))
   } else {
-    design <- suppressMessages(add_interviews(design, interviews, # nolint: object_usage_linter
-      catch = catch_total, effort = hours_fished,
-      trip_status = trip_status, trip_duration = trip_duration
+    design <- suppressMessages(add_interviews(
+      design,
+      interviews, # nolint: object_usage_linter
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ))
   }
-  suppressMessages(add_catch(design, catch_df, # nolint: object_usage_linter
-    catch_uid = interview_id, interview_uid = interview_id,
-    species = species, count = count, catch_type = catch_type
+  suppressMessages(add_catch(
+    design,
+    catch_df, # nolint: object_usage_linter
+    catch_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    count = count,
+    catch_type = catch_type
   ))
 }
 
 make_test_design_no_catch <- function() {
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     example_calendar, # nolint: object_usage_linter
-    date = date, strata = day_type # nolint: object_usage_linter
+    date = date,
+    strata = day_type # nolint: object_usage_linter
   )
   design <- suppressMessages(add_counts(design, example_counts)) # nolint: object_usage_linter
-  suppressMessages(add_interviews( # nolint: object_usage_linter
-    design, example_interviews, # nolint: object_usage_linter
-    catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressMessages(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    example_interviews, # nolint: object_usage_linter
+    catch = catch_total,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -403,37 +808,49 @@ make_mor_design_with_catch <- function(n_incomplete = 15) {
     stringsAsFactors = FALSE
   )
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- suppressMessages(add_counts(design, data.frame(
-    date = as.Date("2024-06-01"), day_type = "weekday", effort_hours = 8,
-    stringsAsFactors = FALSE
-  )))
+  design <- suppressMessages(add_counts(
+    design,
+    data.frame(
+      date = as.Date("2024-06-01"),
+      day_type = "weekday",
+      effort_hours = 8,
+      stringsAsFactors = FALSE
+    )
+  ))
   n <- n_incomplete + 5L
   interviews <- data.frame(
-    interview_id  = seq_len(n),
-    date          = as.Date("2024-06-01"),
-    day_type      = "weekday",
-    catch_total   = rep(c(2L, 3L, 4L, 1L, 5L), length.out = n),
-    hours_fished  = rep(c(2.0, 3.0, 4.0, 1.5, 2.5), length.out = n),
-    trip_status   = c(rep("incomplete", n_incomplete), rep("complete", 5L)),
+    interview_id = seq_len(n),
+    date = as.Date("2024-06-01"),
+    day_type = "weekday",
+    catch_total = rep(c(2L, 3L, 4L, 1L, 5L), length.out = n),
+    hours_fished = rep(c(2.0, 3.0, 4.0, 1.5, 2.5), length.out = n),
+    trip_status = c(rep("incomplete", n_incomplete), rep("complete", 5L)),
     trip_duration = rep(c(2.0, 3.0, 4.0, 1.5, 2.5), length.out = n),
     stringsAsFactors = FALSE
   )
   design <- suppressMessages(add_interviews(
-    design, interviews,
-    catch = catch_total, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   ))
   catch_df <- data.frame(
     interview_id = rep(seq_len(n), each = 2L),
-    species      = rep(c("walleye", "bass"), times = n),
-    count        = rep(c(1L, 1L), times = n),
-    catch_type   = "harvested",
+    species = rep(c("walleye", "bass"), times = n),
+    count = rep(c(1L, 1L), times = n),
+    catch_type = "harvested",
     stringsAsFactors = FALSE
   )
   suppressMessages(add_catch(
-    design, catch_df,
-    catch_uid = interview_id, interview_uid = interview_id,
-    species = species, count = count, catch_type = catch_type
+    design,
+    catch_df,
+    catch_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    count = count,
+    catch_type = catch_type
   ))
 }
 
@@ -490,13 +907,19 @@ test_that("estimate_catch_rate species: non-zero CPUE when catch has only harves
   d_base <- make_test_design_no_catch()
   catch_no_caught <- example_catch[example_catch$catch_type != "caught", ]
   d <- suppressWarnings(suppressMessages(add_catch(
-    d_base, catch_no_caught,
-    catch_uid = interview_id, interview_uid = interview_id,
-    species = species, count = count, catch_type = catch_type
+    d_base,
+    catch_no_caught,
+    catch_uid = interview_id,
+    interview_uid = interview_id,
+    species = species,
+    count = count,
+    catch_type = catch_type
   )))
   result <- suppressWarnings(suppressMessages(estimate_catch_rate(d, by = species)))
-  expect_true(any(result$estimates$estimate > 0),
-    info = "CPUE must be non-zero when catch data uses harvested/released types only")
+  expect_true(
+    any(result$estimates$estimate > 0),
+    info = "CPUE must be non-zero when catch data uses harvested/released types only"
+  )
 })
 
 # ---------------------------------------------------------------------------
@@ -597,7 +1020,10 @@ test_that("estimate_release_rate errors when no catch data", {
 test_that("estimate_release_rate errors when no interview survey", {
   d <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   d$catch <- data.frame(
-    interview_id = 1L, species = "walleye", count = 1L, catch_type = "released"
+    interview_id = 1L,
+    species = "walleye",
+    count = 1L,
+    catch_type = "released"
   )
   expect_error(estimate_release_rate(d), "add_interviews")
 })
@@ -646,7 +1072,10 @@ test_that("estimate_total_release errors when no catch data", {
 test_that("estimate_total_release errors when no counts", {
   d <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   d$catch <- data.frame(
-    interview_id = 1L, species = "w", count = 1L, catch_type = "released"
+    interview_id = 1L,
+    species = "w",
+    count = 1L,
+    catch_type = "released"
   )
   expect_error(suppressMessages(estimate_total_release(d)))
 })
@@ -662,8 +1091,10 @@ test_that("estimate_total_release by=day_type routes through grouped path", {
   result <- suppressWarnings(estimate_total_release(d, by = day_type))
   expect_s3_class(result, "creel_estimates")
   expect_equal(nrow(result$estimates), 2L)
-  expect_true(all(c("day_type", "estimate", "se", "ci_lower", "ci_upper", "n") %in%
-    names(result$estimates)))
+  expect_true(all(
+    c("day_type", "estimate", "se", "ci_lower", "ci_upper", "n") %in%
+      names(result$estimates)
+  ))
 })
 
 test_that("estimate_total_release grouped estimates are positive", {
@@ -682,9 +1113,7 @@ test_that("estimate_total_catch unchanged without species (backward compat)", {
   d_without <- make_test_design_no_catch()
   r_with <- suppressWarnings(suppressMessages(estimate_total_catch(d_with)))
   r_without <- suppressWarnings(suppressMessages(estimate_total_catch(d_without)))
-  expect_equal(r_with$estimates$estimate, r_without$estimates$estimate,
-    tolerance = 1e-6
-  )
+  expect_equal(r_with$estimates$estimate, r_without$estimates$estimate, tolerance = 1e-6)
 })
 
 test_that("estimate_total_catch by=species returns one row per species", {
@@ -733,15 +1162,18 @@ test_that("estimate_total_harvest unchanged without species (backward compat)", 
   d_with <- make_test_design_with_catch(include_harvest = TRUE)
   d_without <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   d_without <- suppressMessages(add_counts(d_without, example_counts))
-  d_without <- suppressMessages(add_interviews(d_without, example_interviews,
-    catch = catch_total, harvest = catch_kept, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+  d_without <- suppressMessages(add_interviews(
+    d_without,
+    example_interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   ))
   r_with <- suppressWarnings(suppressMessages(estimate_total_harvest(d_with)))
   r_without <- suppressWarnings(suppressMessages(estimate_total_harvest(d_without)))
-  expect_equal(r_with$estimates$estimate, r_without$estimates$estimate,
-    tolerance = 1e-6
-  )
+  expect_equal(r_with$estimates$estimate, r_without$estimates$estimate, tolerance = 1e-6)
 })
 
 test_that("estimate_total_harvest by=species returns one row per species", {
@@ -771,9 +1203,14 @@ test_that("estimate_total_harvest species returns species column first", {
 test_that("estimate_total_harvest species errors when no catch data", {
   d_without <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   d_without <- suppressMessages(add_counts(d_without, example_counts))
-  d_without <- suppressMessages(add_interviews(d_without, example_interviews,
-    catch = catch_total, harvest = catch_kept, effort = hours_fished,
-    trip_status = trip_status, trip_duration = trip_duration
+  d_without <- suppressMessages(add_interviews(
+    d_without,
+    example_interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
   ))
   expect_error(
     suppressWarnings(suppressMessages(estimate_total_harvest(d_without, by = species))),

--- a/tests/testthat/test-estimate-total-catch.R
+++ b/tests/testthat/test-estimate-total-catch.R
@@ -10,7 +10,9 @@ make_total_catch_design <- function() {
   # Create design with both data sources
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -37,7 +39,9 @@ make_interviews_only_design <- function() {
   data("example_interviews", package = "tidycreel")
 
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -51,8 +55,14 @@ make_interviews_only_design <- function() {
 make_total_catch_partial_sample_design <- function() {
   calendar <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -76,7 +86,9 @@ make_total_catch_partial_sample_design <- function() {
 
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
@@ -121,13 +133,17 @@ make_species_missing_rate_strata_design <- function() {
 
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
-  add_catch(design, catch_df, # nolint: object_usage_linter
+  add_catch(
+    design,
+    catch_df, # nolint: object_usage_linter
     catch_uid = interview_id,
     interview_uid = interview_id,
     species = species,
@@ -177,12 +193,42 @@ make_total_catch_special_strata_design <- function() {
     date = rep(sampled_days$date, each = 6),
     analysis_stratum = rep(sampled_days$analysis_stratum, each = 6),
     catch_total = c(
-      5, 6, 5, 6, 5, 6,
-      6, 7, 6, 7, 6, 7,
-      7, 8, 7, 8, 7, 8,
-      8, 9, 8, 9, 8, 9,
-      2, 3, 2, 3, 2, 3,
-      3, 4, 3, 4, 3, 4
+      5,
+      6,
+      5,
+      6,
+      5,
+      6,
+      6,
+      7,
+      6,
+      7,
+      6,
+      7,
+      7,
+      8,
+      7,
+      8,
+      7,
+      8,
+      8,
+      9,
+      8,
+      9,
+      8,
+      9,
+      2,
+      3,
+      2,
+      3,
+      2,
+      3,
+      3,
+      4,
+      3,
+      4,
+      3,
+      4
     ),
     hours_fished = c(
       rep(3, 12),
@@ -200,7 +246,9 @@ make_total_catch_special_strata_design <- function() {
 
   design <- creel_design(calendar, date = date, strata = analysis_stratum) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  add_interviews(design, interviews, # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
@@ -310,7 +358,9 @@ test_that("estimate_total_catch can group by schedule-defined special strata", {
   result <- estimate_total_catch(design, by = analysis_stratum, target = "period_total") # nolint: object_usage_linter
 
   expect_true("analysis_stratum" %in% names(result$estimates))
-  expect_true(all(c("high_use_july", "high_use_aug", "regular") %in% result$estimates$analysis_stratum))
+  expect_true(all(
+    c("high_use_july", "high_use_aug", "regular") %in% result$estimates$analysis_stratum
+  ))
 })
 
 # Input validation tests ----
@@ -363,8 +413,10 @@ test_that("total catch estimate equals sum of per-stratum effort * cpue products
     stringsAsFactors = FALSE
   )
   counts <- data.frame(
-    date = calendar$date, day_type = calendar$day_type,
-    effort_hours = c(10, 12, 14, 11, 13, 15, 10), stringsAsFactors = FALSE
+    date = calendar$date,
+    day_type = calendar$day_type,
+    effort_hours = c(10, 12, 14, 11, 13, 15, 10),
+    stringsAsFactors = FALSE
   )
   n_int <- 15L
   set.seed(123L)
@@ -380,8 +432,14 @@ test_that("total catch estimate equals sum of per-stratum effort * cpue products
   d1 <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   d1 <- suppressMessages(suppressWarnings(add_counts(d1, counts))) # nolint: object_usage_linter
   d1 <- suppressMessages(suppressWarnings(
-    add_interviews(d1, interviews, catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-      trip_status = trip_status, trip_duration = trip_duration)
+    add_interviews(
+      d1,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished, # nolint: object_usage_linter
+      trip_status = trip_status,
+      trip_duration = trip_duration
+    )
   ))
 
   result <- suppressWarnings(suppressMessages(estimate_total_catch(d1))) # nolint: object_usage_linter
@@ -401,8 +459,10 @@ test_that("total catch SE matches stratified-sum delta method formula", {
     stringsAsFactors = FALSE
   )
   counts <- data.frame(
-    date = calendar$date, day_type = calendar$day_type,
-    effort_hours = c(10, 12, 14, 11, 13, 15, 10), stringsAsFactors = FALSE
+    date = calendar$date,
+    day_type = calendar$day_type,
+    effort_hours = c(10, 12, 14, 11, 13, 15, 10),
+    stringsAsFactors = FALSE
   )
   n_int <- 15L
   set.seed(123L)
@@ -418,8 +478,14 @@ test_that("total catch SE matches stratified-sum delta method formula", {
   d1 <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   d1 <- suppressMessages(suppressWarnings(add_counts(d1, counts))) # nolint: object_usage_linter
   d1 <- suppressMessages(suppressWarnings(
-    add_interviews(d1, interviews, catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-      trip_status = trip_status, trip_duration = trip_duration)
+    add_interviews(
+      d1,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished, # nolint: object_usage_linter
+      trip_status = trip_status,
+      trip_duration = trip_duration
+    )
   ))
 
   result <- suppressWarnings(suppressMessages(estimate_total_catch(d1))) # nolint: object_usage_linter
@@ -482,7 +548,9 @@ make_grouped_test_design <- function() {
   # Create design
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -626,7 +694,9 @@ test_that("full workflow with example data produces valid result", {
   # Create complete design
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -655,8 +725,10 @@ test_that("total catch components are consistent with stratified-sum estimator",
     stringsAsFactors = FALSE
   )
   counts <- data.frame(
-    date = calendar$date, day_type = calendar$day_type,
-    effort_hours = c(10, 12, 14, 11, 13, 15, 10), stringsAsFactors = FALSE
+    date = calendar$date,
+    day_type = calendar$day_type,
+    effort_hours = c(10, 12, 14, 11, 13, 15, 10),
+    stringsAsFactors = FALSE
   )
   n_int <- 15L
   set.seed(123L)
@@ -672,8 +744,14 @@ test_that("total catch components are consistent with stratified-sum estimator",
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- suppressMessages(suppressWarnings(add_counts(design, counts))) # nolint: object_usage_linter
   design <- suppressMessages(suppressWarnings(
-    add_interviews(design, interviews, catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-      trip_status = trip_status, trip_duration = trip_duration)
+    add_interviews(
+      design,
+      interviews,
+      catch = catch_total,
+      effort = hours_fished, # nolint: object_usage_linter
+      trip_status = trip_status,
+      trip_duration = trip_duration
+    )
   ))
 
   effort_est <- suppressWarnings(estimate_effort(design)) # nolint: object_usage_linter
@@ -697,7 +775,9 @@ test_that("total harvest <= total catch for same design", {
   # Create complete design including harvest
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
@@ -731,7 +811,8 @@ make_br_catch_design <- function() {
     date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04")),
     day_type = "weekday"
   )
-  creel_design( # nolint: object_usage_linter
+  creel_design(
+    # nolint: object_usage_linter
     calendar = cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
@@ -754,8 +835,12 @@ make_br_catch_interviews <- function(design) {
   # c_i/pi_i: A=56.25, A=93.75, B=5.0, B=2.5, C=16.67, C=12.5 — C_hat > 0
   interviews_df <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-01", "2024-06-02"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-01",
+      "2024-06-02"
     )),
     site = c("A", "A", "B", "B", "C", "C"),
     circuit = "c1",
@@ -766,7 +851,8 @@ make_br_catch_interviews <- function(design) {
     fish_kept = c(2L, 4L, 1L, 0L, 3L, 2L),
     trip_status = rep("complete", 6)
   )
-  add_interviews( # nolint: object_usage_linter
+  add_interviews(
+    # nolint: object_usage_linter
     design,
     interviews_df,
     effort = hours_fished, # nolint: object_usage_linter
@@ -827,17 +913,36 @@ test_that("estimate_total_catch() verbose=FALSE produces no dispatch message", {
 #' 9 interviews per section. Fixture name is explicit about purpose
 #' (total catch context). Data shape is identical to the Phase 40 fixture
 #' make_3section_design_with_interviews().
-make_3section_total_catch_design <- function() { # nolint: object_length_linter
+make_3section_total_catch_design <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -856,14 +961,44 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
       # North: weekday ~15-25, weekend ~20-28
-      20, 22, 18, 25, 15, 24,
-      21, 26, 23, 28, 20, 27,
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
       # Central: weekday ~30-45, weekend ~35-48
-      35, 38, 32, 42, 30, 45,
-      37, 44, 40, 48, 35, 46,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
       # South: weekday ~5-12, weekend ~6-13
-      8, 10, 5, 12, 6, 11,
-      7, 9, 6, 13, 8, 10
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -873,59 +1008,174 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
   interviews <- data.frame(
     date = as.Date(c(
       # North (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
       # Central (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21",
       # South (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central", "South"), each = 9),
     catch_total = c(
       # North: ~1 fish/hr
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
       # Central: ~1.5 fish/hr
-      5, 6, 5, 7, 6, 5, 7, 8, 6,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6,
       # South: ~2.5 fish/hr
-      10, 12, 9, 11, 10, 12, 13, 11, 10
+      10,
+      12,
+      9,
+      11,
+      10,
+      12,
+      13,
+      11,
+      10
     ),
     hours_fished = c(
       # North: 2-3 hrs
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central: 3-4 hrs
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South: 4-5 hrs
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     trip_status = rep("complete", 27),
     trip_duration = c(
       # North
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -933,17 +1183,36 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
 #'
 #' Registered sections: "North", "Central", "South".
 #' Interview data contains only "North" and "Central" rows — "South" absent.
-make_3section_catch_design_missing_south <- function() { # nolint: object_length_linter
+make_3section_catch_design_missing_south <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -960,9 +1229,42 @@ make_3section_catch_design_missing_south <- function() { # nolint: object_length
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -971,40 +1273,118 @@ make_3section_catch_design_missing_south <- function() { # nolint: object_length
   # Only North and Central interviews — South absent
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     trip_status = rep("complete", 18),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -1111,9 +1491,11 @@ make_ice_total_catch_design <- function() {
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "ice",
     effort_type = "time_on_ice",
     p_period = 0.5
@@ -1127,7 +1509,8 @@ make_ice_total_catch_design <- function() {
     trip_status = rep("complete", 4L),
     stringsAsFactors = FALSE
   )
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
     design,
     interviews_df,
     catch = walleye_catch, # nolint: object_usage_linter
@@ -1155,9 +1538,11 @@ make_camera_total_catch_design <- function() {
   dates <- unique(cal$date)[1:4]
   day_types <- cal$day_type[match(dates, cal$date)]
 
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "camera",
     camera_mode = "counter"
   )
@@ -1178,8 +1563,10 @@ make_camera_total_catch_design <- function() {
     walleye_kept = c(1L, 1L, 0L, 0L, 2L, 0L, 1L, 0L, 2L, 0L, 1L, 1L),
     stringsAsFactors = FALSE
   )
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
@@ -1222,9 +1609,11 @@ make_aerial_total_catch_design <- function() {
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "aerial",
     h_open = 14
   )
@@ -1240,13 +1629,32 @@ make_aerial_total_catch_design <- function() {
     date = rep(as.Date(c("2024-07-01", "2024-07-02", "2024-07-03", "2024-07-04")), each = 4),
     day_type = rep(c("weekday", "weekday", "weekend", "weekend"), each = 4),
     trip_status = rep("complete", 16),
-    hours_fished = c(2.5, 3.0, 1.5, 4.0, 2.0, 3.5, 1.0, 2.5, 3.0, 4.5, 2.0, 3.5, 4.0, 3.0, 2.5, 1.5),
+    hours_fished = c(
+      2.5,
+      3.0,
+      1.5,
+      4.0,
+      2.0,
+      3.5,
+      1.0,
+      2.5,
+      3.0,
+      4.5,
+      2.0,
+      3.5,
+      4.0,
+      3.0,
+      2.5,
+      1.5
+    ),
     walleye = c(0L, 1L, 2L, 0L, 1L, 0L, 3L, 1L, 0L, 2L, 1L, 0L, 3L, 1L, 0L, 2L),
     walleye_kept = c(0L, 1L, 1L, 0L, 1L, 0L, 2L, 1L, 0L, 1L, 1L, 0L, 2L, 1L, 0L, 1L),
     stringsAsFactors = FALSE
   )
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
     catch = walleye, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter

--- a/tests/testthat/test-estimate-total-catch.R
+++ b/tests/testthat/test-estimate-total-catch.R
@@ -1275,3 +1275,23 @@ test_that("AIR-05: estimate_total_catch() on aerial routes through standard (non
   # Aerial is NOT in c("bus_route", "ice") — standard path produces "product-total-catch"
   expect_equal(result$method, "product-total-catch")
 })
+
+# TOTC-WARN: standard-path missing-strata warning ----
+
+test_that("estimate_total_catch warns on standard (non-species) path when effort strata lack rate coverage", {
+  # Reuse species fixture: interviews only in weekdays, counts in both strata.
+  # The standard (no by=species) path must also warn — previously it was silent.
+  design <- make_species_missing_rate_strata_design() # nolint: object_usage_linter
+  expect_warning(
+    estimate_total_catch(design), # nolint: object_usage_linter
+    regexp = "no matching rate estimate"
+  )
+})
+
+test_that("estimate_total_catch(by=day_type) warns on grouped standard path when effort strata lack rate coverage", {
+  design <- make_species_missing_rate_strata_design() # nolint: object_usage_linter
+  expect_warning(
+    estimate_total_catch(design, by = day_type), # nolint: object_usage_linter
+    regexp = "no matching rate estimate"
+  )
+})

--- a/tests/testthat/test-estimate-total-harvest.R
+++ b/tests/testthat/test-estimate-total-harvest.R
@@ -816,3 +816,21 @@ test_that("PROD-01-harvest-missing: missing section inserts NA row with data_ava
   expect_false(south_row$data_available)
   expect_true(is.na(south_row$estimate))
 })
+
+# TOTH-WARN: standard-path missing-strata warning ----
+
+test_that("estimate_total_harvest warns on standard (non-species) path when effort strata lack rate coverage", {
+  design <- make_total_harvest_missing_rate_strata_design() # nolint: object_usage_linter
+  expect_warning(
+    estimate_total_harvest(design), # nolint: object_usage_linter
+    regexp = "no matching rate estimate"
+  )
+})
+
+test_that("estimate_total_harvest(by=day_type) warns on grouped standard path when effort strata lack rate coverage", {
+  design <- make_total_harvest_missing_rate_strata_design() # nolint: object_usage_linter
+  expect_warning(
+    estimate_total_harvest(design, by = day_type), # nolint: object_usage_linter
+    regexp = "no matching rate estimate"
+  )
+})

--- a/tests/testthat/test-estimate-total-harvest.R
+++ b/tests/testthat/test-estimate-total-harvest.R
@@ -10,7 +10,9 @@ make_total_harvest_design <- function() {
   # Create design with both data sources including harvest
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
@@ -22,7 +24,8 @@ make_total_harvest_design <- function() {
 }
 
 #' Create test design without harvest column
-make_design_no_harvest <- function() { # nolint: object_length_linter
+make_design_no_harvest <- function() {
+  # nolint: object_length_linter
   data("example_calendar", package = "tidycreel")
   data("example_counts", package = "tidycreel")
   data("example_interviews", package = "tidycreel")
@@ -30,7 +33,9 @@ make_design_no_harvest <- function() { # nolint: object_length_linter
   # Create design but don't specify harvest parameter
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
@@ -46,10 +51,22 @@ make_total_harvest_species_design <- function() {
   set.seed(42)
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10", "2024-06-11", "2024-06-12",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16",
-      "2024-06-22", "2024-06-23", "2024-06-29", "2024-06-30"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-11",
+      "2024-06-12",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-22",
+      "2024-06-23",
+      "2024-06-29",
+      "2024-06-30"
     )),
     day_type = c(rep("weekday", 8), rep("weekend", 8)),
     stringsAsFactors = FALSE
@@ -62,14 +79,28 @@ make_total_harvest_species_design <- function() {
   )
   # 12 interviews per stratum (24 total), each a completed trip
   iview_dates <- c(
-    rep(as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-10"
-    )), 2),
-    rep(as.Date(c(
-      "2024-06-08", "2024-06-09", "2024-06-15",
-      "2024-06-16", "2024-06-22", "2024-06-23"
-    )), 2)
+    rep(
+      as.Date(c(
+        "2024-06-03",
+        "2024-06-04",
+        "2024-06-05",
+        "2024-06-06",
+        "2024-06-07",
+        "2024-06-10"
+      )),
+      2
+    ),
+    rep(
+      as.Date(c(
+        "2024-06-08",
+        "2024-06-09",
+        "2024-06-15",
+        "2024-06-16",
+        "2024-06-22",
+        "2024-06-23"
+      )),
+      2
+    )
   )
   iview_dtype <- c(rep("weekday", 12), rep("weekend", 12))
   catch_total <- sample(1:5, 24, replace = TRUE)
@@ -100,19 +131,23 @@ make_total_harvest_species_design <- function() {
 
   design <- creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total,
     harvest = catch_kept,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
-  design <- add_catch(design, catch_df, # nolint: object_usage_linter
-    catch_uid     = interview_id,
+  design <- add_catch(
+    design,
+    catch_df, # nolint: object_usage_linter
+    catch_uid = interview_id,
     interview_uid = interview_id,
-    species       = species,
-    count         = count,
-    catch_type    = catch_type
+    species = species,
+    count = count,
+    catch_type = catch_type
   )
 
   design
@@ -153,14 +188,18 @@ make_total_harvest_missing_rate_strata_design <- function() {
 
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total,
     harvest = catch_kept,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
-  add_catch(design, catch_df, # nolint: object_usage_linter
+  add_catch(
+    design,
+    catch_df, # nolint: object_usage_linter
     catch_uid = interview_id,
     interview_uid = interview_id,
     species = species,
@@ -270,7 +309,9 @@ test_that("estimate_total_harvest errors when design has no counts", {
   data("example_interviews", package = "tidycreel")
 
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total,
     harvest = catch_kept,
     effort = hours_fished,
@@ -321,7 +362,7 @@ test_that("estimate_total_harvest errors for invalid variance method", {
 test_that("total harvest estimate equals sum of per-stratum effort * hpue", {
   design <- make_total_harvest_design()
 
-  result    <- estimate_total_harvest(design) # nolint: object_usage_linter
+  result <- estimate_total_harvest(design) # nolint: object_usage_linter
   by_strata <- estimate_total_harvest(design, by = day_type) # nolint: object_usage_linter
 
   # Ungrouped total must equal sum of per-stratum products (stratified formula)
@@ -333,7 +374,7 @@ test_that("total harvest estimate equals sum of per-stratum effort * hpue", {
 test_that("total harvest SE matches stratified delta method formula", {
   design <- make_total_harvest_design()
 
-  result    <- estimate_total_harvest(design) # nolint: object_usage_linter
+  result <- estimate_total_harvest(design) # nolint: object_usage_linter
   by_strata <- estimate_total_harvest(design, by = day_type) # nolint: object_usage_linter
 
   # Var(total) = sum(Var_h) for independent strata; SE = sqrt(sum(se_h^2))
@@ -378,7 +419,9 @@ make_grouped_harvest_design <- function() {
   # Create design
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
@@ -485,7 +528,9 @@ test_that("full workflow with example data produces valid total harvest", {
   # Create complete design including harvest
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
@@ -510,7 +555,7 @@ test_that("total harvest components are consistent", {
   design <- make_total_harvest_design()
 
   total_harvest_est <- estimate_total_harvest(design) # nolint: object_usage_linter
-  by_strata         <- estimate_total_harvest(design, by = day_type) # nolint: object_usage_linter
+  by_strata <- estimate_total_harvest(design, by = day_type) # nolint: object_usage_linter
 
   # Ungrouped total = sum of per-stratum products (stratified consistency check)
   expected_estimate <- sum(by_strata$estimates$estimate)
@@ -528,17 +573,36 @@ test_that("total harvest components are consistent", {
 #' both counts and interview data (including harvest col) for all three
 #' sections. 12-date calendar, 9 interviews per section. Data shape is
 #' identical to the Phase 40 fixture make_3section_design_with_interviews().
-make_3section_total_catch_design <- function() { # nolint: object_length_linter
+make_3section_total_catch_design <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -557,14 +621,44 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
       # North: weekday ~15-25, weekend ~20-28
-      20, 22, 18, 25, 15, 24,
-      21, 26, 23, 28, 20, 27,
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
       # Central: weekday ~30-45, weekend ~35-48
-      35, 38, 32, 42, 30, 45,
-      37, 44, 40, 48, 35, 46,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
       # South: weekday ~5-12, weekend ~6-13
-      8, 10, 5, 12, 6, 11,
-      7, 9, 6, 13, 8, 10
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -574,67 +668,207 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
   interviews <- data.frame(
     date = as.Date(c(
       # North (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
       # Central (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21",
       # South (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central", "South"), each = 9),
     catch_total = c(
       # North: ~1 fish/hr
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
       # Central: ~1.5 fish/hr
-      5, 6, 5, 7, 6, 5, 7, 8, 6,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6,
       # South: ~2.5 fish/hr
-      10, 12, 9, 11, 10, 12, 13, 11, 10
+      10,
+      12,
+      9,
+      11,
+      10,
+      12,
+      13,
+      11,
+      10
     ),
     catch_kept = c(
       # North
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
       # Central
-      3, 4, 3, 5, 4, 3, 5, 6, 4,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4,
       # South
-      7, 9, 6, 8, 7, 9, 10, 8, 7
+      7,
+      9,
+      6,
+      8,
+      7,
+      9,
+      10,
+      8,
+      7
     ),
     hours_fished = c(
       # North: 2-3 hrs
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central: 3-4 hrs
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South: 4-5 hrs
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     trip_status = rep("complete", 27),
     trip_duration = c(
       # North
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, harvest = catch_kept, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
@@ -722,17 +956,36 @@ test_that("PROD-02-harvest-target: section path preserves requested effort targe
 #'
 #' Registered sections: "North", "Central", "South".
 #' Interview data contains only "North" and "Central" rows — "South" absent.
-make_3section_harvest_design_missing_south <- function() { # nolint: object_length_linter
+make_3section_harvest_design_missing_south <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -749,9 +1002,42 @@ make_3section_harvest_design_missing_south <- function() { # nolint: object_leng
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -760,48 +1046,144 @@ make_3section_harvest_design_missing_south <- function() { # nolint: object_leng
   # Only North and Central interviews — South absent
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     trip_status = rep("complete", 18),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, harvest = catch_kept, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 }
 
-test_that("PROD-01-harvest-missing: missing section inserts NA row with data_available=FALSE for estimate_total_harvest", { # nolint: line_length_linter
+test_that("PROD-01-harvest-missing: missing section inserts NA row with data_available=FALSE for estimate_total_harvest", {
+  # nolint: line_length_linter
   design <- make_3section_harvest_design_missing_south() # nolint: object_usage_linter
   warns <- character(0)
   result <- withCallingHandlers(

--- a/tests/testthat/test-estimate-total-release.R
+++ b/tests/testthat/test-estimate-total-release.R
@@ -10,21 +10,29 @@ make_total_release_design <- function() {
 
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, example_counts) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
     trip_duration = trip_duration # nolint: object_usage_linter
   )
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, example_catch, # nolint: object_usage_linter
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    example_catch, # nolint: object_usage_linter
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
 #' Create test design with counts only (no interviews), needed for validation test
-make_counts_only_release_design <- function() { # nolint: object_length_linter
+make_counts_only_release_design <- function() {
+  # nolint: object_length_linter
   data("example_calendar", package = "tidycreel")
   data("example_counts", package = "tidycreel")
 
@@ -33,22 +41,30 @@ make_counts_only_release_design <- function() { # nolint: object_length_linter
 }
 
 #' Create test design with interviews only (no counts)
-make_interviews_only_release_design <- function() { # nolint: object_length_linter
+make_interviews_only_release_design <- function() {
+  # nolint: object_length_linter
   data("example_calendar", package = "tidycreel")
   data("example_interviews", package = "tidycreel")
   data("example_catch", package = "tidycreel")
 
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  design <- add_interviews(design, example_interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     trip_status = trip_status, # nolint: object_usage_linter
     trip_duration = trip_duration # nolint: object_usage_linter
   )
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, example_catch, # nolint: object_usage_linter
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    example_catch, # nolint: object_usage_linter
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
@@ -86,14 +102,18 @@ make_total_release_missing_rate_strata_design <- function() {
 
   design <- creel_design(calendar, date = date, strata = day_type) # nolint: object_usage_linter
   design <- add_counts(design, counts) # nolint: object_usage_linter
-  design <- add_interviews(design, interviews, # nolint: object_usage_linter
+  design <- add_interviews(
+    design,
+    interviews, # nolint: object_usage_linter
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, catch_df,
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    catch_df,
     catch_uid = interview_id,
     interview_uid = interview_id,
     species = species,
@@ -283,17 +303,36 @@ test_that("estimate_total_release with conf_level = 0.90 produces narrower CI th
 #' sections. 12-date calendar, 9 interviews per section. Data shape is
 #' identical to the Phase 40 fixture make_3section_design_with_interviews().
 #' Fixture name is explicit about purpose (total catch/release context).
-make_3section_total_catch_design <- function() { # nolint: object_length_linter
+make_3section_total_catch_design <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -312,14 +351,44 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
       # North: weekday ~15-25, weekend ~20-28
-      20, 22, 18, 25, 15, 24,
-      21, 26, 23, 28, 20, 27,
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
       # Central: weekday ~30-45, weekend ~35-48
-      35, 38, 32, 42, 30, 45,
-      37, 44, 40, 48, 35, 46,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
       # South: weekday ~5-12, weekend ~6-13
-      8, 10, 5, 12, 6, 11,
-      7, 9, 6, 13, 8, 10
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -329,68 +398,208 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
   interviews <- data.frame(
     date = as.Date(c(
       # North (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
       # Central (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21",
       # South (9 interviews)
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-07", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central", "South"), each = 9),
     catch_total = c(
       # North: ~1 fish/hr
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
       # Central: ~1.5 fish/hr
-      5, 6, 5, 7, 6, 5, 7, 8, 6,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6,
       # South: ~2.5 fish/hr
-      10, 12, 9, 11, 10, 12, 13, 11, 10
+      10,
+      12,
+      9,
+      11,
+      10,
+      12,
+      13,
+      11,
+      10
     ),
     catch_kept = c(
       # North
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
       # Central
-      3, 4, 3, 5, 4, 3, 5, 6, 4,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4,
       # South
-      7, 9, 6, 8, 7, 9, 10, 8, 7
+      7,
+      9,
+      6,
+      8,
+      7,
+      9,
+      10,
+      8,
+      7
     ),
     hours_fished = c(
       # North: 2-3 hrs
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central: 3-4 hrs
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South: 4-5 hrs
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     trip_status = rep("complete", 27),
     trip_duration = c(
       # North
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
       # Central
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0,
       # South
-      4.0, 5.0, 4.0, 4.5, 4.0, 5.0, 5.0, 4.5, 4.0
+      4.0,
+      5.0,
+      4.0,
+      4.5,
+      4.0,
+      5.0,
+      5.0,
+      4.5,
+      4.0
     ),
     interview_id = seq_len(27L),
     stringsAsFactors = FALSE
   )
 
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, harvest = catch_kept, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   # Build catch data: one "released" row per interview (released = catch - kept)
@@ -402,10 +611,15 @@ make_3section_total_catch_design <- function() { # nolint: object_length_linter
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, catch_df,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    catch_df,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
@@ -493,17 +707,36 @@ test_that("PROD-02-release-target: section path preserves requested effort targe
 #'
 #' Registered sections: "North", "Central", "South".
 #' Interview data contains only "North" and "Central" rows — "South" absent.
-make_3section_release_design_missing_south <- function() { # nolint: object_length_linter
+make_3section_release_design_missing_south <- function() {
+  # nolint: object_length_linter
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06",
-      "2024-06-07", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-14", "2024-06-15",
-      "2024-06-16", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend", "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -520,9 +753,42 @@ make_3section_release_design_missing_south <- function() { # nolint: object_leng
     day_type = rep(cal$day_type, times = 3),
     section = rep(c("North", "Central", "South"), each = nrow(cal)),
     effort_hours = c(
-      20, 22, 18, 25, 15, 24, 21, 26, 23, 28, 20, 27,
-      35, 38, 32, 42, 30, 45, 37, 44, 40, 48, 35, 46,
-      8, 10, 5, 12, 6, 11, 7, 9, 6, 13, 8, 10
+      20,
+      22,
+      18,
+      25,
+      15,
+      24,
+      21,
+      26,
+      23,
+      28,
+      20,
+      27,
+      35,
+      38,
+      32,
+      42,
+      30,
+      45,
+      37,
+      44,
+      40,
+      48,
+      35,
+      46,
+      8,
+      10,
+      5,
+      12,
+      6,
+      11,
+      7,
+      9,
+      6,
+      13,
+      8,
+      10
     ),
     stringsAsFactors = FALSE
   )
@@ -531,45 +797,140 @@ make_3section_release_design_missing_south <- function() { # nolint: object_leng
   # Only North and Central interviews (interview_id 1..18) — South absent
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-07", "2024-06-10", "2024-06-07",
-      "2024-06-08", "2024-06-09", "2024-06-14",
-      "2024-06-03", "2024-06-04", "2024-06-05",
-      "2024-06-06", "2024-06-10", "2024-06-10",
-      "2024-06-08", "2024-06-09", "2024-06-21"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-07",
+      "2024-06-10",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-14",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-10",
+      "2024-06-10",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-21"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend",
-      "weekday", "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend"
     ),
     section = rep(c("North", "Central"), each = 9),
     catch_total = c(
-      2, 3, 2, 4, 3, 2, 3, 4, 3,
-      5, 6, 5, 7, 6, 5, 7, 8, 6
+      2,
+      3,
+      2,
+      4,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      6,
+      5,
+      7,
+      6,
+      5,
+      7,
+      8,
+      6
     ),
     catch_kept = c(
-      1, 2, 1, 3, 2, 1, 2, 3, 2,
-      3, 4, 3, 5, 4, 3, 5, 6, 4
+      1,
+      2,
+      1,
+      3,
+      2,
+      1,
+      2,
+      3,
+      2,
+      3,
+      4,
+      3,
+      5,
+      4,
+      3,
+      5,
+      6,
+      4
     ),
     hours_fished = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     trip_status = rep("complete", 18),
     trip_duration = c(
-      2.0, 3.0, 2.5, 3.0, 2.0, 2.5, 3.0, 3.5, 3.0,
-      3.5, 4.0, 3.5, 4.5, 4.0, 3.5, 4.5, 5.0, 4.0
+      2.0,
+      3.0,
+      2.5,
+      3.0,
+      2.0,
+      2.5,
+      3.0,
+      3.5,
+      3.0,
+      3.5,
+      4.0,
+      3.5,
+      4.5,
+      4.0,
+      3.5,
+      4.5,
+      5.0,
+      4.0
     ),
     interview_id = 1L:18L,
     stringsAsFactors = FALSE
   )
 
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, interviews,
-    catch = catch_total, harvest = catch_kept, effort = hours_fished, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    interviews,
+    catch = catch_total,
+    harvest = catch_kept,
+    effort = hours_fished, # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   # Build catch data: released rows for North + Central only (interview_id 1..18)
@@ -581,14 +942,20 @@ make_3section_release_design_missing_south <- function() { # nolint: object_leng
     stringsAsFactors = FALSE
   )
 
-  suppressWarnings(add_catch( # nolint: object_usage_linter
-    design, catch_df,
-    catch_uid = interview_id, interview_uid = interview_id, # nolint: object_usage_linter
-    species = species, count = count, catch_type = catch_type # nolint: object_usage_linter
+  suppressWarnings(add_catch(
+    # nolint: object_usage_linter
+    design,
+    catch_df,
+    catch_uid = interview_id,
+    interview_uid = interview_id, # nolint: object_usage_linter
+    species = species,
+    count = count,
+    catch_type = catch_type # nolint: object_usage_linter
   ))
 }
 
-test_that("PROD-01-release-missing: missing section inserts NA row with data_available=FALSE for estimate_total_release", { # nolint: line_length_linter
+test_that("PROD-01-release-missing: missing section inserts NA row with data_available=FALSE for estimate_total_release", {
+  # nolint: line_length_linter
   design <- make_3section_release_design_missing_south() # nolint: object_usage_linter
   warns <- character(0)
   result <- withCallingHandlers(

--- a/tests/testthat/test-estimate-total-release.R
+++ b/tests/testthat/test-estimate-total-release.R
@@ -603,3 +603,11 @@ test_that("PROD-01-release-missing: missing section inserts NA row with data_ava
   expect_false(south_row$data_available)
   expect_true(is.na(south_row$estimate))
 })
+
+# TOTR-WARN: standard-path missing-strata warning ----
+# Note: the release path builds RPUE via the interview survey design, which produces
+# stratum estimates for all calendar strata even when only some have interview records.
+# The warn_missing_rate_strata() guard is present in the code path (added 2026-06-24)
+# but the make_total_release_missing_rate_strata_design() fixture does not create a
+# true missing-strata gap in rpue_df. A dedicated fixture would be needed to trigger
+# this path for releases; deferred — coverage provided by catch and harvest paths.

--- a/tests/testthat/test-estimate-trip-density.R
+++ b/tests/testthat/test-estimate-trip-density.R
@@ -276,3 +276,56 @@ test_that("Test V: smoke — tidy() and write_estimates() succeed", {
   expect_no_error(write_estimates(result, path = tmp))
   expect_true(file.exists(tmp))
 })
+
+# -- RPT-01b: single-interview stratum NA-SE guards ---------------------------
+
+test_that("RPT-01b: ungrouped single interview warns and returns NA SE/CI", {
+  effort_one <- new_creel_estimates(
+    estimates = tibble::tibble(
+      estimate = 500, se = 25, ci_lower = 451, ci_upper = 549, n = 1L
+    ),
+    method = "total", variance_method = "taylor",
+    design = NULL, conf_level = 0.95, by_vars = NULL
+  )
+  design_one <- list(
+    trip_duration_col = "duration",
+    interviews        = data.frame(duration = 4.0)
+  )
+  expect_warning(
+    result <- estimate_angler_trips(effort_one, design_one),
+    regexp = "SE of mean trip length is undefined"
+  )
+  expect_false(is.na(result$estimates$estimate))  # point estimate valid
+  expect_true(is.na(result$estimates$se))
+  expect_true(is.na(result$estimates$ci_lower))
+  expect_true(is.na(result$estimates$ci_upper))
+})
+
+test_that("RPT-01b: grouped singleton stratum warns and returns NA SE/CI for that row", {
+  effort_g <- new_creel_estimates(
+    estimates = tibble::tibble(
+      day_type = c("weekday", "weekend"),
+      estimate = c(600, 400), se = c(30, 20),
+      ci_lower = c(541, 361), ci_upper = c(659, 439), n = c(6L, 1L)
+    ),
+    method = "total", variance_method = "taylor",
+    design = NULL, conf_level = 0.95, by_vars = "day_type"
+  )
+  design_g <- list(
+    trip_duration_col = "duration",
+    interviews        = data.frame(
+      day_type = c(rep("weekday", 6), "weekend"),
+      duration = c(3.0, 4.0, 5.0, 3.5, 4.5, 3.0, 2.0)
+    )
+  )
+  expect_warning(
+    result <- estimate_angler_trips(effort_g, design_g),
+    regexp = "SE of mean trip length is undefined"
+  )
+  stratum_rows <- result$estimates[result$estimates$day_type != ".overall", ]
+  wknd <- stratum_rows[stratum_rows$day_type == "weekend", ]
+  wkday <- stratum_rows[stratum_rows$day_type == "weekday", ]
+  expect_false(is.na(wknd$estimate))   # point estimate valid
+  expect_true(is.na(wknd$se))          # SE undefined for singleton
+  expect_false(is.na(wkday$se))        # weekday (n=6) has valid SE
+})

--- a/tests/testthat/test-estimate-trip-density.R
+++ b/tests/testthat/test-estimate-trip-density.R
@@ -12,24 +12,24 @@ dur_ungrouped <- c(3.0, 4.0, 5.0, 3.5, 4.5)
 
 effort_ungrouped <- new_creel_estimates(
   estimates = tibble::tibble(
-    estimate   = 1000,
-    se         = 50,
+    estimate = 1000,
+    se = 50,
     se_between = 30,
-    se_within  = 40,
-    ci_lower   = 902,
-    ci_upper   = 1098,
-    n          = 20
+    se_within = 40,
+    ci_lower = 902,
+    ci_upper = 1098,
+    n = 20
   ),
-  method          = "total",
+  method = "total",
   variance_method = "taylor",
-  design          = NULL,
-  conf_level      = 0.95,
-  by_vars         = NULL
+  design = NULL,
+  conf_level = 0.95,
+  by_vars = NULL
 )
 
 design_ungrouped <- list(
   trip_duration_col = "duration",
-  interviews        = data.frame(duration = dur_ungrouped)
+  interviews = data.frame(duration = dur_ungrouped)
 )
 
 dur_weekday <- c(3.0, 4.0, 5.0, 3.5, 4.5, 3.0)
@@ -39,21 +39,21 @@ effort_grouped <- new_creel_estimates(
   estimates = tibble::tibble(
     day_type = c("weekday", "weekend"),
     estimate = c(600, 400),
-    se       = c(30, 20),
+    se = c(30, 20),
     ci_lower = c(541, 361),
     ci_upper = c(659, 439),
-    n        = c(60L, 40L)
+    n = c(60L, 40L)
   ),
-  method          = "total",
+  method = "total",
   variance_method = "taylor",
-  design          = NULL,
-  conf_level      = 0.95,
-  by_vars         = "day_type"
+  design = NULL,
+  conf_level = 0.95,
+  by_vars = "day_type"
 )
 
 design_grouped <- list(
   trip_duration_col = "duration",
-  interviews        = data.frame(
+  interviews = data.frame(
     day_type = c(rep("weekday", length(dur_weekday)), rep("weekend", length(dur_weekend))),
     duration = c(dur_weekday, dur_weekend)
   )
@@ -62,7 +62,7 @@ design_grouped <- list(
 # -- Tests --------------------------------------------------------------------
 
 test_that("Test A: ungrouped — point estimate equals E / mean(duration)", {
-  result   <- estimate_angler_trips(effort_ungrouped, design_ungrouped)
+  result <- estimate_angler_trips(effort_ungrouped, design_ungrouped)
   expected <- 1000 / mean(dur_ungrouped)
   expect_equal(result$estimates$estimate, expected, tolerance = 1e-10)
 })
@@ -72,13 +72,13 @@ test_that("Test B: ungrouped — SE matches Delta Method formula Var(E/L) = Var(
   # for a derived quantity T = E / L where E and L are independently estimated.
   result <- estimate_angler_trips(effort_ungrouped, design_ungrouped)
 
-  E     <- 1000
-  se_E  <- 50
-  L     <- mean(dur_ungrouped)
-  se_L  <- stats::sd(dur_ungrouped) / sqrt(length(dur_ungrouped))
+  E <- 1000
+  se_E <- 50
+  L <- mean(dur_ungrouped)
+  se_L <- stats::sd(dur_ungrouped) / sqrt(length(dur_ungrouped))
 
-  var_trips    <- se_E^2 / L^2 + E^2 * se_L^2 / L^4
-  expected_se  <- sqrt(var_trips)
+  var_trips <- se_E^2 / L^2 + E^2 * se_L^2 / L^4
+  expected_se <- sqrt(var_trips)
 
   expect_equal(result$estimates$se, expected_se, tolerance = 1e-10)
 })
@@ -118,9 +118,9 @@ test_that("Test F: grouped — .overall row present, estimate = sum of stratum t
 test_that("Test G: grouped — .overall SE is quadrature sum of stratum variances", {
   result <- estimate_angler_trips(effort_grouped, design_grouped)
 
-  L_wd   <- mean(dur_weekday)
+  L_wd <- mean(dur_weekday)
   se_L_wd <- stats::sd(dur_weekday) / sqrt(length(dur_weekday))
-  L_we   <- mean(dur_weekend)
+  L_we <- mean(dur_weekend)
   se_L_we <- stats::sd(dur_weekend) / sqrt(length(dur_weekend))
 
   var_wd <- 30^2 / L_wd^2 + 600^2 * se_L_wd^2 / L_wd^4
@@ -155,7 +155,7 @@ test_that("Test J: missing by_vars column in interviews fires cli_abort", {
   # Grouped effort expects 'day_type' in interviews, but this design has none
   design_no_bv <- list(
     trip_duration_col = "duration",
-    interviews        = data.frame(duration = c(3.0, 4.0, 5.0))
+    interviews = data.frame(duration = c(3.0, 4.0, 5.0))
   )
   expect_error(
     estimate_angler_trips(effort_grouped, design_no_bv),
@@ -170,7 +170,7 @@ test_that("Test K: smoke — tidy() returns a data.frame", {
 
 test_that("Test L: smoke — write_estimates() to tempfile succeeds", {
   result <- estimate_angler_trips(effort_ungrouped, design_ungrouped)
-  tmp    <- tempfile(fileext = ".csv")
+  tmp <- tempfile(fileext = ".csv")
   expect_no_error(write_estimates(result, path = tmp))
   expect_true(file.exists(tmp))
 })
@@ -181,19 +181,19 @@ test_that("Test L: smoke — write_estimates() to tempfile succeeds", {
 # Fixture: ungrouped effort with se_between/se_within present
 effort_with_decomp <- new_creel_estimates(
   estimates = tibble::tibble(
-    estimate   = 5000,
-    se         = 250,
+    estimate = 5000,
+    se = 250,
     se_between = 150,
-    se_within  = 200,
-    ci_lower   = 4510,
-    ci_upper   = 5490,
-    n          = 40
+    se_within = 200,
+    ci_lower = 4510,
+    ci_upper = 5490,
+    n = 40
   ),
-  method          = "total",
+  method = "total",
   variance_method = "taylor",
-  design          = NULL,
-  conf_level      = 0.95,
-  by_vars         = NULL
+  design = NULL,
+  conf_level = 0.95,
+  by_vars = NULL
 )
 
 # Fixture: grouped effort without se_between/se_within
@@ -201,16 +201,16 @@ effort_grouped_no_decomp <- new_creel_estimates(
   estimates = tibble::tibble(
     day_type = c("weekday", "weekend"),
     estimate = c(3000, 2000),
-    se       = c(150, 100),
+    se = c(150, 100),
     ci_lower = c(2706, 1804),
     ci_upper = c(3294, 2196),
-    n        = c(30L, 20L)
+    n = c(30L, 20L)
   ),
-  method          = "total",
+  method = "total",
   variance_method = "taylor",
-  design          = NULL,
-  conf_level      = 0.95,
-  by_vars         = "day_type"
+  design = NULL,
+  conf_level = 0.95,
+  by_vars = "day_type"
 )
 
 test_that("Test M: estimate equals effort estimate / acres", {
@@ -236,7 +236,7 @@ test_that("Test P: se_between and se_within scaled when present", {
   # constant (linear propagation, no Delta Method needed).
   result <- estimate_effort_per_acre(effort_with_decomp, 120)
   expect_equal(result$estimates$se_between, 150 / 120, tolerance = 1e-10)
-  expect_equal(result$estimates$se_within,  200 / 120, tolerance = 1e-10)
+  expect_equal(result$estimates$se_within, 200 / 120, tolerance = 1e-10)
 })
 
 test_that("Test Q: se_between and se_within absent when not in input", {
@@ -244,7 +244,7 @@ test_that("Test Q: se_between and se_within absent when not in input", {
   # estimate_effort_per_acre must not fabricate them.
   result2 <- estimate_effort_per_acre(effort_grouped_no_decomp, 80)
   expect_false("se_between" %in% names(result2$estimates))
-  expect_false("se_within"  %in% names(result2$estimates))
+  expect_false("se_within" %in% names(result2$estimates))
 })
 
 test_that("Test R: returns creel_estimates with method effort-per-acre", {
@@ -260,7 +260,7 @@ test_that("Test S: by_vars and conf_level inherited from effort object", {
 })
 
 test_that("Test T: non-positive acres fires cli_abort", {
-  expect_error(estimate_effort_per_acre(effort_with_decomp, 0),  regexp = "positive")
+  expect_error(estimate_effort_per_acre(effort_with_decomp, 0), regexp = "positive")
   expect_error(estimate_effort_per_acre(effort_with_decomp, -5), regexp = "positive")
 })
 
@@ -282,20 +282,27 @@ test_that("Test V: smoke — tidy() and write_estimates() succeed", {
 test_that("RPT-01b: ungrouped single interview warns and returns NA SE/CI", {
   effort_one <- new_creel_estimates(
     estimates = tibble::tibble(
-      estimate = 500, se = 25, ci_lower = 451, ci_upper = 549, n = 1L
+      estimate = 500,
+      se = 25,
+      ci_lower = 451,
+      ci_upper = 549,
+      n = 1L
     ),
-    method = "total", variance_method = "taylor",
-    design = NULL, conf_level = 0.95, by_vars = NULL
+    method = "total",
+    variance_method = "taylor",
+    design = NULL,
+    conf_level = 0.95,
+    by_vars = NULL
   )
   design_one <- list(
     trip_duration_col = "duration",
-    interviews        = data.frame(duration = 4.0)
+    interviews = data.frame(duration = 4.0)
   )
   expect_warning(
     result <- estimate_angler_trips(effort_one, design_one),
     regexp = "SE of mean trip length is undefined"
   )
-  expect_false(is.na(result$estimates$estimate))  # point estimate valid
+  expect_false(is.na(result$estimates$estimate)) # point estimate valid
   expect_true(is.na(result$estimates$se))
   expect_true(is.na(result$estimates$ci_lower))
   expect_true(is.na(result$estimates$ci_upper))
@@ -305,15 +312,21 @@ test_that("RPT-01b: grouped singleton stratum warns and returns NA SE/CI for tha
   effort_g <- new_creel_estimates(
     estimates = tibble::tibble(
       day_type = c("weekday", "weekend"),
-      estimate = c(600, 400), se = c(30, 20),
-      ci_lower = c(541, 361), ci_upper = c(659, 439), n = c(6L, 1L)
+      estimate = c(600, 400),
+      se = c(30, 20),
+      ci_lower = c(541, 361),
+      ci_upper = c(659, 439),
+      n = c(6L, 1L)
     ),
-    method = "total", variance_method = "taylor",
-    design = NULL, conf_level = 0.95, by_vars = "day_type"
+    method = "total",
+    variance_method = "taylor",
+    design = NULL,
+    conf_level = 0.95,
+    by_vars = "day_type"
   )
   design_g <- list(
     trip_duration_col = "duration",
-    interviews        = data.frame(
+    interviews = data.frame(
       day_type = c(rep("weekday", 6), "weekend"),
       duration = c(3.0, 4.0, 5.0, 3.5, 4.5, 3.0, 2.0)
     )
@@ -325,7 +338,7 @@ test_that("RPT-01b: grouped singleton stratum warns and returns NA SE/CI for tha
   stratum_rows <- result$estimates[result$estimates$day_type != ".overall", ]
   wknd <- stratum_rows[stratum_rows$day_type == "weekend", ]
   wkday <- stratum_rows[stratum_rows$day_type == "weekday", ]
-  expect_false(is.na(wknd$estimate))   # point estimate valid
-  expect_true(is.na(wknd$se))          # SE undefined for singleton
-  expect_false(is.na(wkday$se))        # weekday (n=6) has valid SE
+  expect_false(is.na(wknd$estimate)) # point estimate valid
+  expect_true(is.na(wknd$se)) # SE undefined for singleton
+  expect_false(is.na(wkday$se)) # weekday (n=6) has valid SE
 })

--- a/tests/testthat/test-example-sections.R
+++ b/tests/testthat/test-example-sections.R
@@ -57,8 +57,13 @@ test_that("example_sections_interviews loads with correct structure", {
   expect_equal(nrow(example_sections_interviews), 27L)
   expect_true(all(
     c(
-      "date", "section", "catch_total", "catch_kept", "hours_fished",
-      "trip_status", "trip_duration"
+      "date",
+      "section",
+      "catch_total",
+      "catch_kept",
+      "hours_fished",
+      "trip_status",
+      "trip_duration"
     ) %in%
       names(example_sections_interviews)
   ))
@@ -103,17 +108,22 @@ test_that("creel design built from example_sections datasets succeeds and estima
 
   design <- creel_design(
     example_sections_calendar, # nolint: object_usage_linter
-    date = date, strata = day_type # nolint: object_usage_linter
+    date = date,
+    strata = day_type # nolint: object_usage_linter
   )
   design <- add_sections(design, sections_df, section_col = section) # nolint: object_usage_linter
   design <- suppressWarnings(
     add_counts(design, example_sections_counts) # nolint: object_usage_linter
   )
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, example_sections_interviews,
-    catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    example_sections_interviews,
+    catch = catch_total,
+    effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   result <- estimate_effort(design)
@@ -133,17 +143,22 @@ test_that("estimate_catch_rate on example_sections design returns exactly 3 rows
 
   design <- creel_design(
     example_sections_calendar, # nolint: object_usage_linter
-    date = date, strata = day_type # nolint: object_usage_linter
+    date = date,
+    strata = day_type # nolint: object_usage_linter
   )
   design <- add_sections(design, sections_df, section_col = section) # nolint: object_usage_linter
   design <- suppressWarnings(
     add_counts(design, example_sections_counts) # nolint: object_usage_linter
   )
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, example_sections_interviews,
-    catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    example_sections_interviews,
+    catch = catch_total,
+    effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   result <- estimate_catch_rate(design)
@@ -163,17 +178,22 @@ test_that("estimate_total_catch with aggregate_sections = TRUE returns 4 rows", 
 
   design <- creel_design(
     example_sections_calendar, # nolint: object_usage_linter
-    date = date, strata = day_type # nolint: object_usage_linter
+    date = date,
+    strata = day_type # nolint: object_usage_linter
   )
   design <- add_sections(design, sections_df, section_col = section) # nolint: object_usage_linter
   design <- suppressWarnings(
     add_counts(design, example_sections_counts) # nolint: object_usage_linter
   )
-  design <- suppressWarnings(add_interviews( # nolint: object_usage_linter
-    design, example_sections_interviews,
-    catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
+  design <- suppressWarnings(add_interviews(
+    # nolint: object_usage_linter
+    design,
+    example_sections_interviews,
+    catch = catch_total,
+    effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
-    trip_status = trip_status, trip_duration = trip_duration # nolint: object_usage_linter
+    trip_status = trip_status,
+    trip_duration = trip_duration # nolint: object_usage_linter
   ))
 
   result <- estimate_total_catch(design, aggregate_sections = TRUE)

--- a/tests/testthat/test-format-estimates.R
+++ b/tests/testthat/test-format-estimates.R
@@ -41,7 +41,13 @@ test_that("format displays 'Ratio-of-Means HPUE' for harvest method", {
 
 test_that("format displays 'Total Catch (Effort x CPUE)' for product-total-catch method", {
   obj <- tidycreel:::new_creel_estimates(
-    estimates = tibble::tibble(estimate = 1500, se = 150, ci_lower = 1200, ci_upper = 1800, n = 22L),
+    estimates = tibble::tibble(
+      estimate = 1500,
+      se = 150,
+      ci_lower = 1200,
+      ci_upper = 1800,
+      n = 22L
+    ),
     method = "product-total-catch"
   )
   output <- format(obj)

--- a/tests/testthat/test-hybrid-design.R
+++ b/tests/testthat/test-hybrid-design.R
@@ -4,8 +4,10 @@
 make_access <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02",
-      "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     count = c(12L, 15L, 30L, 28L),
@@ -16,8 +18,10 @@ make_access <- function() {
 make_roving <- function() {
   data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02",
-      "2024-06-08", "2024-06-09"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
     count = c(8L, 10L, 22L, 25L),
@@ -26,15 +30,17 @@ make_roving <- function() {
 }
 
 fractions <- list(
-  access  = c(weekday = 0.5, weekend = 0.5),
-  roving  = c(weekday = 0.4, weekend = 0.4)
+  access = c(weekday = 0.5, weekend = 0.5),
+  roving = c(weekday = 0.4, weekend = 0.4)
 )
 
 # Input validation ------------------------------------------------------------
 
 test_that("HYBR-01: errors when access_data is not a data frame", {
   expect_error(
-    as_hybrid_svydesign(list(), make_roving(),
+    as_hybrid_svydesign(
+      list(),
+      make_roving(),
       access_fraction = fractions$access,
       roving_fraction = fractions$roving
     ),
@@ -44,7 +50,9 @@ test_that("HYBR-01: errors when access_data is not a data frame", {
 
 test_that("HYBR-02: errors when roving_data is not a data frame", {
   expect_error(
-    as_hybrid_svydesign(make_access(), NULL,
+    as_hybrid_svydesign(
+      make_access(),
+      NULL,
       access_fraction = fractions$access,
       roving_fraction = fractions$roving
     ),
@@ -56,7 +64,9 @@ test_that("HYBR-03: errors when required column missing from access_data", {
   df <- make_access()
   df$count <- NULL
   expect_error(
-    as_hybrid_svydesign(df, make_roving(),
+    as_hybrid_svydesign(
+      df,
+      make_roving(),
       access_fraction = fractions$access,
       roving_fraction = fractions$roving
     ),
@@ -68,7 +78,9 @@ test_that("HYBR-04: errors when required column missing from roving_data", {
   df <- make_roving()
   df$date <- NULL
   expect_error(
-    as_hybrid_svydesign(make_access(), df,
+    as_hybrid_svydesign(
+      make_access(),
+      df,
       access_fraction = fractions$access,
       roving_fraction = fractions$roving
     ),
@@ -78,25 +90,23 @@ test_that("HYBR-04: errors when required column missing from roving_data", {
 
 test_that("HYBR-05: errors when access_fraction is NULL", {
   expect_error(
-    as_hybrid_svydesign(make_access(), make_roving(),
-      roving_fraction = fractions$roving
-    ),
+    as_hybrid_svydesign(make_access(), make_roving(), roving_fraction = fractions$roving),
     class = "rlang_error"
   )
 })
 
 test_that("HYBR-06: errors when roving_fraction is NULL", {
   expect_error(
-    as_hybrid_svydesign(make_access(), make_roving(),
-      access_fraction = fractions$access
-    ),
+    as_hybrid_svydesign(make_access(), make_roving(), access_fraction = fractions$access),
     class = "rlang_error"
   )
 })
 
 test_that("HYBR-07: errors when fraction missing a stratum", {
   expect_error(
-    as_hybrid_svydesign(make_access(), make_roving(),
+    as_hybrid_svydesign(
+      make_access(),
+      make_roving(),
       access_fraction = c(weekday = 0.5), # missing weekend
       roving_fraction = fractions$roving
     ),
@@ -106,7 +116,9 @@ test_that("HYBR-07: errors when fraction missing a stratum", {
 
 test_that("HYBR-08: errors when fraction value <= 0", {
   expect_error(
-    as_hybrid_svydesign(make_access(), make_roving(),
+    as_hybrid_svydesign(
+      make_access(),
+      make_roving(),
       access_fraction = c(weekday = 0, weekend = 0.5),
       roving_fraction = fractions$roving
     ),
@@ -116,7 +128,9 @@ test_that("HYBR-08: errors when fraction value <= 0", {
 
 test_that("HYBR-09: errors when fraction value > 1", {
   expect_error(
-    as_hybrid_svydesign(make_access(), make_roving(),
+    as_hybrid_svydesign(
+      make_access(),
+      make_roving(),
       access_fraction = c(weekday = 1.5, weekend = 0.5),
       roving_fraction = fractions$roving
     ),
@@ -128,7 +142,8 @@ test_that("HYBR-09: errors when fraction value > 1", {
 
 test_that("HYBR-10: returns an svydesign object", {
   design <- suppressWarnings(as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving
   ))
@@ -137,7 +152,8 @@ test_that("HYBR-10: returns an svydesign object", {
 
 test_that("HYBR-11: returns creel_hybrid_svydesign class", {
   design <- suppressWarnings(as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving
   ))
@@ -146,7 +162,8 @@ test_that("HYBR-11: returns creel_hybrid_svydesign class", {
 
 test_that("HYBR-12: combined data has component column", {
   design <- suppressWarnings(as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving
   ))
@@ -156,7 +173,8 @@ test_that("HYBR-12: combined data has component column", {
 
 test_that("HYBR-13: combined data has weight column", {
   design <- suppressWarnings(as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving
   ))
@@ -166,7 +184,8 @@ test_that("HYBR-13: combined data has weight column", {
 
 test_that("HYBR-14: row count equals nrow(access) + nrow(roving)", {
   design <- suppressWarnings(as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving
   ))
@@ -177,7 +196,8 @@ test_that("HYBR-14: row count equals nrow(access) + nrow(roving)", {
 
 test_that("HYBR-15: access weights = 1 / access_fraction", {
   design <- suppressWarnings(as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = c(weekday = 0.5, weekend = 0.25),
     roving_fraction = fractions$roving
   ))
@@ -194,13 +214,16 @@ test_that("HYBR-16: asymmetric dates produce a warning", {
   access_extra <- rbind(
     make_access(),
     data.frame(
-      date = as.Date("2024-06-15"), day_type = "weekday",
-      count = 5L, stringsAsFactors = FALSE
+      date = as.Date("2024-06-15"),
+      day_type = "weekday",
+      count = 5L,
+      stringsAsFactors = FALSE
     )
   )
   expect_warning(
     as_hybrid_svydesign(
-      access_extra, make_roving(),
+      access_extra,
+      make_roving(),
       access_fraction = c(weekday = 0.5, weekend = 0.5),
       roving_fraction = fractions$roving
     )
@@ -210,7 +233,8 @@ test_that("HYBR-16: asymmetric dates produce a warning", {
 test_that("HYBR-17: symmetric dates produce no PSU warning", {
   expect_no_warning(
     as_hybrid_svydesign(
-      make_access(), make_roving(),
+      make_access(),
+      make_roving(),
       access_fraction = fractions$access,
       roving_fraction = fractions$roving,
       fpc = FALSE
@@ -222,7 +246,8 @@ test_that("HYBR-17: symmetric dates produce no PSU warning", {
 
 test_that("HYBR-18: fpc = FALSE produces a valid design", {
   design <- as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving,
     fpc = FALSE
@@ -244,7 +269,8 @@ test_that("HYBR-19: custom column names work", {
   names(roving_custom)[names(roving_custom) == "count"] <- "n_anglers"
 
   design <- as_hybrid_svydesign(
-    access_custom, roving_custom,
+    access_custom,
+    roving_custom,
     date_col = "survey_date",
     strata_col = "stratum",
     count_col = "n_anglers",
@@ -258,7 +284,8 @@ test_that("HYBR-19: custom column names work", {
 
 test_that("HYBR-20: svytotal runs without error on the hybrid design", {
   design <- as_hybrid_svydesign(
-    make_access(), make_roving(),
+    make_access(),
+    make_roving(),
     access_fraction = fractions$access,
     roving_fraction = fractions$roving,
     fpc = FALSE

--- a/tests/testthat/test-impute-camera-counts.R
+++ b/tests/testthat/test-impute-camera-counts.R
@@ -4,23 +4,41 @@
 
 make_camera_counts_clean <- function() {
   data.frame(
-    date           = as.Date(c("2024-06-03", "2024-06-04", "2024-06-05",
-                               "2024-06-08", "2024-06-09", "2024-06-10")),
-    day_type       = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
-    ingress_count  = c(48L, 52L, 43L, 80L, 75L, 88L),
-    camera_status  = rep("operational", 6L),
+    date = as.Date(c(
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-10"
+    )),
+    day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
+    ingress_count = c(48L, 52L, 43L, 80L, 75L, 88L),
+    camera_status = rep("operational", 6L),
     stringsAsFactors = FALSE
   )
 }
 
 make_camera_counts_with_outages <- function() {
   data.frame(
-    date           = as.Date(c("2024-06-03", "2024-06-04", "2024-06-05",
-                               "2024-06-08", "2024-06-09", "2024-06-10")),
-    day_type       = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
-    ingress_count  = c(48L, NA, 43L, 80L, NA, 88L),
-    camera_status  = c("operational", "battery_failure", "operational",
-                       "operational", "memory_full", "operational"),
+    date = as.Date(c(
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-10"
+    )),
+    day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
+    ingress_count = c(48L, NA, 43L, 80L, NA, 88L),
+    camera_status = c(
+      "operational",
+      "battery_failure",
+      "operational",
+      "operational",
+      "memory_full",
+      "operational"
+    ),
     stringsAsFactors = FALSE
   )
 }
@@ -28,12 +46,16 @@ make_camera_counts_with_outages <- function() {
 make_camera_counts_high_miss <- function() {
   # Weekday stratum has 2 out of 3 rows missing (>50%)
   data.frame(
-    date           = as.Date(c("2024-06-03", "2024-06-04", "2024-06-05",
-                               "2024-06-08", "2024-06-09")),
-    day_type       = c("weekday", "weekday", "weekday", "weekend", "weekend"),
-    ingress_count  = c(48L, NA, NA, 80L, 75L),
-    camera_status  = c("operational", "battery_failure", "memory_full",
-                       "operational", "operational"),
+    date = as.Date(c("2024-06-03", "2024-06-04", "2024-06-05", "2024-06-08", "2024-06-09")),
+    day_type = c("weekday", "weekday", "weekday", "weekend", "weekend"),
+    ingress_count = c(48L, NA, NA, 80L, 75L),
+    camera_status = c(
+      "operational",
+      "battery_failure",
+      "memory_full",
+      "operational",
+      "operational"
+    ),
     stringsAsFactors = FALSE
   )
 }
@@ -41,11 +63,10 @@ make_camera_counts_high_miss <- function() {
 make_camera_counts_all_missing_stratum <- function() {
   # Weekend stratum has ALL rows as outages (no observed counts)
   data.frame(
-    date           = as.Date(c("2024-06-03", "2024-06-04",
-                               "2024-06-08", "2024-06-09")),
-    day_type       = c("weekday", "weekday", "weekend", "weekend"),
-    ingress_count  = c(48L, 43L, NA, NA),
-    camera_status  = c("operational", "operational", "battery_failure", "memory_full"),
+    date = as.Date(c("2024-06-03", "2024-06-04", "2024-06-08", "2024-06-09")),
+    day_type = c("weekday", "weekday", "weekend", "weekend"),
+    ingress_count = c(48L, 43L, NA, NA),
+    camera_status = c("operational", "operational", "battery_failure", "memory_full"),
     stringsAsFactors = FALSE
   )
 }
@@ -62,8 +83,12 @@ test_that("rejects non-data-frame input", {
 test_that("rejects invalid method argument", {
   counts <- make_camera_counts_with_outages()
   expect_error(
-    impute_camera_counts(counts, count_col = "ingress_count",
-                         strata_col = "day_type", method = "invalid"),
+    impute_camera_counts(
+      counts,
+      count_col = "ingress_count",
+      strata_col = "day_type",
+      method = "invalid"
+    ),
     class = "error"
   )
 })
@@ -71,8 +96,7 @@ test_that("rejects invalid method argument", {
 test_that("aborts when count_col is missing from data", {
   counts <- make_camera_counts_with_outages()
   expect_error(
-    impute_camera_counts(counts, count_col = "no_such_col",
-                         strata_col = "day_type"),
+    impute_camera_counts(counts, count_col = "no_such_col", strata_col = "day_type"),
     class = "rlang_error"
   )
 })
@@ -80,8 +104,7 @@ test_that("aborts when count_col is missing from data", {
 test_that("aborts when strata_col is missing from data", {
   counts <- make_camera_counts_with_outages()
   expect_error(
-    impute_camera_counts(counts, count_col = "ingress_count",
-                         strata_col = "no_such_col"),
+    impute_camera_counts(counts, count_col = "ingress_count", strata_col = "no_such_col"),
     class = "rlang_error"
   )
 })
@@ -89,9 +112,12 @@ test_that("aborts when strata_col is missing from data", {
 test_that("aborts when status_col is missing from data", {
   counts <- make_camera_counts_with_outages()
   expect_error(
-    impute_camera_counts(counts, count_col = "ingress_count",
-                         strata_col = "day_type",
-                         status_col = "no_such_status"),
+    impute_camera_counts(
+      counts,
+      count_col = "ingress_count",
+      strata_col = "day_type",
+      status_col = "no_such_status"
+    ),
     class = "rlang_error"
   )
 })
@@ -100,53 +126,48 @@ test_that("aborts when status_col is missing from data", {
 
 test_that("CAMP-01: returns all rows including imputed ones", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_equal(nrow(result), nrow(counts))
 })
 
 test_that("CAMP-01: no NA values remain in count column after imputation", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_true(all(!is.na(result$ingress_count)))
 })
 
 test_that("CAMP-01: .imputed flag column is present in output", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_true(".imputed" %in% names(result))
 })
 
 test_that("CAMP-02: imputed rows have .imputed = TRUE", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
-  outage_rows <- which(counts$camera_status != "operational" &
-                         is.na(counts$ingress_count))
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
+  outage_rows <- which(
+    counts$camera_status != "operational" &
+      is.na(counts$ingress_count)
+  )
   expect_true(all(result$.imputed[outage_rows]))
 })
 
 test_that("CAMP-02: operational rows have .imputed = FALSE", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   op_rows <- which(counts$camera_status == "operational")
   expect_true(all(!result$.imputed[op_rows]))
 })
 
 test_that("CAMP-03: imputed count column is integer type", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_true(is.integer(result$ingress_count))
 })
 
 test_that("D-07: original camera_status values are preserved in imputed rows", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   # battery_failure row should still show battery_failure
   bat_fail_idx <- which(counts$camera_status == "battery_failure")
   expect_equal(result$camera_status[bat_fail_idx], "battery_failure")
@@ -157,8 +178,7 @@ test_that("D-07: original camera_status values are preserved in imputed rows", {
 
 test_that("clean data (no outages) returns unchanged with .imputed = FALSE everywhere", {
   counts <- make_camera_counts_clean()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_equal(nrow(result), nrow(counts))
   expect_true(all(!result$.imputed))
   expect_equal(result$ingress_count, counts$ingress_count)
@@ -166,8 +186,7 @@ test_that("clean data (no outages) returns unchanged with .imputed = FALSE every
 
 test_that("imputed counts are positive integers (GLM Poisson predictions)", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   imputed_rows <- which(result$.imputed)
   expect_true(all(result$ingress_count[imputed_rows] >= 0L))
 })
@@ -177,8 +196,7 @@ test_that("imputed counts are positive integers (GLM Poisson predictions)", {
 test_that("CAMP-04: warns when missingness > 50% in a stratum", {
   counts <- make_camera_counts_high_miss()
   expect_warning(
-    impute_camera_counts(counts, count_col = "ingress_count",
-                         strata_col = "day_type"),
+    impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type"),
     class = "warning"
   )
 })
@@ -189,8 +207,7 @@ test_that("CAMP-05: aborts when entire stratum has no observed counts", {
   # so suppress warnings to let expect_error see the error condition.
   expect_error(
     suppressWarnings(
-      impute_camera_counts(counts, count_col = "ingress_count",
-                           strata_col = "day_type")
+      impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
     ),
     class = "rlang_error"
   )
@@ -200,15 +217,13 @@ test_that("CAMP-05: aborts when entire stratum has no observed counts", {
 
 test_that("output has same columns as input plus .imputed", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_equal(names(result), c(names(counts), ".imputed"))
 })
 
 test_that("non-count columns (date, day_type) are preserved unchanged", {
   counts <- make_camera_counts_with_outages()
-  result <- impute_camera_counts(counts, count_col = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   expect_equal(result$date, counts$date)
   expect_equal(result$day_type, counts$day_type)
 })
@@ -221,19 +236,23 @@ test_that("CAMP-02: method = 'glmm' proceeds or errors on missing glmmTMB", {
   # If not installed rlang::check_installed() fires an error mentioning glmmTMB.
   if (requireNamespace("glmmTMB", quietly = TRUE)) {
     result <- suppressWarnings(
-      impute_camera_counts(counts,
-                           count_col = "ingress_count",
-                           strata_col = "day_type",
-                           method = "glmm")
+      impute_camera_counts(
+        counts,
+        count_col = "ingress_count",
+        strata_col = "day_type",
+        method = "glmm"
+      )
     )
     expect_s3_class(result, "data.frame")
     expect_true(".imputed" %in% names(result))
   } else {
     expect_error(
-      impute_camera_counts(counts,
-                           count_col = "ingress_count",
-                           strata_col = "day_type",
-                           method = "glmm"),
+      impute_camera_counts(
+        counts,
+        count_col = "ingress_count",
+        strata_col = "day_type",
+        method = "glmm"
+      ),
       regexp = "glmmTMB"
     )
   }
@@ -243,17 +262,20 @@ test_that("CAMP-02: method = 'glmm' proceeds or errors on missing glmmTMB", {
 
 test_that("CAMP-03: imputed output passes into add_counts() without column manipulation", {
   counts <- make_camera_counts_with_outages()
-  imputed <- impute_camera_counts(counts,
-                                  count_col  = "ingress_count",
-                                  strata_col = "day_type")
+  imputed <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   cal <- data.frame(
-    date     = imputed$date,
+    date = imputed$date,
     day_type = imputed$day_type,
     stringsAsFactors = FALSE
   )
   design <- suppressWarnings(
-    creel_design(cal, date = date, strata = day_type, # nolint
-                 survey_type = "camera", camera_mode = "counter")
+    creel_design(
+      cal,
+      date = date,
+      strata = day_type, # nolint
+      survey_type = "camera",
+      camera_mode = "counter"
+    )
   )
   # Should not error — schema-compatible imputed output
   expect_no_error(
@@ -268,9 +290,7 @@ test_that("CAMP-04: no warning when missingness <= 50% in all strata", {
   counts <- make_camera_counts_with_outages()
   # make_camera_counts_with_outages has 1 outage per stratum (1/3 each = 33%)
   expect_no_warning(
-    impute_camera_counts(counts,
-                         count_col  = "ingress_count",
-                         strata_col = "day_type")
+    impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   )
 })
 
@@ -280,24 +300,36 @@ test_that("CR-01: non-operational row with pre-existing non-NA count is NOT mark
   # A non-operational row that already has a count (manually keyed by biologist)
   # should not be flagged as imputed — only truly NA-before rows should be.
   counts <- data.frame(
-    date          = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03",
-                               "2024-06-04", "2024-06-05", "2024-06-06")),
-    day_type      = c("weekday", "weekday", "weekday",
-                      "weekend", "weekend", "weekend"),
+    date = as.Date(c(
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06"
+    )),
+    day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend"),
     ingress_count = c(10L, NA_integer_, 8L, 15L, 12L, NA_integer_),
-    camera_status = c("operational", "battery_failure", "partial_outage",
-                      "operational", "operational", "battery_failure"),
+    camera_status = c(
+      "operational",
+      "battery_failure",
+      "partial_outage",
+      "operational",
+      "operational",
+      "battery_failure"
+    ),
     stringsAsFactors = FALSE
   )
   # row 3: non-operational ("partial_outage") but count is already 8 (non-NA)
   # row 2: non-operational + NA => should be imputed
   # row 6: non-operational + NA => should be imputed
-  result <- impute_camera_counts(counts,
-                                 count_col  = "ingress_count",
-                                 strata_col = "day_type")
+  result <- impute_camera_counts(counts, count_col = "ingress_count", strata_col = "day_type")
   # Row 3 (partial_outage, pre-existing count 8) must NOT be marked imputed
   row3 <- result[result$date == as.Date("2024-06-03"), ]
-  expect_false(row3$.imputed, info = "non-operational row with pre-existing count should not be .imputed")
+  expect_false(
+    row3$.imputed,
+    info = "non-operational row with pre-existing count should not be .imputed"
+  )
   # Rows 2 and 6 (NA before) MUST be marked imputed
   row2 <- result[result$date == as.Date("2024-06-02"), ]
   row6 <- result[result$date == as.Date("2024-06-06"), ]

--- a/tests/testthat/test-invariants.R
+++ b/tests/testthat/test-invariants.R
@@ -170,17 +170,21 @@ test_that("INV-bound: u_hat in [0,1] for bounded inputs", {
 
   # Generate inputs where C <= T to guarantee u_hat <= 1
   quickcheck::for_all(
-    T_val   = quickcheck::integer_bounded(left = 1L, right = 500L, len = 1L),
-    n_val   = quickcheck::integer_bounded(left = 1L, right = 300L, len = 1L),
-    frac_m  = quickcheck::double_bounded(left = 0, right = 1, len = 1L),
-    frac_C  = quickcheck::double_bounded(left = 0, right = 1, len = 1L),
+    T_val = quickcheck::integer_bounded(left = 1L, right = 500L, len = 1L),
+    n_val = quickcheck::integer_bounded(left = 1L, right = 300L, len = 1L),
+    frac_m = quickcheck::double_bounded(left = 0, right = 1, len = 1L),
+    frac_C = quickcheck::double_bounded(left = 0, right = 1, len = 1L),
     se_frac = quickcheck::double_bounded(left = 0, right = 0.5, len = 1L),
     property = function(T_val, n_val, frac_m, frac_C, se_frac) {
-      m_val    <- as.integer(floor(frac_m * n_val))
-      C_val    <- frac_C * T_val                    # C <= T => u_hat <= 1
+      m_val <- as.integer(floor(frac_m * n_val))
+      C_val <- frac_C * T_val # C <= T => u_hat <= 1
       se_C_val <- se_frac * C_val
       r <- estimate_exploitation_rate(
-        T = T_val, C = C_val, se_C = se_C_val, n = n_val, m = m_val
+        T = T_val,
+        C = C_val,
+        se_C = se_C_val,
+        n = n_val,
+        m = m_val
       )
       u <- r$estimates$estimate
       expect_true(u >= 0 && u <= 1)
@@ -192,19 +196,27 @@ test_that("INV-monotone-C: u_hat increases with C (T, n, m fixed)", {
   skip_if_not_installed("quickcheck")
 
   quickcheck::for_all(
-    T_val  = quickcheck::integer_bounded(left = 10L, right = 500L, len = 1L),
-    n_val  = quickcheck::integer_bounded(left = 5L,  right = 300L, len = 1L),
+    T_val = quickcheck::integer_bounded(left = 10L, right = 500L, len = 1L),
+    n_val = quickcheck::integer_bounded(left = 5L, right = 300L, len = 1L),
     frac_m = quickcheck::double_bounded(left = 0.01, right = 0.5, len = 1L),
     property = function(T_val, n_val, frac_m) {
-      m_val  <- as.integer(floor(frac_m * n_val))
-      C1     <- T_val * 0.1
-      C2     <- T_val * 0.5
-      se_C   <- T_val * 0.05
+      m_val <- as.integer(floor(frac_m * n_val))
+      C1 <- T_val * 0.1
+      C2 <- T_val * 0.5
+      se_C <- T_val * 0.05
       u1 <- estimate_exploitation_rate(
-        T = T_val, C = C1, se_C = se_C, n = n_val, m = m_val
+        T = T_val,
+        C = C1,
+        se_C = se_C,
+        n = n_val,
+        m = m_val
       )$estimates$estimate
       u2 <- estimate_exploitation_rate(
-        T = T_val, C = C2, se_C = se_C, n = n_val, m = m_val
+        T = T_val,
+        C = C2,
+        se_C = se_C,
+        n = n_val,
+        m = m_val
       )$estimates$estimate
       expect_true(u2 > u1)
     }
@@ -215,20 +227,30 @@ test_that("INV-monotone-m: u_hat increases with m (T, C, n fixed)", {
   skip_if_not_installed("quickcheck")
 
   quickcheck::for_all(
-    T_val  = quickcheck::integer_bounded(left = 10L, right = 500L, len = 1L),
-    n_val  = quickcheck::integer_bounded(left = 10L, right = 300L, len = 1L),
+    T_val = quickcheck::integer_bounded(left = 10L, right = 500L, len = 1L),
+    n_val = quickcheck::integer_bounded(left = 10L, right = 300L, len = 1L),
     frac_C = quickcheck::double_bounded(left = 0.05, right = 0.5, len = 1L),
     property = function(T_val, n_val, frac_C) {
-      C_val  <- frac_C * T_val
-      se_C   <- C_val * 0.1
-      m1     <- as.integer(floor(n_val * 0.05))
-      m2     <- as.integer(floor(n_val * 0.30))
-      if (m1 >= m2) return(invisible(TRUE))  # skip degenerate case
+      C_val <- frac_C * T_val
+      se_C <- C_val * 0.1
+      m1 <- as.integer(floor(n_val * 0.05))
+      m2 <- as.integer(floor(n_val * 0.30))
+      if (m1 >= m2) {
+        return(invisible(TRUE))
+      } # skip degenerate case
       u1 <- estimate_exploitation_rate(
-        T = T_val, C = C_val, se_C = se_C, n = n_val, m = m1
+        T = T_val,
+        C = C_val,
+        se_C = se_C,
+        n = n_val,
+        m = m1
       )$estimates$estimate
       u2 <- estimate_exploitation_rate(
-        T = T_val, C = C_val, se_C = se_C, n = n_val, m = m2
+        T = T_val,
+        C = C_val,
+        se_C = se_C,
+        n = n_val,
+        m = m2
       )$estimates$estimate
       expect_true(u2 > u1)
     }
@@ -239,30 +261,31 @@ test_that("INV-strata-agg: aggregate equals T-weighted mean of stratum estimates
   skip_if_not_installed("quickcheck")
 
   quickcheck::for_all(
-    T1      = quickcheck::integer_bounded(left = 10L, right = 300L, len = 1L),
-    T2      = quickcheck::integer_bounded(left = 10L, right = 300L, len = 1L),
+    T1 = quickcheck::integer_bounded(left = 10L, right = 300L, len = 1L),
+    T2 = quickcheck::integer_bounded(left = 10L, right = 300L, len = 1L),
     frac_C1 = quickcheck::double_bounded(left = 0.01, right = 0.5, len = 1L),
     frac_C2 = quickcheck::double_bounded(left = 0.01, right = 0.5, len = 1L),
     frac_m1 = quickcheck::double_bounded(left = 0.01, right = 0.5, len = 1L),
     frac_m2 = quickcheck::double_bounded(left = 0.01, right = 0.5, len = 1L),
-    n1      = quickcheck::integer_bounded(left = 5L, right = 200L, len = 1L),
-    n2      = quickcheck::integer_bounded(left = 5L, right = 200L, len = 1L),
+    n1 = quickcheck::integer_bounded(left = 5L, right = 200L, len = 1L),
+    n2 = quickcheck::integer_bounded(left = 5L, right = 200L, len = 1L),
     property = function(T1, T2, frac_C1, frac_C2, frac_m1, frac_m2, n1, n2) {
-      C1 <- frac_C1 * T1; C2 <- frac_C2 * T2
+      C1 <- frac_C1 * T1
+      C2 <- frac_C2 * T2
       m1 <- as.integer(floor(frac_m1 * n1))
       m2 <- as.integer(floor(frac_m2 * n2))
       strata_df <- data.frame(
-        stratum  = c("a", "b"),
-        T_h      = c(T1, T2),
-        C_h      = c(C1, C2),
-        se_C_h   = c(C1 * 0.1, C2 * 0.1),
-        n_h      = c(n1, n2),
-        m_h      = c(m1, m2)
+        stratum = c("a", "b"),
+        T_h = c(T1, T2),
+        C_h = c(C1, C2),
+        se_C_h = c(C1 * 0.1, C2 * 0.1),
+        n_h = c(n1, n2),
+        m_h = c(m1, m2)
       )
-      res          <- estimate_exploitation_rate(strata = strata_df, by = "stratum")
-      ests         <- res$estimates
+      res <- estimate_exploitation_rate(strata = strata_df, by = "stratum")
+      ests <- res$estimates
       stratum_ests <- ests[ests$stratum != ".overall", ]
-      overall      <- ests[ests$stratum == ".overall", ]
+      overall <- ests[ests$stratum == ".overall", ]
       expected_agg <- sum(stratum_ests$T * stratum_ests$estimate) /
         sum(stratum_ests$T)
       expect_equal(overall$estimate, expected_agg, tolerance = 1e-10)

--- a/tests/testthat/test-lubridate-guards.R
+++ b/tests/testthat/test-lubridate-guards.R
@@ -12,7 +12,9 @@ pkg_root <- function() {
       return(path)
     }
     parent <- dirname(path)
-    if (parent == path) break
+    if (parent == path) {
+      break
+    }
     path <- parent
   }
   NULL
@@ -32,7 +34,9 @@ test_that("DEPS-02: lubridate is in Suggests, not Imports, in DESCRIPTION", {
     repeat {
       imports_block <- c(imports_block, desc_lines[i])
       i <- i + 1
-      if (i > length(desc_lines)) break
+      if (i > length(desc_lines)) {
+        break
+      }
       if (!grepl("^\\s", desc_lines[i])) break
     }
   }
@@ -51,7 +55,9 @@ test_that("DEPS-02: lubridate is in Suggests, not Imports, in DESCRIPTION", {
     repeat {
       suggests_block <- c(suggests_block, desc_lines[i])
       i <- i + 1
-      if (i > length(desc_lines)) break
+      if (i > length(desc_lines)) {
+        break
+      }
       if (!grepl("^\\s", desc_lines[i])) break
     }
   }

--- a/tests/testthat/test-nonresponse-adjust.R
+++ b/tests/testthat/test-nonresponse-adjust.R
@@ -160,3 +160,19 @@ test_that("NR-12: unit response rate = 1 produces same estimates as unadjusted",
     tolerance = 1e-6
   )
 })
+
+# NR-13: method dispatch guards -----------------------------------------------
+
+test_that("NR-13: method='calibrate' raises an informative error", {
+  design <- make_nr_design()
+  resp <- data.frame(
+    stratum = c("weekday", "weekend"),
+    n_sampled = c(80L, 60L),
+    n_responded = c(72L, 48L),
+    stringsAsFactors = FALSE
+  )
+  expect_error(
+    adjust_nonresponse(design, resp, method = "calibrate"),
+    regexp = "not yet implemented"
+  )
+})

--- a/tests/testthat/test-nonresponse-adjust.R
+++ b/tests/testthat/test-nonresponse-adjust.R
@@ -11,10 +11,12 @@ make_nr_design <- function() {
     add_counts(design, example_counts)
   ))
   suppressMessages(suppressWarnings(
-    add_interviews(design, example_interviews,
-      catch         = catch_total,
-      effort        = hours_fished,
-      trip_status   = trip_status,
+    add_interviews(
+      design,
+      example_interviews,
+      catch = catch_total,
+      effort = hours_fished,
+      trip_status = trip_status,
       trip_duration = trip_duration
     )
   ))
@@ -77,9 +79,7 @@ test_that("NR-05: weight_adjustment = 1 / response_rate", {
   resp <- make_response_rates(weekday_pct = 0.80, weekend_pct = 0.50)
   result <- suppressWarnings(adjust_nonresponse(design, resp))
   diag <- attr(result, "nonresponse_diagnostics")
-  expect_equal(diag$weight_adjustment, 1 / diag$response_rate,
-    tolerance = 1e-8
-  )
+  expect_equal(diag$weight_adjustment, 1 / diag$response_rate, tolerance = 1e-8)
 })
 
 # Warning / abort tests --------------------------------------------------------
@@ -156,9 +156,7 @@ test_that("NR-12: unit response rate = 1 produces same estimates as unadjusted",
   adj_design <- suppressWarnings(adjust_nonresponse(design, resp))
   est_orig <- suppressWarnings(estimate_catch_rate(design))
   est_adj <- suppressWarnings(estimate_catch_rate(adj_design))
-  expect_equal(est_orig$estimates$estimate, est_adj$estimates$estimate,
-    tolerance = 1e-6
-  )
+  expect_equal(est_orig$estimates$estimate, est_adj$estimates$estimate, tolerance = 1e-6)
 })
 
 # NR-13: method dispatch guards -----------------------------------------------

--- a/tests/testthat/test-plot-design.R
+++ b/tests/testthat/test-plot-design.R
@@ -12,9 +12,9 @@ make_design_no_counts <- function() {
 
 make_design_with_counts <- function() {
   counts <- data.frame(
-    date     = as.Date(c("2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09")),
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09")),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
-    count    = c(10L, 14L, 30L, 35L)
+    count = c(10L, 14L, 30L, 35L)
   )
   d <- make_design_no_counts()
   suppressWarnings(add_counts(d, counts))
@@ -80,8 +80,14 @@ test_that("PLTD-08: no-counts plot n_days matches calendar", {
 make_design_two_strata <- function(with_counts = FALSE) {
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-08", "2024-06-09",
-      "2024-06-15", "2024-06-16", "2024-06-22", "2024-06-23"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16",
+      "2024-06-22",
+      "2024-06-23"
     )),
     day_type = rep(c("weekday", "weekend"), 4),
     season = c(rep("early", 4), rep("late", 4)),
@@ -92,10 +98,10 @@ make_design_two_strata <- function(with_counts = FALSE) {
   )
   if (with_counts) {
     counts <- data.frame(
-      date     = cal$date,
+      date = cal$date,
       day_type = cal$day_type,
-      season   = cal$season,
-      count    = c(5L, 10L, 8L, 20L, 6L, 12L, 9L, 22L)
+      season = cal$season,
+      count = c(5L, 10L, 8L, 20L, 6L, 12L, 9L, 22L)
     )
     d <- suppressWarnings(add_counts(d, counts))
   }
@@ -127,7 +133,8 @@ test_that("PLTD-12: multi-strata with-counts colour label reflects both strata",
   d <- make_design_two_strata(with_counts = TRUE)
   p <- suppressWarnings(plot_design(d))
   expect_match(
-    p$labels$colour, "day_type.*season|season.*day_type",
+    p$labels$colour,
+    "day_type.*season|season.*day_type",
     perl = TRUE
   )
 })

--- a/tests/testthat/test-power-creel.R
+++ b/tests/testthat/test-power-creel.R
@@ -3,53 +3,68 @@
 # Shared inputs ---------------------------------------------------------------
 effort_args <- list(
   strata = c("weekday", "weekend"),
-  N_h    = c(65, 28),
+  N_h = c(65, 28),
   ybar_h = c(50, 60),
-  s2_h   = c(400, 500)
+  s2_h = c(400, 500)
 )
 
 # mode = "effort_n" -----------------------------------------------------------
 
 test_that("PWRC-01: effort_n returns data frame", {
-  res <- do.call(power_creel, c(
-    list(mode = "effort_n", target_rse = 0.20),
-    effort_args
-  ))
+  res <- do.call(
+    power_creel,
+    c(
+      list(mode = "effort_n", target_rse = 0.20),
+      effort_args
+    )
+  )
   expect_s3_class(res, "data.frame")
 })
 
 test_that("PWRC-02: effort_n has expected columns", {
-  res <- do.call(power_creel, c(
-    list(mode = "effort_n", target_rse = 0.20),
-    effort_args
-  ))
+  res <- do.call(
+    power_creel,
+    c(
+      list(mode = "effort_n", target_rse = 0.20),
+      effort_args
+    )
+  )
   expect_named(res, c("stratum", "n_required", "target_rse"))
 })
 
 test_that("PWRC-03: effort_n has stratum rows + total row", {
-  res <- do.call(power_creel, c(
-    list(mode = "effort_n", target_rse = 0.20),
-    effort_args
-  ))
+  res <- do.call(
+    power_creel,
+    c(
+      list(mode = "effort_n", target_rse = 0.20),
+      effort_args
+    )
+  )
   expect_true("total" %in% res$stratum)
   expect_true("weekday" %in% res$stratum)
   expect_true("weekend" %in% res$stratum)
 })
 
 test_that("PWRC-04: effort_n n_required are positive integers", {
-  res <- do.call(power_creel, c(
-    list(mode = "effort_n", target_rse = 0.20),
-    effort_args
-  ))
+  res <- do.call(
+    power_creel,
+    c(
+      list(mode = "effort_n", target_rse = 0.20),
+      effort_args
+    )
+  )
   expect_true(is.integer(res$n_required))
   expect_true(all(res$n_required >= 1L))
 })
 
 test_that("PWRC-05: effort_n target_rse column matches input", {
-  res <- do.call(power_creel, c(
-    list(mode = "effort_n", target_rse = 0.15),
-    effort_args
-  ))
+  res <- do.call(
+    power_creel,
+    c(
+      list(mode = "effort_n", target_rse = 0.15),
+      effort_args
+    )
+  )
   expect_true(all(res$target_rse == 0.15))
 })
 
@@ -78,8 +93,11 @@ test_that("PWRC-07: effort_n errors without target_rse", {
 test_that("PWRC-08: effort_n errors without N_h", {
   expect_error(
     power_creel(
-      mode = "effort_n", target_rse = 0.20,
-      strata = c("a", "b"), ybar_h = c(1, 1), s2_h = c(1, 1)
+      mode = "effort_n",
+      target_rse = 0.20,
+      strata = c("a", "b"),
+      ybar_h = c(1, 1),
+      s2_h = c(1, 1)
     ),
     class = "rlang_error"
   )
@@ -88,9 +106,12 @@ test_that("PWRC-08: effort_n errors without N_h", {
 test_that("PWRC-09: effort_n errors when strata length != N_h length", {
   expect_error(
     power_creel(
-      mode = "effort_n", target_rse = 0.20,
-      strata = c("a"), N_h = c(10, 20),
-      ybar_h = c(1, 1), s2_h = c(1, 1)
+      mode = "effort_n",
+      target_rse = 0.20,
+      strata = c("a"),
+      N_h = c(10, 20),
+      ybar_h = c(1, 1),
+      s2_h = c(1, 1)
     ),
     class = "rlang_error"
   )
@@ -100,27 +121,39 @@ test_that("PWRC-09: effort_n errors when strata length != N_h length", {
 
 test_that("PWRC-10: cpue_n returns data frame", {
   res <- power_creel(
-    mode = "cpue_n", target_rse = 0.20,
-    cv_catch = 0.8, cv_effort = 0.5
+    mode = "cpue_n",
+    target_rse = 0.20,
+    cv_catch = 0.8,
+    cv_effort = 0.5
   )
   expect_s3_class(res, "data.frame")
 })
 
 test_that("PWRC-11: cpue_n has expected columns", {
   res <- power_creel(
-    mode = "cpue_n", target_rse = 0.20,
-    cv_catch = 0.8, cv_effort = 0.5
+    mode = "cpue_n",
+    target_rse = 0.20,
+    cv_catch = 0.8,
+    cv_effort = 0.5
   )
-  expect_named(res, c(
-    "n_required", "target_rse", "cv_catch",
-    "cv_effort", "rho"
-  ))
+  expect_named(
+    res,
+    c(
+      "n_required",
+      "target_rse",
+      "cv_catch",
+      "cv_effort",
+      "rho"
+    )
+  )
 })
 
 test_that("PWRC-12: cpue_n n_required is a positive integer", {
   res <- power_creel(
-    mode = "cpue_n", target_rse = 0.20,
-    cv_catch = 0.8, cv_effort = 0.5
+    mode = "cpue_n",
+    target_rse = 0.20,
+    cv_catch = 0.8,
+    cv_effort = 0.5
   )
   expect_equal(nrow(res), 1L)
   expect_true(is.integer(res$n_required))
@@ -129,12 +162,18 @@ test_that("PWRC-12: cpue_n n_required is a positive integer", {
 
 test_that("PWRC-13: cpue_n rho = 0.5 gives fewer interviews than rho = 0", {
   n_zero <- power_creel(
-    mode = "cpue_n", target_rse = 0.20,
-    cv_catch = 0.8, cv_effort = 0.5, rho = 0
+    mode = "cpue_n",
+    target_rse = 0.20,
+    cv_catch = 0.8,
+    cv_effort = 0.5,
+    rho = 0
   )$n_required
   n_pos <- power_creel(
-    mode = "cpue_n", target_rse = 0.20,
-    cv_catch = 0.8, cv_effort = 0.5, rho = 0.5
+    mode = "cpue_n",
+    target_rse = 0.20,
+    cv_catch = 0.8,
+    cv_effort = 0.5,
+    rho = 0.5
   )$n_required
   expect_gte(n_zero, n_pos)
 })
@@ -157,27 +196,40 @@ test_that("PWRC-15: cpue_n errors without cv_catch", {
 
 test_that("PWRC-16: power mode returns data frame", {
   res <- power_creel(
-    mode = "power", n = 80L,
-    cv_historical = 0.5, delta_pct = 0.20
+    mode = "power",
+    n = 80L,
+    cv_historical = 0.5,
+    delta_pct = 0.20
   )
   expect_s3_class(res, "data.frame")
 })
 
 test_that("PWRC-17: power mode has expected columns", {
   res <- power_creel(
-    mode = "power", n = 80L,
-    cv_historical = 0.5, delta_pct = 0.20
+    mode = "power",
+    n = 80L,
+    cv_historical = 0.5,
+    delta_pct = 0.20
   )
-  expect_named(res, c(
-    "power", "n", "delta_pct", "cv_historical",
-    "alpha", "alternative"
-  ))
+  expect_named(
+    res,
+    c(
+      "power",
+      "n",
+      "delta_pct",
+      "cv_historical",
+      "alpha",
+      "alternative"
+    )
+  )
 })
 
 test_that("PWRC-18: power is in (0, 1)", {
   res <- power_creel(
-    mode = "power", n = 80L,
-    cv_historical = 0.5, delta_pct = 0.20
+    mode = "power",
+    n = 80L,
+    cv_historical = 0.5,
+    delta_pct = 0.20
   )
   expect_gt(res$power, 0)
   expect_lt(res$power, 1)
@@ -185,20 +237,26 @@ test_that("PWRC-18: power is in (0, 1)", {
 
 test_that("PWRC-19: larger n gives higher power", {
   p_small <- power_creel(
-    mode = "power", n = 30L,
-    cv_historical = 0.5, delta_pct = 0.20
+    mode = "power",
+    n = 30L,
+    cv_historical = 0.5,
+    delta_pct = 0.20
   )$power
   p_large <- power_creel(
-    mode = "power", n = 200L,
-    cv_historical = 0.5, delta_pct = 0.20
+    mode = "power",
+    n = 200L,
+    cv_historical = 0.5,
+    delta_pct = 0.20
   )$power
   expect_gt(p_large, p_small)
 })
 
 test_that("PWRC-20: cv_catch used as cv_historical proxy", {
   res <- power_creel(
-    mode = "power", n = 80L,
-    cv_catch = 0.5, delta_pct = 0.20
+    mode = "power",
+    n = 80L,
+    cv_catch = 0.5,
+    delta_pct = 0.20
   )
   expect_equal(res$cv_historical, 0.5)
 })
@@ -226,13 +284,17 @@ test_that("PWRC-23: power mode errors without cv source", {
 
 test_that("PWRC-24: one.sided gives higher power than two.sided", {
   p_two <- power_creel(
-    mode = "power", n = 80L,
-    cv_historical = 0.5, delta_pct = 0.20,
+    mode = "power",
+    n = 80L,
+    cv_historical = 0.5,
+    delta_pct = 0.20,
     alternative = "two.sided"
   )$power
   p_one <- power_creel(
-    mode = "power", n = 80L,
-    cv_historical = 0.5, delta_pct = 0.20,
+    mode = "power",
+    n = 80L,
+    cv_historical = 0.5,
+    delta_pct = 0.20,
     alternative = "one.sided"
   )$power
   expect_gt(p_one, p_two)

--- a/tests/testthat/test-power-sample-size.R
+++ b/tests/testthat/test-power-sample-size.R
@@ -490,3 +490,57 @@ test_that("optimal_n errors on NA cost_ratio", {
     )
   )
 })
+
+# POWER-06b: optimal_n bug guards ----
+
+test_that("optimal_n named cost_ratio is reordered to match N_h, not applied positionally", {
+  # Bug: c(weekend=2, weekday=1) was applied positionally before fix.
+  # weekday stratum is cheaper in both calls; allocation must be the same.
+  N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
+  r_named_match <- optimal_n(
+    cv_target = 0.05, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500),
+    cost_ratio = c(weekday = 1, weekend = 2)
+  )
+  r_named_reversed <- optimal_n(
+    cv_target = 0.05, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500),
+    cost_ratio = c(weekend = 2, weekday = 1)
+  )
+  expect_identical(r_named_match, r_named_reversed)
+})
+
+test_that("optimal_n named cost_ratio with wrong names errors", {
+  expect_error(
+    optimal_n(
+      cv_target  = 0.05,
+      N_h        = c(weekday = 65, weekend = 28),
+      ybar_h     = c(50, 60),
+      s2_h       = c(400, 500),
+      cost_ratio = c(weekday = 1, holiday = 2)
+    ),
+    regexp = "names must match"
+  )
+})
+
+test_that("optimal_n errors when all s2_h are zero", {
+  expect_error(
+    optimal_n(
+      cv_target = 0.20,
+      N_h       = c(weekday = 65, weekend = 28),
+      ybar_h    = c(50, 60),
+      s2_h      = c(0, 0)
+    ),
+    regexp = "zero"
+  )
+})
+
+test_that("optimal_n errors when E_total is zero (all ybar_h zero)", {
+  expect_error(
+    optimal_n(
+      cv_target = 0.20,
+      N_h       = c(weekday = 65, weekend = 28),
+      ybar_h    = c(0, 0),
+      s2_h      = c(400, 500)
+    ),
+    regexp = "zero total"
+  )
+})

--- a/tests/testthat/test-power-sample-size.R
+++ b/tests/testthat/test-power-sample-size.R
@@ -325,9 +325,9 @@ test_that("creel_n_camera errors on cv_target outside (0, 1]", {
 test_that("optimal_n returns named integer vector with total element", {
   result <- optimal_n(
     cv_target = 0.20,
-    N_h    = c(weekday = 65, weekend = 28),
+    N_h = c(weekday = 65, weekend = 28),
     ybar_h = c(50, 60),
-    s2_h   = c(400, 500)
+    s2_h = c(400, 500)
   )
   expect_true(is.integer(result))
   expect_named(result, c("weekday", "weekend", "total"), ignore.order = FALSE)
@@ -337,9 +337,9 @@ test_that("optimal_n returns named integer vector with total element", {
 test_that("optimal_n numerical check: weekday=25, weekend=13, total=37 at cv=0.05", {
   result <- optimal_n(
     cv_target = 0.05,
-    N_h    = c(weekday = 65, weekend = 28),
+    N_h = c(weekday = 65, weekend = 28),
     ybar_h = c(50, 60),
-    s2_h   = c(400, 500)
+    s2_h = c(400, 500)
   )
   expect_identical(result[["total"]], 37L)
   expect_identical(result[["weekday"]], 25L)
@@ -349,9 +349,9 @@ test_that("optimal_n numerical check: weekday=25, weekend=13, total=37 at cv=0.0
 test_that("optimal_n Neyman allocation: high-variance stratum gets >= proportional share", {
   # weekend has higher s2_h (500 > 400); Neyman should allocate more relative share
   # than proportional (N_h-based) would
-  N_h    <- c(weekday = 65, weekend = 28)  # nolint: object_name_linter
+  N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
   ybar_h <- c(50, 60)
-  s2_h   <- c(400, 500)
+  s2_h <- c(400, 500)
   result <- optimal_n(cv_target = 0.05, N_h = N_h, ybar_h = ybar_h, s2_h = s2_h)
   n_total <- result[["total"]]
   prop_share_wkend <- ceiling(n_total * 28 / 93)
@@ -359,15 +359,15 @@ test_that("optimal_n Neyman allocation: high-variance stratum gets >= proportion
 })
 
 test_that("optimal_n cost_ratio shifts allocation toward cheaper strata", {
-  N_h    <- c(weekday = 65, weekend = 28)  # nolint: object_name_linter
+  N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
   ybar_h <- c(50, 60)
-  s2_h   <- c(400, 500)
+  s2_h <- c(400, 500)
   result_equal <- optimal_n(cv_target = 0.05, N_h = N_h, ybar_h = ybar_h, s2_h = s2_h)
   result_costly <- optimal_n(
-    cv_target  = 0.05,
-    N_h        = N_h,
-    ybar_h     = ybar_h,
-    s2_h       = s2_h,
+    cv_target = 0.05,
+    N_h = N_h,
+    ybar_h = ybar_h,
+    s2_h = s2_h,
     cost_ratio = c(weekday = 1, weekend = 2)
   )
   # weekend is more expensive -> fewer weekend days, more weekday days
@@ -378,10 +378,10 @@ test_that("optimal_n cost_ratio shifts allocation toward cheaper strata", {
 test_that("optimal_n cost_ratio numerical check: weekday=29, weekend=10, total=38 when weekend costs 2x", {
   # Cochran 5.34 with FPC: n = A*C/(V_0 + sum(N_h*s2_h)) where A=sum(N_h*s_h/sqrt(c_h))
   result <- optimal_n(
-    cv_target  = 0.05,
-    N_h        = c(weekday = 65, weekend = 28),
-    ybar_h     = c(50, 60),
-    s2_h       = c(400, 500),
+    cv_target = 0.05,
+    N_h = c(weekday = 65, weekend = 28),
+    ybar_h = c(50, 60),
+    s2_h = c(400, 500),
     cost_ratio = c(1, 2)
   )
   expect_identical(result[["total"]], 38L)
@@ -391,31 +391,44 @@ test_that("optimal_n cost_ratio numerical check: weekday=29, weekend=10, total=3
 
 test_that("optimal_n cost_ratio achieves target CV (extreme costs, with FPC)", {
   # Ensures Cochran 5.34 n_total (not 5.25) is used -- extreme cost_ratio exposes the bug
-  N_h    <- c(weekday = 65, weekend = 28)  # nolint: object_name_linter
-  ybar_h <- c(50, 60); s2_h <- c(400, 500); cv_target <- 0.05
-  result <- optimal_n(cv_target = cv_target, N_h = N_h, ybar_h = ybar_h, s2_h = s2_h,
-                      cost_ratio = c(weekday = 1, weekend = 10))
+  N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
+  ybar_h <- c(50, 60)
+  s2_h <- c(400, 500)
+  cv_target <- 0.05
+  result <- optimal_n(
+    cv_target = cv_target,
+    N_h = N_h,
+    ybar_h = ybar_h,
+    s2_h = s2_h,
+    cost_ratio = c(weekday = 1, weekend = 10)
+  )
   n_h <- result[c("weekday", "weekend")]
   E_total <- sum(N_h * ybar_h)
-  V_achieved <- sum(N_h^2 * s2_h / n_h) - sum(N_h * s2_h)  # stratified total variance with FPC
+  V_achieved <- sum(N_h^2 * s2_h / n_h) - sum(N_h * s2_h) # stratified total variance with FPC
   cv_achieved <- sqrt(V_achieved) / E_total
   expect_true(cv_achieved <= cv_target)
 })
 
 test_that("optimal_n scalar cost_ratio expands to all strata", {
   r1 <- optimal_n(
-    cv_target = 0.05, N_h = c(weekday = 65, weekend = 28),
-    ybar_h = c(50, 60), s2_h = c(400, 500), cost_ratio = 1
+    cv_target = 0.05,
+    N_h = c(weekday = 65, weekend = 28),
+    ybar_h = c(50, 60),
+    s2_h = c(400, 500),
+    cost_ratio = 1
   )
   r2 <- optimal_n(
-    cv_target = 0.05, N_h = c(weekday = 65, weekend = 28),
-    ybar_h = c(50, 60), s2_h = c(400, 500), cost_ratio = c(1, 1)
+    cv_target = 0.05,
+    N_h = c(weekday = 65, weekend = 28),
+    ybar_h = c(50, 60),
+    s2_h = c(400, 500),
+    cost_ratio = c(1, 1)
   )
   expect_identical(r1, r2)
 })
 
 test_that("optimal_n tighter cv_target gives larger n_total", {
-  N_h    <- c(weekday = 65, weekend = 28)  # nolint: object_name_linter
+  N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
   n_tight <- optimal_n(cv_target = 0.10, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500))
   n_loose <- optimal_n(cv_target = 0.20, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500))
   expect_true(n_tight[["total"]] > n_loose[["total"]])
@@ -424,9 +437,9 @@ test_that("optimal_n tighter cv_target gives larger n_total", {
 test_that("optimal_n works with single stratum", {
   result <- optimal_n(
     cv_target = 0.20,
-    N_h    = c(all_days = 93),
+    N_h = c(all_days = 93),
     ybar_h = 55,
-    s2_h   = 450
+    s2_h = 450
   )
   expect_named(result, c("all_days", "total"), ignore.order = FALSE)
   expect_true(result[["all_days"]] >= 1L)
@@ -435,9 +448,9 @@ test_that("optimal_n works with single stratum", {
 test_that("optimal_n stratum sum >= total (ceiling artifact)", {
   result <- optimal_n(
     cv_target = 0.05,
-    N_h    = c(weekday = 65, weekend = 28),
+    N_h = c(weekday = 65, weekend = 28),
     ybar_h = c(50, 60),
-    s2_h   = c(400, 500)
+    s2_h = c(400, 500)
   )
   stratum_sum <- sum(result[names(result) != "total"])
   expect_true(stratum_sum >= result[["total"]])
@@ -453,27 +466,27 @@ test_that("optimal_n errors on mismatched stratum lengths", {
   expect_error(
     optimal_n(
       cv_target = 0.20,
-      N_h    = c(weekday = 65, weekend = 28),
+      N_h = c(weekday = 65, weekend = 28),
       ybar_h = c(50, 60, 70),
-      s2_h   = c(400, 500)
+      s2_h = c(400, 500)
     )
   )
 })
 
 test_that("optimal_n errors on cv_target outside (0, 1]", {
-  N_h <- c(weekday = 65, weekend = 28)  # nolint: object_name_linter
-  expect_error(optimal_n(cv_target = 0,    N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500)))
+  N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
+  expect_error(optimal_n(cv_target = 0, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500)))
   expect_error(optimal_n(cv_target = -0.1, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500)))
-  expect_error(optimal_n(cv_target = 1.1,  N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500)))
+  expect_error(optimal_n(cv_target = 1.1, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500)))
 })
 
 test_that("optimal_n errors on non-positive cost_ratio", {
   expect_error(
     optimal_n(
-      cv_target  = 0.20,
-      N_h        = c(weekday = 65, weekend = 28),
-      ybar_h     = c(50, 60),
-      s2_h       = c(400, 500),
+      cv_target = 0.20,
+      N_h = c(weekday = 65, weekend = 28),
+      ybar_h = c(50, 60),
+      s2_h = c(400, 500),
       cost_ratio = c(1, -1)
     )
   )
@@ -482,10 +495,10 @@ test_that("optimal_n errors on non-positive cost_ratio", {
 test_that("optimal_n errors on NA cost_ratio", {
   expect_error(
     optimal_n(
-      cv_target  = 0.20,
-      N_h        = c(weekday = 65, weekend = 28),
-      ybar_h     = c(50, 60),
-      s2_h       = c(400, 500),
+      cv_target = 0.20,
+      N_h = c(weekday = 65, weekend = 28),
+      ybar_h = c(50, 60),
+      s2_h = c(400, 500),
       cost_ratio = NA_real_
     )
   )
@@ -498,11 +511,17 @@ test_that("optimal_n named cost_ratio is reordered to match N_h, not applied pos
   # weekday stratum is cheaper in both calls; allocation must be the same.
   N_h <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
   r_named_match <- optimal_n(
-    cv_target = 0.05, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500),
+    cv_target = 0.05,
+    N_h = N_h,
+    ybar_h = c(50, 60),
+    s2_h = c(400, 500),
     cost_ratio = c(weekday = 1, weekend = 2)
   )
   r_named_reversed <- optimal_n(
-    cv_target = 0.05, N_h = N_h, ybar_h = c(50, 60), s2_h = c(400, 500),
+    cv_target = 0.05,
+    N_h = N_h,
+    ybar_h = c(50, 60),
+    s2_h = c(400, 500),
     cost_ratio = c(weekend = 2, weekday = 1)
   )
   expect_identical(r_named_match, r_named_reversed)
@@ -511,10 +530,10 @@ test_that("optimal_n named cost_ratio is reordered to match N_h, not applied pos
 test_that("optimal_n named cost_ratio with wrong names errors", {
   expect_error(
     optimal_n(
-      cv_target  = 0.05,
-      N_h        = c(weekday = 65, weekend = 28),
-      ybar_h     = c(50, 60),
-      s2_h       = c(400, 500),
+      cv_target = 0.05,
+      N_h = c(weekday = 65, weekend = 28),
+      ybar_h = c(50, 60),
+      s2_h = c(400, 500),
       cost_ratio = c(weekday = 1, holiday = 2)
     ),
     regexp = "names must match"
@@ -525,9 +544,9 @@ test_that("optimal_n errors when all s2_h are zero", {
   expect_error(
     optimal_n(
       cv_target = 0.20,
-      N_h       = c(weekday = 65, weekend = 28),
-      ybar_h    = c(50, 60),
-      s2_h      = c(0, 0)
+      N_h = c(weekday = 65, weekend = 28),
+      ybar_h = c(50, 60),
+      s2_h = c(0, 0)
     ),
     regexp = "zero"
   )
@@ -537,9 +556,9 @@ test_that("optimal_n errors when E_total is zero (all ybar_h zero)", {
   expect_error(
     optimal_n(
       cv_target = 0.20,
-      N_h       = c(weekday = 65, weekend = 28),
-      ybar_h    = c(0, 0),
-      s2_h      = c(400, 500)
+      N_h = c(weekday = 65, weekend = 28),
+      ybar_h = c(0, 0),
+      s2_h = c(400, 500)
     ),
     regexp = "zero total"
   )

--- a/tests/testthat/test-prep-counts.R
+++ b/tests/testthat/test-prep-counts.R
@@ -29,8 +29,16 @@ test_that("prep_counts_daily_effort() returns canonical columns with optional fi
   expect_named(
     result,
     c(
-      "date", "month", "day_type", "effort_type", "daily_effort", "psu",
-      "correction_factor", "n_counts", "within_day_var", "source_method"
+      "date",
+      "month",
+      "day_type",
+      "effort_type",
+      "daily_effort",
+      "psu",
+      "correction_factor",
+      "n_counts",
+      "within_day_var",
+      "source_method"
     )
   )
   expect_equal(result$daily_effort, c(12.5, 18.0))
@@ -254,12 +262,23 @@ test_that("prep_counts_boat_party() computes canonical daily boat effort rows", 
 
   expect_named(
     result,
-    c("date", "day_type", "effort_type", "daily_effort", "psu", "correction_factor", "source_method")
+    c(
+      "date",
+      "day_type",
+      "effort_type",
+      "daily_effort",
+      "psu",
+      "correction_factor",
+      "source_method"
+    )
   )
   expect_equal(result$effort_type, c("boat", "boat"))
   expect_equal(result$daily_effort, c(25, 24))
   expect_equal(result$correction_factor, c(1, 1))
-  expect_equal(result$source_method, c("boat_count_x_mean_party_size", "boat_count_x_mean_party_size"))
+  expect_equal(
+    result$source_method,
+    c("boat_count_x_mean_party_size", "boat_count_x_mean_party_size")
+  )
 })
 
 test_that("prep_counts_boat_party() applies correction_factor", {

--- a/tests/testthat/test-prep-interviews.R
+++ b/tests/testthat/test-prep-interviews.R
@@ -37,9 +37,20 @@ test_that("prep_interviews_trips() returns canonical columns from direct effort 
   expect_named(
     result,
     c(
-      "date", "interview_uid", "effort_hours", "trip_status", "trip_duration",
-      "n_anglers", "refused", "month", "day_type", "catch_total",
-      "harvest_total", "angler_type", "angler_method", "species_sought"
+      "date",
+      "interview_uid",
+      "effort_hours",
+      "trip_status",
+      "trip_duration",
+      "n_anglers",
+      "refused",
+      "month",
+      "day_type",
+      "catch_total",
+      "harvest_total",
+      "angler_type",
+      "angler_method",
+      "species_sought"
     )
   )
   expect_equal(result$trip_status, c("complete", "incomplete"))

--- a/tests/testthat/test-primary-source-validation.R
+++ b/tests/testthat/test-primary-source-validation.R
@@ -23,7 +23,8 @@ make_box20_6_example1 <- function() {
     day_type = c("weekday", "weekday", "weekday", "weekday"),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     calendar = cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
@@ -44,67 +45,131 @@ make_box20_6_example1 <- function() {
   # Total: 4+3+6+2 = 15 interview rows.
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-01", "2024-06-02", "2024-06-02",
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-03", "2024-06-04",
-      "2024-06-03", "2024-06-04",
+      "2024-06-01",
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-02",
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-03",
+      "2024-06-04",
       "2024-06-03"
     )),
     day_type = "weekday",
     site = c(
-      "A", "A", "A", "A",
-      "B", "B", "B",
-      "C", "C", "C",
-      "C", "C",
-      "C", "D",
+      "A",
+      "A",
+      "A",
+      "A",
+      "B",
+      "B",
+      "B",
+      "C",
+      "C",
+      "C",
+      "C",
+      "C",
+      "C",
+      "D",
       "D"
     ),
     circuit = "circ1",
     hours_fished = c(
-      7.5, 7.5, 7.5, 7.5,
-      20.0 / 3, 20.0 / 3, 20.0 / 3,
-      57.5 / 6, 57.5 / 6, 57.5 / 6,
-      57.5 / 6, 57.5 / 6,
-      57.5 / 6, 2.5,
+      7.5,
+      7.5,
+      7.5,
+      7.5,
+      20.0 / 3,
+      20.0 / 3,
+      20.0 / 3,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      2.5,
       2.5
     ),
     fish_kept = c(
-      1L, 0L, 1L, 0L,
-      1L, 0L, 1L,
-      1L, 1L, 0L,
-      1L, 0L,
-      1L, 0L,
+      1L,
+      0L,
+      1L,
+      0L,
+      1L,
+      0L,
+      1L,
+      1L,
+      1L,
+      0L,
+      1L,
+      0L,
+      1L,
+      0L,
       0L
     ),
     fish_caught = c(
-      2L, 1L, 1L, 1L,
-      2L, 1L, 1L,
-      2L, 1L, 1L,
-      1L, 1L,
-      1L, 1L,
+      2L,
+      1L,
+      1L,
+      1L,
+      2L,
+      1L,
+      1L,
+      2L,
+      1L,
+      1L,
+      1L,
+      1L,
+      1L,
+      1L,
       1L
     ),
     n_counted = c(
-      4L, 4L, 4L, 4L,
-      3L, 3L, 3L,
-      6L, 6L, 6L,
-      6L, 6L,
-      6L, 2L,
+      4L,
+      4L,
+      4L,
+      4L,
+      3L,
+      3L,
+      3L,
+      6L,
+      6L,
+      6L,
+      6L,
+      6L,
+      6L,
+      2L,
       2L
     ),
     n_interviewed = c(
-      4L, 4L, 4L, 4L,
-      3L, 3L, 3L,
-      6L, 6L, 6L,
-      6L, 6L,
-      6L, 2L,
+      4L,
+      4L,
+      4L,
+      4L,
+      3L,
+      3L,
+      3L,
+      6L,
+      6L,
+      6L,
+      6L,
+      6L,
+      6L,
+      2L,
       2L
     ),
     trip_status = "complete",
     stringsAsFactors = FALSE
   )
-  add_interviews( # nolint: object_usage_linter
+  add_interviews(
+    # nolint: object_usage_linter
     design,
     interviews,
     effort = hours_fished, # nolint: object_usage_linter
@@ -116,56 +181,41 @@ make_box20_6_example1 <- function() {
   )
 }
 
-test_that(
-  "Site C contribution to effort equals 57.5/0.20 = 287.5 (Malvestuto 1996, Box 20.6, p. 614)",
-  {
-    result <- estimate_effort(make_box20_6_example1())
-    sc <- attr(result, "site_contributions")
-    site_c <- sc[sc$site == "C", ]
-    # Malvestuto 1996, Box 20.6, p. 614
-    expect_equal(sum(site_c$e_i_over_pi_i), 287.5, tolerance = 1e-6)
-  }
-)
+test_that("Site C contribution to effort equals 57.5/0.20 = 287.5 (Malvestuto 1996, Box 20.6, p. 614)", {
+  result <- estimate_effort(make_box20_6_example1())
+  sc <- attr(result, "site_contributions")
+  site_c <- sc[sc$site == "C", ]
+  # Malvestuto 1996, Box 20.6, p. 614
+  expect_equal(sum(site_c$e_i_over_pi_i), 287.5, tolerance = 1e-6)
+})
 
-test_that(
-  "E_hat is sum of all site contributions (Horvitz-Thompson property)",
-  {
-    result <- estimate_effort(make_box20_6_example1())
-    # Malvestuto 1996, Box 20.6, p. 614: E_hat = 200+160+287.5+200 = 847.5
-    expected_e_hat <- 30.0 / 0.15 + 20.0 / 0.125 + 57.5 / 0.20 + 5.0 / 0.025
-    expect_equal(result$estimates$estimate, expected_e_hat, tolerance = 1e-6)
-  }
-)
+test_that("E_hat is sum of all site contributions (Horvitz-Thompson property)", {
+  result <- estimate_effort(make_box20_6_example1())
+  # Malvestuto 1996, Box 20.6, p. 614: E_hat = 200+160+287.5+200 = 847.5
+  expected_e_hat <- 30.0 / 0.15 + 20.0 / 0.125 + 57.5 / 0.20 + 5.0 / 0.025
+  expect_equal(result$estimates$estimate, expected_e_hat, tolerance = 1e-6)
+})
 
-test_that(
-  "estimate_effort() result class is creel_estimates for bus-route design",
-  {
-    result <- estimate_effort(make_box20_6_example1())
-    expect_s3_class(result, "creel_estimates")
-  }
-)
+test_that("estimate_effort() result class is creel_estimates for bus-route design", {
+  result <- estimate_effort(make_box20_6_example1())
+  expect_s3_class(result, "creel_estimates")
+})
 
-test_that(
-  "Bus-route effort method is 'total' (Horvitz-Thompson total estimator)",
-  {
-    result <- estimate_effort(make_box20_6_example1())
-    expect_equal(result$method, "total")
-  }
-)
+test_that("Bus-route effort method is 'total' (Horvitz-Thompson total estimator)", {
+  result <- estimate_effort(make_box20_6_example1())
+  expect_equal(result$method, "total")
+})
 
-test_that(
-  "Example 1 harvest estimate: H_hat = sum(h_i/pi_i) with per-interview harvest",
-  {
-    # Harvest uses fish_kept column with no expansion (n_counted = n_interviewed).
-    # Per CONTEXT.md: effort validation alongside harvest/catch.
-    result <- estimate_harvest_rate(make_box20_6_example1())
-    expect_s3_class(result, "creel_estimates")
-    # H_hat should be positive and finite
-    expect_true(is.numeric(result$estimates$estimate))
-    expect_true(result$estimates$estimate > 0)
-    expect_true(is.finite(result$estimates$estimate))
-  }
-)
+test_that("Example 1 harvest estimate: H_hat = sum(h_i/pi_i) with per-interview harvest", {
+  # Harvest uses fish_kept column with no expansion (n_counted = n_interviewed).
+  # Per CONTEXT.md: effort validation alongside harvest/catch.
+  result <- estimate_harvest_rate(make_box20_6_example1())
+  expect_s3_class(result, "creel_estimates")
+  # H_hat should be positive and finite
+  expect_true(is.numeric(result$estimates$estimate))
+  expect_true(result$estimates$estimate > 0)
+  expect_true(is.finite(result$estimates$estimate))
+})
 
 # Malvestuto Box 20.6 Example 2 (enumeration expansion) ----
 # Same design as Example 1 but Site C: n_counted=24, n_interviewed=11.
@@ -187,7 +237,8 @@ make_box20_6_example2 <- function() {
     day_type = c("weekday", "weekday", "weekday", "weekday"),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     calendar = cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
@@ -204,69 +255,133 @@ make_box20_6_example2 <- function() {
   # Total: 4+3+6+2 = 15 interview rows.
   interviews <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-01", "2024-06-02", "2024-06-02",
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-01", "2024-06-02", "2024-06-03",
-      "2024-06-03", "2024-06-04",
-      "2024-06-03", "2024-06-04",
+      "2024-06-01",
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-02",
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-03",
+      "2024-06-04",
       "2024-06-03"
     )),
     day_type = "weekday",
     site = c(
-      "A", "A", "A", "A",
-      "B", "B", "B",
-      "C", "C", "C",
-      "C", "C",
-      "C", "D",
+      "A",
+      "A",
+      "A",
+      "A",
+      "B",
+      "B",
+      "B",
+      "C",
+      "C",
+      "C",
+      "C",
+      "C",
+      "C",
+      "D",
       "D"
     ),
     circuit = "circ1",
     hours_fished = c(
-      7.5, 7.5, 7.5, 7.5,
-      20.0 / 3, 20.0 / 3, 20.0 / 3,
-      57.5 / 6, 57.5 / 6, 57.5 / 6,
-      57.5 / 6, 57.5 / 6,
-      57.5 / 6, 2.5,
+      7.5,
+      7.5,
+      7.5,
+      7.5,
+      20.0 / 3,
+      20.0 / 3,
+      20.0 / 3,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      57.5 / 6,
+      2.5,
       2.5
     ),
     fish_kept = c(
-      1L, 0L, 1L, 0L,
-      1L, 0L, 1L,
-      1L, 1L, 0L,
-      1L, 0L,
-      1L, 0L,
+      1L,
+      0L,
+      1L,
+      0L,
+      1L,
+      0L,
+      1L,
+      1L,
+      1L,
+      0L,
+      1L,
+      0L,
+      1L,
+      0L,
       0L
     ),
     fish_caught = c(
-      2L, 1L, 1L, 1L,
-      2L, 1L, 1L,
-      2L, 1L, 1L,
-      1L, 1L,
-      1L, 1L,
+      2L,
+      1L,
+      1L,
+      1L,
+      2L,
+      1L,
+      1L,
+      2L,
+      1L,
+      1L,
+      1L,
+      1L,
+      1L,
+      1L,
       1L
     ),
     # Malvestuto 1996, Box 20.6, p. 614 (enumeration expansion):
     # Site C: 24 counted, 11 interviewed. Others: n_counted = n_interviewed.
     n_counted = c(
-      4L, 4L, 4L, 4L,
-      3L, 3L, 3L,
-      24L, 24L, 24L,
-      24L, 24L,
-      24L, 2L,
+      4L,
+      4L,
+      4L,
+      4L,
+      3L,
+      3L,
+      3L,
+      24L,
+      24L,
+      24L,
+      24L,
+      24L,
+      24L,
+      2L,
       2L
     ),
     n_interviewed = c(
-      4L, 4L, 4L, 4L,
-      3L, 3L, 3L,
-      11L, 11L, 11L,
-      11L, 11L,
-      11L, 2L,
+      4L,
+      4L,
+      4L,
+      4L,
+      3L,
+      3L,
+      3L,
+      11L,
+      11L,
+      11L,
+      11L,
+      11L,
+      11L,
+      2L,
       2L
     ),
     trip_status = "complete",
     stringsAsFactors = FALSE
   )
-  add_interviews( # nolint: object_usage_linter
+  add_interviews(
+    # nolint: object_usage_linter
     design,
     interviews,
     effort = hours_fished, # nolint: object_usage_linter
@@ -278,54 +393,42 @@ make_box20_6_example2 <- function() {
   )
 }
 
-test_that(
-  "Site C expansion factor is 24/11 in enumeration counts",
-  {
-    design <- make_box20_6_example2()
-    enum_counts <- get_enumeration_counts(design)
-    site_c <- enum_counts[enum_counts$site == "C", ]
-    # Malvestuto 1996, Box 20.6, p. 614
-    expect_equal(site_c$.expansion[1], 24 / 11, tolerance = 1e-6)
-  }
-)
+test_that("Site C expansion factor is 24/11 in enumeration counts", {
+  design <- make_box20_6_example2()
+  enum_counts <- get_enumeration_counts(design)
+  site_c <- enum_counts[enum_counts$site == "C", ]
+  # Malvestuto 1996, Box 20.6, p. 614
+  expect_equal(site_c$.expansion[1], 24 / 11, tolerance = 1e-6)
+})
 
-test_that(
-  "E_hat with expansion is larger than E_hat without expansion (VALID-02)",
-  {
-    result_ex1 <- estimate_effort(make_box20_6_example1())
-    result_ex2 <- estimate_effort(make_box20_6_example2())
-    expect_gt(result_ex2$estimates$estimate, result_ex1$estimates$estimate)
-  }
-)
+test_that("E_hat with expansion is larger than E_hat without expansion (VALID-02)", {
+  result_ex1 <- estimate_effort(make_box20_6_example1())
+  result_ex2 <- estimate_effort(make_box20_6_example2())
+  expect_gt(result_ex2$estimates$estimate, result_ex1$estimates$estimate)
+})
 
-test_that(
-  "Site C contribution with expansion equals (57.5 * 24/11) / 0.20",
-  {
-    result_ex2 <- estimate_effort(make_box20_6_example2())
-    # Malvestuto 1996, Box 20.6, p. 614 (enumeration expansion)
-    expansion <- 24 / 11
-    expected_c <- (57.5 * expansion) / 0.20
-    sc <- attr(result_ex2, "site_contributions")
-    c_contributions <- sc[sc$site == "C", "e_i_over_pi_i"]
-    expect_equal(sum(c_contributions), expected_c, tolerance = 1e-6)
-  }
-)
+test_that("Site C contribution with expansion equals (57.5 * 24/11) / 0.20", {
+  result_ex2 <- estimate_effort(make_box20_6_example2())
+  # Malvestuto 1996, Box 20.6, p. 614 (enumeration expansion)
+  expansion <- 24 / 11
+  expected_c <- (57.5 * expansion) / 0.20
+  sc <- attr(result_ex2, "site_contributions")
+  c_contributions <- sc[sc$site == "C", "e_i_over_pi_i"]
+  expect_equal(sum(c_contributions), expected_c, tolerance = 1e-6)
+})
 
-test_that(
-  "Sites without expansion (A, B, D) have same contributions in Example 2 as Example 1",
-  {
-    result_ex1 <- estimate_effort(make_box20_6_example1())
-    result_ex2 <- estimate_effort(make_box20_6_example2())
-    sc1 <- attr(result_ex1, "site_contributions")
-    sc2 <- attr(result_ex2, "site_contributions")
-    for (s in c("A", "B", "D")) {
-      sum1 <- sum(sc1[sc1$site == s, "e_i_over_pi_i"])
-      sum2 <- sum(sc2[sc2$site == s, "e_i_over_pi_i"])
-      lbl <- paste0("Site ", s, " contribution unchanged between Ex1 and Ex2")
-      expect_equal(sum2, sum1, tolerance = 1e-6, label = lbl)
-    }
+test_that("Sites without expansion (A, B, D) have same contributions in Example 2 as Example 1", {
+  result_ex1 <- estimate_effort(make_box20_6_example1())
+  result_ex2 <- estimate_effort(make_box20_6_example2())
+  sc1 <- attr(result_ex1, "site_contributions")
+  sc2 <- attr(result_ex2, "site_contributions")
+  for (s in c("A", "B", "D")) {
+    sum1 <- sum(sc1[sc1$site == s, "e_i_over_pi_i"])
+    sum2 <- sum(sc2[sc2$site == s, "e_i_over_pi_i"])
+    lbl <- paste0("Site ", s, " contribution unchanged between Ex1 and Ex2")
+    expect_equal(sum2, sum1, tolerance = 1e-6, label = lbl)
   }
-)
+})
 
 # Integration tests ----
 # Verify the complete bus-route workflow wiring: design -> add_interviews -> estimate_*
@@ -333,53 +436,41 @@ test_that(
 # that unit tests on individual functions cannot detect.
 # VALID-05: complete workflow integration tests.
 
-test_that(
-  "Complete bus-route workflow: design -> data -> effort estimation succeeds (VALID-05)",
-  {
-    d <- make_box20_6_example2()
-    result <- suppressWarnings(estimate_effort(d))
-    # VALID-05: complete workflow integration
-    expect_s3_class(result, "creel_estimates")
-    expect_true(is.finite(result$estimates$estimate))
-    expect_true(result$estimates$estimate > 0)
-    expect_true(is.finite(result$estimates$se))
-    expect_true(result$estimates$se > 0)
-  }
-)
+test_that("Complete bus-route workflow: design -> data -> effort estimation succeeds (VALID-05)", {
+  d <- make_box20_6_example2()
+  result <- suppressWarnings(estimate_effort(d))
+  # VALID-05: complete workflow integration
+  expect_s3_class(result, "creel_estimates")
+  expect_true(is.finite(result$estimates$estimate))
+  expect_true(result$estimates$estimate > 0)
+  expect_true(is.finite(result$estimates$se))
+  expect_true(result$estimates$se > 0)
+})
 
-test_that(
-  "Complete bus-route workflow: design -> data -> harvest estimation succeeds (VALID-05)",
-  {
-    d <- make_box20_6_example2()
-    result <- suppressWarnings(estimate_harvest_rate(d))
-    expect_s3_class(result, "creel_estimates")
-    expect_true(is.finite(result$estimates$estimate))
-    expect_true(result$estimates$estimate > 0)
-    expect_true(is.finite(result$estimates$se))
-  }
-)
+test_that("Complete bus-route workflow: design -> data -> harvest estimation succeeds (VALID-05)", {
+  d <- make_box20_6_example2()
+  result <- suppressWarnings(estimate_harvest_rate(d))
+  expect_s3_class(result, "creel_estimates")
+  expect_true(is.finite(result$estimates$estimate))
+  expect_true(result$estimates$estimate > 0)
+  expect_true(is.finite(result$estimates$se))
+})
 
-test_that(
-  "Bus-route total-catch estimation succeeds with Box 20.6 data (VALID-05)",
-  {
-    d <- make_box20_6_example2()
-    result <- suppressWarnings(estimate_total_catch(d))
-    expect_s3_class(result, "creel_estimates")
-    expect_true(is.finite(result$estimates$estimate))
-    expect_true(result$estimates$estimate > 0)
-  }
-)
+test_that("Bus-route total-catch estimation succeeds with Box 20.6 data (VALID-05)", {
+  d <- make_box20_6_example2()
+  result <- suppressWarnings(estimate_total_catch(d))
+  expect_s3_class(result, "creel_estimates")
+  expect_true(is.finite(result$estimates$estimate))
+  expect_true(result$estimates$estimate > 0)
+})
 
-test_that(
-  "Grouped effort estimation by day_type returns one row (all weekday data)",
-  {
-    d <- make_box20_6_example2()
-    result <- suppressWarnings(estimate_effort(d, by = day_type))
-    expect_s3_class(result, "creel_estimates")
-    # All dates are weekday so one group
-    expect_equal(nrow(result$estimates), 1L)
-  }
-)
+test_that("Grouped effort estimation by day_type returns one row (all weekday data)", {
+  d <- make_box20_6_example2()
+  result <- suppressWarnings(estimate_effort(d, by = day_type))
+  expect_s3_class(result, "creel_estimates")
+  # All dates are weekday so one group
+  expect_equal(nrow(result$estimates), 1L)
+})
 
 # Survey package cross-validation ----
 # Verify inverse probability weighting by replicating the HT estimator manually
@@ -394,88 +485,76 @@ test_that(
 # Point estimate tolerance: 1e-6 (exact match expected)
 # SE tolerance: 1e-3 (per CONTEXT.md decision)
 
-test_that(
-  "Effort estimate matches manual survey::svydesign + svytotal (point estimate, tol 1e-6)",
-  {
-    d <- make_box20_6_example1()
-    int_data <- d$interviews
-    # Compute HT contribution per row: effort * expansion / pi_i
-    # (expansion = 1 for Example 1, so this is effort / pi_i)
-    # Proves inverse probability weighting correctly implements Eq. 19.4
-    int_data$.effort_contrib <- int_data$hours_fished * int_data$.expansion / int_data$.pi_i
-    svy_manual <- suppressWarnings(
-      survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
-    )
-    manual_result <- survey::svytotal(~.effort_contrib, svy_manual)
-    tidycreel_result <- suppressWarnings(estimate_effort(d))
-    expect_equal(
-      tidycreel_result$estimates$estimate,
-      as.numeric(coef(manual_result)),
-      tolerance = 1e-6
-    )
-  }
-)
+test_that("Effort estimate matches manual survey::svydesign + svytotal (point estimate, tol 1e-6)", {
+  d <- make_box20_6_example1()
+  int_data <- d$interviews
+  # Compute HT contribution per row: effort * expansion / pi_i
+  # (expansion = 1 for Example 1, so this is effort / pi_i)
+  # Proves inverse probability weighting correctly implements Eq. 19.4
+  int_data$.effort_contrib <- int_data$hours_fished * int_data$.expansion / int_data$.pi_i
+  svy_manual <- suppressWarnings(
+    survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
+  )
+  manual_result <- survey::svytotal(~.effort_contrib, svy_manual)
+  tidycreel_result <- suppressWarnings(estimate_effort(d))
+  expect_equal(
+    tidycreel_result$estimates$estimate,
+    as.numeric(coef(manual_result)),
+    tolerance = 1e-6
+  )
+})
 
-test_that(
-  "Effort SE matches manual survey::svydesign + svytotal (tol 1e-3)",
-  {
-    d <- make_box20_6_example1()
-    int_data <- d$interviews
-    int_data$.effort_contrib <- int_data$hours_fished * int_data$.expansion / int_data$.pi_i
-    svy_manual <- suppressWarnings(
-      survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
-    )
-    manual_result <- survey::svytotal(~.effort_contrib, svy_manual)
-    tidycreel_result <- suppressWarnings(estimate_effort(d))
-    # Per CONTEXT.md: SE tolerance 1e-3 (FPC differences acceptable)
-    expect_equal(
-      tidycreel_result$estimates$se,
-      as.numeric(survey::SE(manual_result)),
-      tolerance = 1e-3
-    )
-  }
-)
+test_that("Effort SE matches manual survey::svydesign + svytotal (tol 1e-3)", {
+  d <- make_box20_6_example1()
+  int_data <- d$interviews
+  int_data$.effort_contrib <- int_data$hours_fished * int_data$.expansion / int_data$.pi_i
+  svy_manual <- suppressWarnings(
+    survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
+  )
+  manual_result <- survey::svytotal(~.effort_contrib, svy_manual)
+  tidycreel_result <- suppressWarnings(estimate_effort(d))
+  # Per CONTEXT.md: SE tolerance 1e-3 (FPC differences acceptable)
+  expect_equal(
+    tidycreel_result$estimates$se,
+    as.numeric(survey::SE(manual_result)),
+    tolerance = 1e-3
+  )
+})
 
-test_that(
-  "Harvest estimate matches manual survey::svydesign + svytotal (point estimate, tol 1e-6)",
-  {
-    d <- make_box20_6_example1()
-    int_data <- d$interviews
-    # Compute HT harvest contribution per row: harvest * expansion / pi_i
-    # (expansion = 1 for Example 1)
-    int_data$.harvest_contrib <- int_data$fish_kept * int_data$.expansion / int_data$.pi_i
-    svy_manual <- suppressWarnings(
-      survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
-    )
-    manual_result <- survey::svytotal(~.harvest_contrib, svy_manual)
-    tidycreel_result <- suppressWarnings(estimate_harvest_rate(d))
-    expect_equal(
-      tidycreel_result$estimates$estimate,
-      as.numeric(coef(manual_result)),
-      tolerance = 1e-6
-    )
-  }
-)
+test_that("Harvest estimate matches manual survey::svydesign + svytotal (point estimate, tol 1e-6)", {
+  d <- make_box20_6_example1()
+  int_data <- d$interviews
+  # Compute HT harvest contribution per row: harvest * expansion / pi_i
+  # (expansion = 1 for Example 1)
+  int_data$.harvest_contrib <- int_data$fish_kept * int_data$.expansion / int_data$.pi_i
+  svy_manual <- suppressWarnings(
+    survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
+  )
+  manual_result <- survey::svytotal(~.harvest_contrib, svy_manual)
+  tidycreel_result <- suppressWarnings(estimate_harvest_rate(d))
+  expect_equal(
+    tidycreel_result$estimates$estimate,
+    as.numeric(coef(manual_result)),
+    tolerance = 1e-6
+  )
+})
 
-test_that(
-  "Harvest SE matches manual survey::svydesign + svytotal (tol 1e-3)",
-  {
-    d <- make_box20_6_example1()
-    int_data <- d$interviews
-    int_data$.harvest_contrib <- int_data$fish_kept * int_data$.expansion / int_data$.pi_i
-    svy_manual <- suppressWarnings(
-      survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
-    )
-    manual_result <- survey::svytotal(~.harvest_contrib, svy_manual)
-    tidycreel_result <- suppressWarnings(estimate_harvest_rate(d))
-    # Per CONTEXT.md: SE tolerance 1e-3 (FPC differences acceptable)
-    expect_equal(
-      tidycreel_result$estimates$se,
-      as.numeric(survey::SE(manual_result)),
-      tolerance = 1e-3
-    )
-  }
-)
+test_that("Harvest SE matches manual survey::svydesign + svytotal (tol 1e-3)", {
+  d <- make_box20_6_example1()
+  int_data <- d$interviews
+  int_data$.harvest_contrib <- int_data$fish_kept * int_data$.expansion / int_data$.pi_i
+  svy_manual <- suppressWarnings(
+    survey::svydesign(ids = ~1, strata = ~day_type, data = int_data)
+  )
+  manual_result <- survey::svytotal(~.harvest_contrib, svy_manual)
+  tidycreel_result <- suppressWarnings(estimate_harvest_rate(d))
+  # Per CONTEXT.md: SE tolerance 1e-3 (FPC differences acceptable)
+  expect_equal(
+    tidycreel_result$estimates$se,
+    as.numeric(survey::SE(manual_result)),
+    tolerance = 1e-3
+  )
+})
 
 # AIR-04: Aerial effort — constructed numeric validation example ----
 # Malvestuto (1996) Box 20.6 has no aerial worked example (only bus-route).
@@ -502,12 +581,22 @@ make_aerial_box20_6 <- function() {
   # All days are surveyed (every calendar date has a count row).
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend"
     ),
     stringsAsFactors = FALSE
   )
@@ -516,42 +605,52 @@ make_aerial_box20_6 <- function() {
   # E_hat = 111 x 14 = 1554 angler-hours (exact, no rounding).
   counts <- data.frame(
     date = as.Date(c(
-      "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-      "2024-06-08", "2024-06-09"
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-05",
+      "2024-06-06",
+      "2024-06-07",
+      "2024-06-08",
+      "2024-06-09"
     )),
     day_type = c(
-      "weekday", "weekday", "weekday", "weekday", "weekday",
-      "weekend", "weekend"
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekday",
+      "weekend",
+      "weekend"
     ),
     n_anglers = c(10L, 15L, 12L, 8L, 11L, 25L, 30L),
     stringsAsFactors = FALSE
   )
-  design <- creel_design( # nolint: object_usage_linter
+  design <- creel_design(
+    # nolint: object_usage_linter
     calendar = cal,
     date = date, # nolint: object_usage_linter
     strata = day_type, # nolint: object_usage_linter
     survey_type = "aerial",
     h_open = 14
   )
-  add_counts( # nolint: object_usage_linter
+  add_counts(
+    # nolint: object_usage_linter
     design,
     counts
   )
 }
 
-test_that(
-  "AIR-04: estimate_effort() matches hand-calculated svytotal x h_open = 111 x 14 = 1554 angler-hours", # nolint: line_length_linter
-  {
-    # Constructed numeric example verified against hand-calculated formula:
-    # svytotal equals sum of all counts (111 anglers) because all calendar
-    # days are observed (no partial sampling, no FPC). E_hat = 111 x 14 = 1554.
-    # Weekday sum is 56 (10+15+12+8+11); weekend sum is 55 (25+30).
-    # Primary source: Pollock et al. (1994) Ch. 12 provides theoretical basis;
-    # Malvestuto (1996) Box 20.6 has no aerial worked example.
-    fixture <- make_aerial_box20_6()
-    result <- suppressWarnings(estimate_effort(fixture))
-    # E_hat = 111 x 14 = 1554 angler-hours (exact integer result)
-    expect_equal(result$estimates$estimate, 1554, tolerance = 1e-4)
-    expect_true(result$estimates$se > 0)
-  }
-)
+test_that("AIR-04: estimate_effort() matches hand-calculated svytotal x h_open = 111 x 14 = 1554 angler-hours", {
+  # nolint: line_length_linter
+  # Constructed numeric example verified against hand-calculated formula:
+  # svytotal equals sum of all counts (111 anglers) because all calendar
+  # days are observed (no partial sampling, no FPC). E_hat = 111 x 14 = 1554.
+  # Weekday sum is 56 (10+15+12+8+11); weekend sum is 55 (25+30).
+  # Primary source: Pollock et al. (1994) Ch. 12 provides theoretical basis;
+  # Malvestuto (1996) Box 20.6 has no aerial worked example.
+  fixture <- make_aerial_box20_6()
+  result <- suppressWarnings(estimate_effort(fixture))
+  # E_hat = 111 x 14 = 1554 angler-hours (exact integer result)
+  expect_equal(result$estimates$estimate, 1554, tolerance = 1e-4)
+  expect_true(result$estimates$se > 0)
+})

--- a/tests/testthat/test-print-validation.R
+++ b/tests/testthat/test-print-validation.R
@@ -16,14 +16,17 @@ test_that("format.creel_tost_validation returns character vector", {
     trip_duration = runif(50, min = 2, max = 4)
   )
 
-  design_with_interviews <- add_interviews(design, interviews,
+  design_with_interviews <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
 
-  result <- validate_incomplete_trips(design_with_interviews,
+  result <- validate_incomplete_trips(
+    design_with_interviews,
     catch = catch_total,
     effort = hours_fished
   )
@@ -49,14 +52,17 @@ test_that("print method displays plot for ungrouped validation", {
     trip_duration = runif(50, min = 2, max = 4)
   )
 
-  design_with_interviews <- add_interviews(design, interviews,
+  design_with_interviews <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
 
-  result <- validate_incomplete_trips(design_with_interviews,
+  result <- validate_incomplete_trips(
+    design_with_interviews,
     catch = catch_total,
     effort = hours_fished
   )
@@ -84,14 +90,17 @@ test_that("print method displays plot for grouped validation", {
     trip_duration = runif(60, min = 2, max = 4)
   )
 
-  design_with_interviews <- add_interviews(design, interviews,
+  design_with_interviews <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
 
-  result <- validate_incomplete_trips(design_with_interviews,
+  result <- validate_incomplete_trips(
+    design_with_interviews,
     catch = catch_total,
     effort = hours_fished,
     by = location
@@ -117,14 +126,17 @@ test_that("formatted output includes overall test results", {
     trip_duration = runif(50, min = 2, max = 4)
   )
 
-  design_with_interviews <- add_interviews(design, interviews,
+  design_with_interviews <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
 
-  result <- validate_incomplete_trips(design_with_interviews,
+  result <- validate_incomplete_trips(
+    design_with_interviews,
     catch = catch_total,
     effort = hours_fished
   )
@@ -156,14 +168,17 @@ test_that("formatted output includes per-group results if grouped", {
     trip_duration = runif(60, min = 2, max = 4)
   )
 
-  design_with_interviews <- add_interviews(design, interviews,
+  design_with_interviews <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
 
-  result <- validate_incomplete_trips(design_with_interviews,
+  result <- validate_incomplete_trips(
+    design_with_interviews,
     catch = catch_total,
     effort = hours_fished,
     by = location
@@ -192,14 +207,17 @@ test_that("formatted output includes recommendation text", {
     trip_duration = runif(50, min = 2, max = 4)
   )
 
-  design_with_interviews <- add_interviews(design, interviews,
+  design_with_interviews <- add_interviews(
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
 
-  result <- validate_incomplete_trips(design_with_interviews,
+  result <- validate_incomplete_trips(
+    design_with_interviews,
     catch = catch_total,
     effort = hours_fished
   )

--- a/tests/testthat/test-quarto-creel-report-template.R
+++ b/tests/testthat/test-quarto-creel-report-template.R
@@ -1,18 +1,9 @@
 # Tests for the Quarto Creel Report template ----
 
 test_that("Quarto Creel Report template exists and is tidycreel aligned", {
-  template_path <- normalizePath(
-    file.path(
-      "..",
-      "..",
-      "inst",
-      "quarto",
-      "templates",
-      "creel-report",
-      "template.qmd"
-    ),
-    winslash = "/",
-    mustWork = FALSE
+  template_path <- system.file(
+    "quarto", "templates", "creel-report", "template.qmd",
+    package = "tidycreel"
   )
   expect_true(file.exists(template_path))
 

--- a/tests/testthat/test-quarto-creel-report-template.R
+++ b/tests/testthat/test-quarto-creel-report-template.R
@@ -1,0 +1,26 @@
+# Tests for the Quarto Creel Report template ----
+
+test_that("Quarto Creel Report template exists and is tidycreel aligned", {
+  template_path <- normalizePath(
+    file.path(
+      "..",
+      "..",
+      "inst",
+      "quarto",
+      "templates",
+      "creel-report",
+      "template.qmd"
+    ),
+    winslash = "/",
+    mustWork = FALSE
+  )
+  expect_true(file.exists(template_path))
+
+  template <- paste(readLines(template_path, warn = FALSE), collapse = "\n")
+  expect_match(template, "creel_design\\(")
+  expect_match(template, "validation_report\\(")
+  expect_match(template, "season_summary\\(")
+  expect_match(template, "theme = \"creel\"")
+  expect_match(template, "Design Parameters")
+  expect_match(template, "Extrapolated Estimates")
+})

--- a/tests/testthat/test-schedule-generators.R
+++ b/tests/testthat/test-schedule-generators.R
@@ -1,7 +1,10 @@
 test_that("SCHED-01: returns tibble with date, day_type, period_id columns for scalar sampling_rate", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = 0.3, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = 0.3,
+    seed = 42
   )
   expect_s3_class(sched, "creel_schedule")
   expect_s3_class(sched, "data.frame")
@@ -12,13 +15,15 @@ test_that("SCHED-01: returns tibble with date, day_type, period_id columns for s
 
 test_that("SCHED-01: stratified sampling — weekday and weekend proportions match sampling_rate", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
     n_periods = 1,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
   )
   sched_all <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
     n_periods = 1,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42,
@@ -35,13 +40,17 @@ test_that("SCHED-01: stratified sampling — weekday and weekend proportions mat
 
 test_that("SCHED-01: seed reproducibility — same seed + inputs produce identical tibbles", {
   sched1 <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = c(weekday = 0.3, weekend = 0.6),
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
   )
   sched2 <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = c(weekday = 0.3, weekend = 0.6),
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
   )
   expect_equal(sched1, sched2)
@@ -49,12 +58,18 @@ test_that("SCHED-01: seed reproducibility — same seed + inputs produce identic
 
 test_that("SCHED-01: seed reproducibility — different seeds produce different results", {
   sched1 <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 1, sampling_rate = 0.3, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 1,
+    sampling_rate = 0.3,
+    seed = 42
   )
   sched2 <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 1, sampling_rate = 0.3, seed = 99
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 1,
+    sampling_rate = 0.3,
+    seed = 99
   )
   # Different seeds should (almost certainly) produce different row sets
   expect_false(identical(sched1$date, sched2$date))
@@ -62,13 +77,19 @@ test_that("SCHED-01: seed reproducibility — different seeds produce different 
 
 test_that("SCHED-01: expand_periods = FALSE collapses to one row per sampled day", {
   sched_collapsed <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 3, sampling_rate = 0.3, seed = 42,
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 3,
+    sampling_rate = 0.3,
+    seed = 42,
     expand_periods = FALSE
   )
   sched_expanded <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 3, sampling_rate = 0.3, seed = 42,
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 3,
+    sampling_rate = 0.3,
+    seed = 42,
     expand_periods = TRUE
   )
   # Collapsed has one row per unique date; expanded has n_periods rows per date
@@ -78,8 +99,11 @@ test_that("SCHED-01: expand_periods = FALSE collapses to one row per sampled day
 
 test_that("SCHED-01: include_all = TRUE returns full season with sampled logical column", {
   sched_all <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 1, sampling_rate = 0.3, seed = 42,
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 1,
+    sampling_rate = 0.3,
+    seed = 42,
     include_all = TRUE
   )
   # Full season is 92 days (June + July + August)
@@ -90,8 +114,11 @@ test_that("SCHED-01: include_all = TRUE returns full season with sampled logical
 
 test_that("SCHED-01: include_all = FALSE (default) does not include sampled column", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 1, sampling_rate = 0.3, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 1,
+    sampling_rate = 0.3,
+    seed = 42
   )
   expect_false("sampled" %in% names(sched))
 })
@@ -99,8 +126,12 @@ test_that("SCHED-01: include_all = FALSE (default) does not include sampled colu
 test_that("SCHED-01: error when both n_days and sampling_rate supplied", {
   expect_error(
     generate_schedule(
-      start_date = "2024-06-01", end_date = "2024-08-31",
-      n_periods = 2, n_days = 10, sampling_rate = 0.3, seed = 42
+      start_date = "2024-06-01",
+      end_date = "2024-08-31",
+      n_periods = 2,
+      n_days = 10,
+      sampling_rate = 0.3,
+      seed = 42
     ),
     class = "rlang_error"
   )
@@ -109,8 +140,10 @@ test_that("SCHED-01: error when both n_days and sampling_rate supplied", {
 test_that("SCHED-01: error when neither n_days nor sampling_rate supplied", {
   expect_error(
     generate_schedule(
-      start_date = "2024-06-01", end_date = "2024-08-31",
-      n_periods = 2, seed = 42
+      start_date = "2024-06-01",
+      end_date = "2024-08-31",
+      n_periods = 2,
+      seed = 42
     ),
     class = "rlang_error"
   )
@@ -118,8 +151,11 @@ test_that("SCHED-01: error when neither n_days nor sampling_rate supplied", {
 
 test_that("SCHED-01: period_labels supplied — period_id is character", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = 0.3, seed = 42,
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = 0.3,
+    seed = 42,
     period_labels = c("morning", "afternoon")
   )
   expect_type(sched$period_id, "character")
@@ -128,8 +164,11 @@ test_that("SCHED-01: period_labels supplied — period_id is character", {
 
 test_that("SCHED-01: ordered_periods = TRUE — period_id is an ordered factor", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 3, sampling_rate = 0.3, seed = 42,
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 3,
+    sampling_rate = 0.3,
+    seed = 42,
     period_labels = c("morning", "afternoon", "evening"),
     ordered_periods = TRUE
   )
@@ -139,8 +178,11 @@ test_that("SCHED-01: ordered_periods = TRUE — period_id is an ordered factor",
 
 test_that("SCHED-01: output inherits 'creel_schedule' and 'data.frame'", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = 0.3, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = 0.3,
+    seed = 42
   )
   expect_true(inherits(sched, "creel_schedule"))
   expect_true(inherits(sched, "data.frame"))
@@ -148,16 +190,22 @@ test_that("SCHED-01: output inherits 'creel_schedule' and 'data.frame'", {
 
 test_that("SCHED-01: output passes validate_calendar_schema() without error", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = 0.3, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = 0.3,
+    seed = 42
   )
   expect_no_error(validate_creel_schedule(sched))
 })
 
 test_that("SCHED-01: n_days scalar selects correct number of days", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 1, n_days = 10, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 1,
+    n_days = 10,
+    seed = 42
   )
   # n_days = 10 applied uniformly: ~10 weekdays and ~10 weekends selected
   # With 92 days total split ~66 weekdays, 26 weekends
@@ -171,8 +219,11 @@ test_that("SCHED-01: withr scoping — global RNG state unchanged after generate
   x1 <- runif(1)
   set.seed(100)
   generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 1, sampling_rate = 0.3, seed = 42
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 1,
+    sampling_rate = 0.3,
+    seed = 42
   )
   x2 <- runif(1)
   expect_equal(x1, x2)
@@ -180,8 +231,10 @@ test_that("SCHED-01: withr scoping — global RNG state unchanged after generate
 
 test_that("SCHED-01: output passes creel_design() without error", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-08-31",
-    n_periods = 2, sampling_rate = c(weekday = 0.3, weekend = 0.6),
+    start_date = "2024-06-01",
+    end_date = "2024-08-31",
+    n_periods = 2,
+    sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
   )
   expect_no_error(creel_design(sched, date = date, strata = day_type))
@@ -208,8 +261,10 @@ test_that("SCHED-01: output passes creel_design() without error", {
 }
 
 .bus_sched <- function() {
-  generate_schedule( # nolint: object_usage_linter
-    "2024-06-01", "2024-08-31",
+  generate_schedule(
+    # nolint: object_usage_linter
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -220,8 +275,11 @@ test_that("SCHED-02: generate_bus_schedule() returns inclusion_prob column", {
   frame <- .bus_frame_single()
   sched <- .bus_sched()
   result <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 2
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 2
   )
   expect_true("inclusion_prob" %in% names(result))
   expect_true(all(result$inclusion_prob > 0))
@@ -232,8 +290,11 @@ test_that("SCHED-02: output is a plain tibble (not creel_schedule subclass)", {
   frame <- .bus_frame_single()
   sched <- .bus_sched()
   result <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 2
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 2
   )
   expect_false(inherits(result, "creel_schedule"))
   expect_true(is.data.frame(result))
@@ -243,8 +304,11 @@ test_that("SCHED-02: output retains all sampling_frame columns", {
   frame <- .bus_frame_single()
   sched <- .bus_sched()
   result <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 2
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 2
   )
   expect_true("site" %in% names(result))
   expect_true("p_site" %in% names(result))
@@ -254,16 +318,22 @@ test_that("SCHED-02: inclusion_prob = p_site * (crew / n_circuits)", {
   frame <- .bus_frame_single()
   sched <- .bus_sched()
   result <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 2
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 2
   )
   # single circuit → n_circuits = 1; p_period = 2/1 = 2 (capped?  no — crew can exceed 1)
   # Actually p_period = crew / n_circuits = 2/1 = 2, then inclusion_prob = p_site * 2
   # But crew=2 with 1 circuit → p_period=2 → inclusion_prob could exceed 1 for some sites
   # Use crew=1 to get clean values
   result2 <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 1
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 1
   )
   expected <- frame$p_site * (1 / 1)
   expect_equal(result2$inclusion_prob, expected)
@@ -273,8 +343,12 @@ test_that("SCHED-02: multi-circuit formula uses n_circuits in denominator", {
   frame <- .bus_frame_multi_circuit()
   sched <- .bus_sched()
   result <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, circuit = circuit, crew = 1
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    circuit = circuit,
+    crew = 1
   )
   # 2 circuits → p_period = 1/2 = 0.5
   expected <- frame$p_site * 0.5
@@ -285,15 +359,22 @@ test_that("SCHED-02: circuit = NULL treated as single circuit", {
   frame <- .bus_frame_single()
   sched <- .bus_sched()
   result_null <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 1
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 1
   )
   # Equivalent to explicitly using a single circuit
   frame2 <- frame
   frame2$circuit <- "circuit_1"
   result_explicit <- generate_bus_schedule(
-    sched, frame2,
-    site = site, p_site = p_site, circuit = circuit, crew = 1
+    sched,
+    frame2,
+    site = site,
+    p_site = p_site,
+    circuit = circuit,
+    crew = 1
   )
   expect_equal(result_null$inclusion_prob, result_explicit$inclusion_prob)
 })
@@ -321,8 +402,12 @@ test_that("SCHED-02: p_site sums to 1.0 per circuit in multi-circuit case", {
   sched <- .bus_sched()
   expect_error(
     generate_bus_schedule(
-      sched, bad_frame,
-      site = site, p_site = p_site, circuit = circuit, crew = 2
+      sched,
+      bad_frame,
+      site = site,
+      p_site = p_site,
+      circuit = circuit,
+      crew = 2
     ),
     class = "rlang_error"
   )
@@ -332,8 +417,11 @@ test_that("SCHED-02: output passes creel_design(survey_type = 'bus_route')", {
   frame <- .bus_frame_single()
   sched <- .bus_sched()
   result <- generate_bus_schedule(
-    sched, frame,
-    site = site, p_site = p_site, crew = 1
+    sched,
+    frame,
+    site = site,
+    p_site = p_site,
+    crew = 1
   )
   # result has inclusion_prob and p_period columns; use p_period with creel_design
   expect_no_error(
@@ -371,14 +459,15 @@ test_that("SCHED-02: seed argument is accepted without error (reserved for futur
 # Canonical valid inputs: 480 min span (06:00–14:00), 4 windows of 30 min with 10 min gap
 # stratum = 480/4 = 120 min; window_size + min_gap = 40 < 120 — valid
 .ct_valid <- function(seed = 42L) {
-  generate_count_times( # nolint: object_usage_linter
-    start_time  = "06:00",
-    end_time    = "14:00",
-    strategy    = "random",
-    n_windows   = 4L,
+  generate_count_times(
+    # nolint: object_usage_linter
+    start_time = "06:00",
+    end_time = "14:00",
+    strategy = "random",
+    n_windows = 4L,
     window_size = 30L,
-    min_gap     = 10L,
-    seed        = seed
+    min_gap = 10L,
+    seed = seed
   )
 }
 
@@ -396,13 +485,13 @@ test_that("COUNT-TIME-01: random strategy returns creel_schedule with required c
 
 test_that("COUNT-TIME-01: systematic strategy — windows spaced exactly k apart", {
   result <- generate_count_times(
-    start_time  = "06:00",
-    end_time    = "14:00",
-    strategy    = "systematic",
-    n_windows   = 4L,
+    start_time = "06:00",
+    end_time = "14:00",
+    strategy = "systematic",
+    n_windows = 4L,
     window_size = 30L,
-    min_gap     = 10L,
-    seed        = 42L
+    min_gap = 10L,
+    seed = 42L
   )
   expect_s3_class(result, "creel_schedule")
   # Convert start_time to minutes and check spacing
@@ -454,8 +543,12 @@ test_that("COUNT-TIME-02: output passes write_schedule() without error", {
 test_that("COUNT-TIME-03: missing strategy argument throws cli_abort()", {
   expect_error(
     generate_count_times(
-      start_time = "06:00", end_time = "14:00",
-      n_windows = 4L, window_size = 30L, min_gap = 10L, seed = 42L
+      start_time = "06:00",
+      end_time = "14:00",
+      n_windows = 4L,
+      window_size = 30L,
+      min_gap = 10L,
+      seed = 42L
     ),
     class = "rlang_error"
   )
@@ -510,7 +603,12 @@ test_that("COUNT-TIME-04: random strategy — all windows within [start_time, en
 
 test_that("COUNT-TIME-04: systematic strategy — all windows within [start_time, end_time]", {
   result <- generate_count_times(
-    "06:00", "14:00", "systematic", 4L, 30L, 10L,
+    "06:00",
+    "14:00",
+    "systematic",
+    4L,
+    30L,
+    10L,
     seed = 42L
   )
   to_min <- function(hhmm) {
@@ -554,15 +652,21 @@ test_that("COUNT-TIME-04: fixed strategy — overlapping fixed_windows throws cl
 
 # Helpers for ACT tests
 .act_sched <- function() {
-  generate_schedule( # nolint: object_usage_linter
-    start_date = "2024-06-01", end_date = "2024-06-07",
-    n_periods = 2, sampling_rate = 0.5, seed = 1
+  generate_schedule(
+    # nolint: object_usage_linter
+    start_date = "2024-06-01",
+    end_date = "2024-06-07",
+    n_periods = 2,
+    sampling_rate = 0.5,
+    seed = 1
   )
 }
 
 .act_ct <- function() {
-  generate_count_times( # nolint: object_usage_linter
-    start_time = "06:00", end_time = "14:00",
+  generate_count_times(
+    # nolint: object_usage_linter
+    start_time = "06:00",
+    end_time = "14:00",
     strategy = "fixed",
     fixed_windows = data.frame(
       start_time = c("07:00", "10:00", "13:00"),
@@ -622,8 +726,11 @@ test_that("ACT-06: result inherits from both 'creel_schedule' and 'data.frame'",
 
 test_that("ACT-07: count_times from generate_count_times(strategy='fixed') works correctly", {
   sched <- generate_schedule(
-    start_date = "2024-06-01", end_date = "2024-06-07",
-    n_periods = 2, sampling_rate = 0.5, seed = 1
+    start_date = "2024-06-01",
+    end_date = "2024-06-07",
+    n_periods = 2,
+    sampling_rate = 0.5,
+    seed = 1
   )
   ct <- generate_count_times(
     strategy = "fixed",
@@ -727,7 +834,7 @@ test_that("SCHED-LEAP-03: non-leap year 2023-02-26 to 2023-03-02 has 5 dates (no
 
 test_that("SCHED-LEAP-04: creel_design() accepts calendar with 2024-02-29 without error", {
   cal <- data.frame(
-    date     = as.Date(c("2024-02-29", "2024-03-01", "2024-03-02")),
+    date = as.Date(c("2024-02-29", "2024-03-01", "2024-03-02")),
     day_type = c("weekday", "weekend", "weekend")
   )
   expect_no_error(
@@ -737,7 +844,7 @@ test_that("SCHED-LEAP-04: creel_design() accepts calendar with 2024-02-29 withou
 
 test_that("SCHED-LEAP-05: creel_design() Feb 29 calendar date round-trips correctly", {
   cal <- data.frame(
-    date     = as.Date(c("2024-02-28", "2024-02-29", "2024-03-01")),
+    date = as.Date(c("2024-02-28", "2024-02-29", "2024-03-01")),
     day_type = c("weekday", "weekday", "weekend")
   )
   d <- creel_design(cal, date = date, strata = day_type)
@@ -891,8 +998,13 @@ test_that("SCHED-INCL-01: crew/circuit ratio producing inclusion_prob > 1 errors
     p_site = c(0.7, 0.3),
     stringsAsFactors = FALSE
   )
-  sched <- generate_schedule("2024-06-01", "2024-06-07",
-    n_periods = 2, sampling_rate = 0.5, seed = 1)
+  sched <- generate_schedule(
+    "2024-06-01",
+    "2024-06-07",
+    n_periods = 2,
+    sampling_rate = 0.5,
+    seed = 1
+  )
   # crew=2, n_circuits=1 → p_period=2 → inclusion_prob for A = 0.7*2 = 1.4 > 1
   expect_error(
     generate_bus_schedule(sched, frame, site = site, p_site = p_site, crew = 2),
@@ -906,8 +1018,13 @@ test_that("SCHED-INCL-02: crew=1 with p_site <= 0.5 does not error for single ci
     p_site = c(0.5, 0.5),
     stringsAsFactors = FALSE
   )
-  sched <- generate_schedule("2024-06-01", "2024-06-07",
-    n_periods = 2, sampling_rate = 0.5, seed = 1)
+  sched <- generate_schedule(
+    "2024-06-01",
+    "2024-06-07",
+    n_periods = 2,
+    sampling_rate = 0.5,
+    seed = 1
+  )
   expect_no_error(
     generate_bus_schedule(sched, frame, site = site, p_site = p_site, crew = 1)
   )

--- a/tests/testthat/test-schedule-generators.R
+++ b/tests/testthat/test-schedule-generators.R
@@ -881,3 +881,34 @@ test_that("SCHED-SPECIAL-05: fragile special-period declarations warn and attach
   expect_true(all(c("severity", "issue", "stratum") %in% names(diagnostics)))
   expect_true(any(diagnostics$severity %in% c("warning", "warn")))
 })
+
+# SCHED-INCL: inclusion_prob > 1 must error ----------------------------------
+
+test_that("SCHED-INCL-01: crew/circuit ratio producing inclusion_prob > 1 errors", {
+  # p_site sums to 1 (valid), but p_site * crew > 1 for site A
+  frame <- data.frame(
+    site = c("A", "B"),
+    p_site = c(0.7, 0.3),
+    stringsAsFactors = FALSE
+  )
+  sched <- generate_schedule("2024-06-01", "2024-06-07",
+    n_periods = 2, sampling_rate = 0.5, seed = 1)
+  # crew=2, n_circuits=1 → p_period=2 → inclusion_prob for A = 0.7*2 = 1.4 > 1
+  expect_error(
+    generate_bus_schedule(sched, frame, site = site, p_site = p_site, crew = 2),
+    regexp = "exceed.*1|probability|crew"
+  )
+})
+
+test_that("SCHED-INCL-02: crew=1 with p_site <= 0.5 does not error for single circuit", {
+  frame <- data.frame(
+    site = c("A", "B"),
+    p_site = c(0.5, 0.5),
+    stringsAsFactors = FALSE
+  )
+  sched <- generate_schedule("2024-06-01", "2024-06-07",
+    n_periods = 2, sampling_rate = 0.5, seed = 1)
+  expect_no_error(
+    generate_bus_schedule(sched, frame, site = site, p_site = p_site, crew = 1)
+  )
+})

--- a/tests/testthat/test-schedule-io.R
+++ b/tests/testthat/test-schedule-io.R
@@ -2,7 +2,8 @@
 
 test_that("SCHED-03: write_schedule() produces readable CSV file", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -14,7 +15,8 @@ test_that("SCHED-03: write_schedule() produces readable CSV file", {
 
 test_that("SCHED-03: CSV write preserves date column as ISO format", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -31,7 +33,8 @@ test_that("SCHED-03: CSV write preserves date column as ISO format", {
 test_that("SCHED-03: xlsx export works when writexl installed", {
   skip_if_not_installed("writexl")
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -48,7 +51,8 @@ test_that("SCHED-03: informative error when writexl missing and xlsx requested",
     "writexl is installed; cannot test missing-package error path"
   )
   sched <- generate_schedule(
-    "2024-06-01", "2024-06-30",
+    "2024-06-01",
+    "2024-06-30",
     n_periods = 1,
     sampling_rate = 0.5,
     seed = 1
@@ -62,7 +66,8 @@ test_that("SCHED-03: informative error when writexl missing and xlsx requested",
 
 test_that("SCHED-03: write_schedule() returns path invisibly", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -76,7 +81,8 @@ test_that("SCHED-03: write_schedule() returns path invisibly", {
 
 test_that("SCHED-04: read_schedule() returns creel_schedule object from CSV", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -89,7 +95,8 @@ test_that("SCHED-04: read_schedule() returns creel_schedule object from CSV", {
 
 test_that("SCHED-04: column types correct after read (Date, character, integer)", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -104,7 +111,8 @@ test_that("SCHED-04: column types correct after read (Date, character, integer)"
 
 test_that("SCHED-04: round-trip write -> read -> creel_design() succeeds", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -133,7 +141,8 @@ test_that("SCHED-04: read_schedule() handles xlsx files", {
   skip_if_not_installed("writexl")
   skip_if_not_installed("readxl")
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42
@@ -163,7 +172,8 @@ test_that("SCHED-04: coercion handles POSIXct date column", {
 
 test_that("SCHED-04: round-trip for include_all = TRUE schedule (with sampled column)", {
   sched <- generate_schedule(
-    "2024-06-01", "2024-08-31",
+    "2024-06-01",
+    "2024-08-31",
     n_periods = 2,
     sampling_rate = c(weekday = 0.3, weekend = 0.6),
     seed = 42,
@@ -215,4 +225,30 @@ test_that("SCHED-IO-01: read_schedule preserves character period_id without NA c
   expect_type(result$period_id, "character")
   expect_equal(result$period_id, c("AM", "PM"))
   expect_false(any(is.na(result$period_id)))
+})
+
+test_that("SCHED-IO-02: write_schedule() aborts when file exists and overwrite = FALSE", {
+  sched <- generate_schedule(
+    start_date = "2024-06-01",
+    end_date = "2024-06-07",
+    n_periods = 1,
+    sampling_rate = c(weekday = 0.5, weekend = 1.0),
+    seed = 1L
+  )
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  write_schedule(sched, tmp)
+  expect_error(write_schedule(sched, tmp), regexp = "already exists")
+})
+
+test_that("SCHED-IO-03: write_schedule() overwrites when overwrite = TRUE", {
+  sched <- generate_schedule(
+    start_date = "2024-06-01",
+    end_date = "2024-06-07",
+    n_periods = 1,
+    sampling_rate = c(weekday = 0.5, weekend = 1.0),
+    seed = 1L
+  )
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  write_schedule(sched, tmp)
+  expect_no_error(write_schedule(sched, tmp, overwrite = TRUE))
 })

--- a/tests/testthat/test-schedule-io.R
+++ b/tests/testthat/test-schedule-io.R
@@ -201,3 +201,18 @@ test_that("SCHED-04: validation error on period_id = 0", {
   utils::write.csv(df, tmp, row.names = FALSE)
   expect_error(read_schedule(tmp), regexp = "period_id")
 })
+
+test_that("SCHED-IO-01: read_schedule preserves character period_id without NA coercion", {
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  df <- data.frame(
+    date = c("2024-06-01", "2024-06-01"),
+    day_type = c("weekday", "weekday"),
+    period_id = c("AM", "PM"),
+    stringsAsFactors = FALSE
+  )
+  utils::write.csv(df, tmp, row.names = FALSE)
+  result <- read_schedule(tmp)
+  expect_type(result$period_id, "character")
+  expect_equal(result$period_id, c("AM", "PM"))
+  expect_false(any(is.na(result$period_id)))
+})

--- a/tests/testthat/test-season-summary.R
+++ b/tests/testthat/test-season-summary.R
@@ -1,15 +1,14 @@
 # Helper: build minimal creel_estimates objects for testing
-make_est <- function(estimate_val, se_val = 1.0, by_vars = NULL,
-                     effort_target = NULL) {
+make_est <- function(estimate_val, se_val = 1.0, by_vars = NULL, effort_target = NULL) {
   tbl <- tibble::tibble(estimate = estimate_val, se = se_val)
   tidycreel:::new_creel_estimates(
-    estimates       = tbl,
-    method          = "total",
+    estimates = tbl,
+    method = "total",
     variance_method = "taylor",
-    design          = NULL,
-    conf_level      = 0.95,
-    by_vars         = by_vars,
-    effort_target   = effort_target
+    design = NULL,
+    conf_level = 0.95,
+    by_vars = by_vars,
+    effort_target = effort_target
   )
 }
 

--- a/tests/testthat/test-simulate-creel-data.R
+++ b/tests/testthat/test-simulate-creel-data.R
@@ -1,41 +1,63 @@
 test_params <- list(
-  effort         = list(gamma_shape = 2.0, gamma_rate = 0.8),
-  party          = list(mean = 1.5),
+  effort = list(gamma_shape = 2.0, gamma_rate = 0.8),
+  party = list(mean = 1.5),
   catch_per_trip = list(mean = 1.8, nb_size = 0.5),
-  harvest        = list(mean_pct = 35),
-  counts         = list(mean_total_anglers = 10)
+  harvest = list(mean_pct = 35),
+  counts = list(mean_total_anglers = 10)
 )
 
 test_that("simulate_creel_data returns correct structure", {
   sim <- simulate_creel_data(
-    params         = test_params,
-    season_days    = 30L,
+    params = test_params,
+    season_days = 30L,
     n_sampled_days = 5L,
-    seed           = 1L
+    seed = 1L
   )
   expect_named(sim, c("schedule", "interviews", "counts", "catch"))
   expect_s3_class(sim$interviews, "data.frame")
-  expect_s3_class(sim$counts,     "data.frame")
-  expect_s3_class(sim$catch,      "data.frame")
+  expect_s3_class(sim$counts, "data.frame")
+  expect_s3_class(sim$catch, "data.frame")
 })
 
 test_that("simulate_creel_data interviews have required columns", {
-  sim <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 2L)
-  req <- c("date", "day_type", "interview_id", "trip_status", "hours_fished",
-           "trip_duration", "n_anglers", "catch_total", "catch_kept",
-           "species_sought")
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 2L
+  )
+  req <- c(
+    "date",
+    "day_type",
+    "interview_id",
+    "trip_status",
+    "hours_fished",
+    "trip_duration",
+    "n_anglers",
+    "catch_total",
+    "catch_kept",
+    "species_sought"
+  )
   expect_true(all(req %in% names(sim$interviews)))
 })
 
 test_that("simulate_creel_data counts have required columns", {
-  sim <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 3L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 3L
+  )
   expect_true(all(c("date", "day_type", "count_time", "total_anglers") %in% names(sim$counts)))
 })
 
 test_that("simulate_creel_data counts: count_time is 1..n per day", {
   sim <- simulate_creel_data(
-    params = test_params, season_days = 20L, n_sampled_days = 5L,
-    n_counts_per_day = 3L, seed = 3L
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    n_counts_per_day = 3L,
+    seed = 3L
   )
   ct_per_day <- tapply(sim$counts$count_time, sim$counts$date, function(x) sort(x))
   expect_true(all(vapply(ct_per_day, function(x) identical(x, 1:3), logical(1))))
@@ -43,31 +65,53 @@ test_that("simulate_creel_data counts: count_time is 1..n per day", {
 
 test_that("simulate_creel_data catch has required columns", {
   sim <- simulate_creel_data(
-    params = test_params, season_days = 20L, n_sampled_days = 5L,
-    species = c("walleye", "pike"), seed = 4L
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    species = c("walleye", "pike"),
+    seed = 4L
   )
   if (nrow(sim$catch) > 0L) {
-    expect_true(all(c("interview_id", "species", "count", "catch_type") %in%
-                      names(sim$catch)))
+    expect_true(all(
+      c("interview_id", "species", "count", "catch_type") %in%
+        names(sim$catch)
+    ))
     expect_true(all(sim$catch$catch_type %in% c("caught", "harvested", "released")))
   }
 })
 
 test_that("simulate_creel_data date column is Date class", {
-  sim <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 5L)
-  if (nrow(sim$interviews) > 0L) expect_s3_class(sim$interviews$date, "Date")
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 5L
+  )
+  if (nrow(sim$interviews) > 0L) {
+    expect_s3_class(sim$interviews$date, "Date")
+  }
   expect_s3_class(sim$counts$date, "Date")
 })
 
 test_that("simulate_creel_data trip_status is complete or incomplete", {
-  sim <- simulate_creel_data(params = test_params, season_days = 30L, n_sampled_days = 10L, seed = 6L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 10L,
+    seed = 6L
+  )
   if (nrow(sim$interviews) > 0L) {
     expect_true(all(sim$interviews$trip_status %in% c("complete", "incomplete")))
   }
 })
 
 test_that("simulate_creel_data incomplete trips: hours_fished <= trip_duration", {
-  sim <- simulate_creel_data(params = test_params, season_days = 40L, n_sampled_days = 15L, seed = 7L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 40L,
+    n_sampled_days = 15L,
+    seed = 7L
+  )
   if (nrow(sim$interviews) > 0L) {
     inc <- sim$interviews[sim$interviews$trip_status == "incomplete", ]
     if (nrow(inc) > 0L) {
@@ -77,30 +121,53 @@ test_that("simulate_creel_data incomplete trips: hours_fished <= trip_duration",
 })
 
 test_that("simulate_creel_data n_anglers >= 1", {
-  sim <- simulate_creel_data(params = test_params, season_days = 30L, n_sampled_days = 8L, seed = 8L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 8L,
+    seed = 8L
+  )
   if (nrow(sim$interviews) > 0L) {
     expect_true(all(sim$interviews$n_anglers >= 1L))
   }
 })
 
 test_that("simulate_creel_data catch_kept <= catch_total", {
-  sim <- simulate_creel_data(params = test_params, season_days = 30L, n_sampled_days = 10L, seed = 9L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 10L,
+    seed = 9L
+  )
   if (nrow(sim$interviews) > 0L) {
     expect_true(all(sim$interviews$catch_kept <= sim$interviews$catch_total))
   }
 })
 
 test_that("simulate_creel_data is reproducible with seed", {
-  s1 <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 42L)
-  s2 <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 42L)
+  s1 <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 42L
+  )
+  s2 <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 42L
+  )
   expect_identical(s1$interviews, s2$interviews)
   expect_identical(s1$counts, s2$counts)
 })
 
 test_that("simulate_creel_data counts: n_counts_per_day respected", {
   sim <- simulate_creel_data(
-    params = test_params, season_days = 10L, n_sampled_days = 4L,
-    n_counts_per_day = 5L, seed = 10L
+    params = test_params,
+    season_days = 10L,
+    n_sampled_days = 4L,
+    n_counts_per_day = 5L,
+    seed = 10L
   )
   counts_per_day <- table(sim$counts$date)
   expect_true(all(counts_per_day == 5L))
@@ -108,11 +175,11 @@ test_that("simulate_creel_data counts: n_counts_per_day respected", {
 
 test_that("simulate_creel_data respects day_types stratification", {
   sim <- simulate_creel_data(
-    params         = test_params,
-    season_days    = 50L,
+    params = test_params,
+    season_days = 50L,
     n_sampled_days = 20L,
-    day_types      = c(weekday = 5/7, weekend = 2/7),
-    seed           = 11L
+    day_types = c(weekday = 5 / 7, weekend = 2 / 7),
+    seed = 11L
   )
   dtypes <- unique(sim$counts$day_type)
   expect_true(all(dtypes %in% c("weekday", "weekend")))
@@ -120,18 +187,18 @@ test_that("simulate_creel_data respects day_types stratification", {
 
 test_that("simulate_creel_data different params produce different results", {
   hi_effort <- list(
-    effort         = list(gamma_shape = 5.0, gamma_rate = 0.5),
-    party          = list(mean = 1.5),
+    effort = list(gamma_shape = 5.0, gamma_rate = 0.5),
+    party = list(mean = 1.5),
     catch_per_trip = list(mean = 1.8, nb_size = 0.5),
-    harvest        = list(mean_pct = 35),
-    counts         = list(mean_total_anglers = 10)
+    harvest = list(mean_pct = 35),
+    counts = list(mean_total_anglers = 10)
   )
   lo_effort <- list(
-    effort         = list(gamma_shape = 1.0, gamma_rate = 2.0),
-    party          = list(mean = 1.5),
+    effort = list(gamma_shape = 1.0, gamma_rate = 2.0),
+    party = list(mean = 1.5),
     catch_per_trip = list(mean = 1.8, nb_size = 0.5),
-    harvest        = list(mean_pct = 35),
-    counts         = list(mean_total_anglers = 10)
+    harvest = list(mean_pct = 35),
+    counts = list(mean_total_anglers = 10)
   )
   hi <- simulate_creel_data(params = hi_effort, season_days = 60L, n_sampled_days = 20L, seed = 12L)
   lo <- simulate_creel_data(params = lo_effort, season_days = 60L, n_sampled_days = 20L, seed = 12L)
@@ -144,7 +211,9 @@ test_that("simulate_creel_data different params produce different results", {
 
 test_that("simulate_creel_data multi-species splits catch across species", {
   sim <- simulate_creel_data(
-    params = test_params, season_days = 30L, n_sampled_days = 10L,
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 10L,
     species = c("walleye", "pike", "bass"),
     species_weights = c(0.5, 0.3, 0.2),
     seed = 13L
@@ -158,7 +227,10 @@ test_that("simulate_creel_data empty result on 0 encounters is valid", {
   sparse_params <- test_params
   sparse_params$counts$mean_total_anglers <- 0.01
   sim <- simulate_creel_data(
-    params = sparse_params, season_days = 5L, n_sampled_days = 2L, seed = 99L
+    params = sparse_params,
+    season_days = 5L,
+    n_sampled_days = 2L,
+    seed = 99L
   )
   expect_named(sim, c("schedule", "interviews", "counts", "catch"))
 })
@@ -166,7 +238,12 @@ test_that("simulate_creel_data empty result on 0 encounters is valid", {
 # ── schedule component ─────────────────────────────────────────────────────────
 
 test_that("SIM-SCH-01: schedule has required columns and correct types", {
-  sim <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 10L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 10L
+  )
   expect_true(all(c("date", "day_type", "sampled") %in% names(sim$schedule)))
   expect_s3_class(sim$schedule$date, "Date")
   expect_type(sim$schedule$day_type, "character")
@@ -174,31 +251,54 @@ test_that("SIM-SCH-01: schedule has required columns and correct types", {
 })
 
 test_that("SIM-SCH-02: schedule has exactly season_days rows", {
-  sim <- simulate_creel_data(params = test_params, season_days = 45L, n_sampled_days = 10L, seed = 11L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 45L,
+    n_sampled_days = 10L,
+    seed = 11L
+  )
   expect_equal(nrow(sim$schedule), 45L)
 })
 
 test_that("SIM-SCH-03: schedule$sampled TRUE count equals n_sampled_days", {
-  sim <- simulate_creel_data(params = test_params, season_days = 30L, n_sampled_days = 8L, seed = 12L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 8L,
+    seed = 12L
+  )
   expect_equal(sum(sim$schedule$sampled), 8L)
 })
 
 test_that("SIM-SCH-04: sampled days match interview and count dates", {
-  sim <- simulate_creel_data(params = test_params, season_days = 30L, n_sampled_days = 8L, seed = 13L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 8L,
+    seed = 13L
+  )
   sched_sampled_dates <- sim$schedule$date[sim$schedule$sampled]
   count_dates <- unique(sim$counts$date)
   expect_true(all(count_dates %in% sched_sampled_dates))
 })
 
 test_that("SIM-SCH-05: schedule passes validate_calendar_schema (pipeable into creel_design)", {
-  sim <- simulate_creel_data(params = test_params, season_days = 20L, n_sampled_days = 5L, seed = 14L)
+  sim <- simulate_creel_data(
+    params = test_params,
+    season_days = 20L,
+    n_sampled_days = 5L,
+    seed = 14L
+  )
   expect_no_error(creel_design(sim$schedule, date = date, strata = day_type))
 })
 
 test_that("SIM-SCH-06: multi-stratum schedule contains only declared day_type levels", {
   sim <- simulate_creel_data(
-    params = test_params, season_days = 30L, n_sampled_days = 8L,
-    day_types = c(weekday = 5/7, weekend = 2/7), seed = 15L
+    params = test_params,
+    season_days = 30L,
+    n_sampled_days = 8L,
+    day_types = c(weekday = 5 / 7, weekend = 2 / 7),
+    seed = 15L
   )
   expect_true(all(sim$schedule$day_type %in% c("weekday", "weekend")))
 })
@@ -225,7 +325,7 @@ test_that("simulate_creel_catch negbin: all values >= 0", {
 
 test_that("simulate_creel_catch delta: zero proportion matches p_zero approximately", {
   p0 <- 0.45
-  x  <- simulate_creel_catch(n = 2000L, family = "delta", p_zero = p0, seed = 3L)
+  x <- simulate_creel_catch(n = 2000L, family = "delta", p_zero = p0, seed = 3L)
   expect_true(abs(mean(x == 0L) - p0) < 0.05)
 })
 
@@ -241,8 +341,20 @@ test_that("simulate_creel_catch reproducible with seed", {
 })
 
 test_that("simulate_creel_catch proportional var_structure: higher effort → higher mean catch", {
-  lo <- simulate_creel_catch(n = 500L, effort = 1.0, mu = 3, var_structure = "proportional", seed = 5L)
-  hi <- simulate_creel_catch(n = 500L, effort = 5.0, mu = 3, var_structure = "proportional", seed = 5L)
+  lo <- simulate_creel_catch(
+    n = 500L,
+    effort = 1.0,
+    mu = 3,
+    var_structure = "proportional",
+    seed = 5L
+  )
+  hi <- simulate_creel_catch(
+    n = 500L,
+    effort = 5.0,
+    mu = 3,
+    var_structure = "proportional",
+    seed = 5L
+  )
   expect_true(mean(hi) > mean(lo))
 })
 

--- a/tests/testthat/test-single-psu-diagnostic.R
+++ b/tests/testthat/test-single-psu-diagnostic.R
@@ -10,12 +10,13 @@
 # Design where 'weekday' stratum has only 1 PSU (day)
 make_single_psu_design <- function() {
   cal <- data.frame(
-    date     = as.Date(c("2024-06-03", "2024-06-08", "2024-06-09")),
+    date = as.Date(c("2024-06-03", "2024-06-08", "2024-06-09")),
     day_type = c("weekday", "weekend", "weekend")
   )
   design <- suppressWarnings(creel_design(
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "instantaneous"
   ))
   counts <- data.frame(
@@ -32,7 +33,8 @@ make_adequate_design <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     add_counts(design, example_counts) # nolint: object_usage_linter
@@ -76,7 +78,8 @@ test_that("estimate_effort() single-PSU error names a special stratum explicitly
   )
   design <- suppressWarnings(creel_design(
     cal,
-    date = date, strata = analysis_stratum, # nolint: object_usage_linter
+    date = date,
+    strata = analysis_stratum, # nolint: object_usage_linter
     survey_type = "instantaneous"
   ))
   counts <- data.frame(
@@ -110,13 +113,18 @@ test_that("estimate_catch_rate() on adequate design works without PSU error", {
   cal <- data.frame(
     date = as.Date("2024-06-01") + c(0, 5, 6, 7, 12, 13),
     day_type = c(
-      "weekday", "weekend", "weekend",
-      "weekend", "weekday", "weekend"
+      "weekday",
+      "weekend",
+      "weekend",
+      "weekend",
+      "weekday",
+      "weekend"
     )
   )
   design <- suppressWarnings(creel_design(
     cal,
-    date = date, strata = day_type, # nolint: object_usage_linter
+    date = date,
+    strata = day_type, # nolint: object_usage_linter
     survey_type = "instantaneous"
   ))
   counts <- data.frame(
@@ -134,8 +142,10 @@ test_that("estimate_catch_rate() on adequate design works without PSU error", {
     interview_id = seq_len(12L)
   )
   design <- suppressWarnings(add_interviews(
-    design, int,
-    catch = catch, effort = effort, # nolint: object_usage_linter
+    design,
+    int,
+    catch = catch,
+    effort = effort, # nolint: object_usage_linter
     trip_status = trip_status # nolint: object_usage_linter
   ))
   expect_no_error(suppressWarnings(estimate_catch_rate(design)))
@@ -164,9 +174,9 @@ make_repvar_design <- function(n_per_stratum) {
     creel_design(cal, date = date, strata = day_type) # nolint: object_usage_linter
   )
   cnts <- data.frame(
-    date     = dates,
+    date = dates,
     day_type = dts,
-    count    = all_counts[seq_len(2L * n_per_stratum)]
+    count = all_counts[seq_len(2L * n_per_stratum)]
   )
   suppressWarnings(add_counts(d, cnts))
 }

--- a/tests/testthat/test-snapshots.R
+++ b/tests/testthat/test-snapshots.R
@@ -5,7 +5,7 @@
 test_that("print.creel_design snapshot", {
   local_reproducible_output(width = 80)
   cal <- data.frame(
-    date     = as.Date(c("2024-06-01", "2024-06-02")),
+    date = as.Date(c("2024-06-01", "2024-06-02")),
     day_type = c("weekday", "weekend")
   )
   design <- creel_design(cal, date = date, strata = day_type)
@@ -16,42 +16,42 @@ test_that("print.creel_estimates_mor snapshot", {
   local_reproducible_output(width = 80)
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02",
-      "2024-06-03", "2024-06-04"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04"
     )),
     day_type = rep("weekday", 4L)
   )
   design <- creel_design(cal, date = date, strata = day_type)
   # 20 interviews: 10 complete + 10 incomplete (MOR requires >= 10 per filtered set)
   interviews <- data.frame(
-    date          = as.Date(rep("2024-06-01", 20L)),
-    catch_total   = rep(c(2L, 3L, 4L, 5L, 6L), 4L),
-    hours_fished  = rep(c(2.0, 3.0, 4.0, 2.5, 3.5), 4L),
-    trip_status   = rep(c("complete", "incomplete"), 10L),
+    date = as.Date(rep("2024-06-01", 20L)),
+    catch_total = rep(c(2L, 3L, 4L, 5L, 6L), 4L),
+    hours_fished = rep(c(2.0, 3.0, 4.0, 2.5, 3.5), 4L),
+    trip_status = rep(c("complete", "incomplete"), 10L),
     trip_duration = rep(c(2.0, 3.0, 4.0, 2.5, 3.5), 4L)
   )
   design_data <- add_interviews(
-    design, interviews,
+    design,
+    interviews,
     catch = catch_total,
     effort = hours_fished,
     trip_status = trip_status,
     trip_duration = trip_duration
   )
-  result <- estimate_catch_rate(design_data,
-    use_trips = "incomplete",
-    estimator = "mor"
-  )
+  result <- estimate_catch_rate(design_data, use_trips = "incomplete", estimator = "mor")
   expect_snapshot(print(result))
 })
 
 test_that("print.creel_schedule snapshot", {
   local_reproducible_output(width = 80)
   sched <- generate_schedule(
-    start_date    = "2024-06-01",
-    end_date      = "2024-06-30",
-    n_periods     = 1L,
+    start_date = "2024-06-01",
+    end_date = "2024-06-30",
+    n_periods = 1L,
     sampling_rate = c(weekday = 0.5, weekend = 0.8),
-    seed          = 42L
+    seed = 42L
   )
   expect_snapshot(print(sched))
 })

--- a/tests/testthat/test-strata-audit.R
+++ b/tests/testthat/test-strata-audit.R
@@ -1,15 +1,15 @@
 # Two-stratum weekday/weekend pilot reference fixture
-N_h_ref    <- c(weekday = 65, weekend = 28)   # nolint: object_name_linter
-n_h_ref    <- c(weekday = 22, weekend = 14)   # nolint: object_name_linter
-ybar_h_ref <- c(weekday = 50, weekend = 60)   # nolint: object_name_linter
-s2_h_ref   <- c(weekday = 400, weekend = 500) # nolint: object_name_linter
+N_h_ref <- c(weekday = 65, weekend = 28) # nolint: object_name_linter
+n_h_ref <- c(weekday = 22, weekend = 14) # nolint: object_name_linter
+ybar_h_ref <- c(weekday = 50, weekend = 60) # nolint: object_name_linter
+s2_h_ref <- c(weekday = 400, weekend = 500) # nolint: object_name_linter
 rse_target_ref <- 0.20
 
 # Pre-computed RSE values (FPC-corrected)
-SE_wday    <- sqrt((1 - 22 / 65) * 400 / 22)  # nolint: object_name_linter
-RSE_wday   <- SE_wday / 50                     # nolint: object_name_linter
-SE_wend    <- sqrt((1 - 14 / 28) * 500 / 14)  # nolint: object_name_linter
-RSE_wend   <- SE_wend / 60                     # nolint: object_name_linter
+SE_wday <- sqrt((1 - 22 / 65) * 400 / 22) # nolint: object_name_linter
+RSE_wday <- SE_wday / 50 # nolint: object_name_linter
+SE_wend <- sqrt((1 - 14 / 28) * 500 / 14) # nolint: object_name_linter
+RSE_wend <- SE_wend / 60 # nolint: object_name_linter
 
 # --- STRAT-01 / STRAT-04: audit_strata.default ---
 
@@ -20,17 +20,30 @@ test_that("Test A: audit_strata.default returns creel_strata_audit class", {
 
 test_that("Test B: $strata has required column names", {
   result <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref) # nolint: object_name_linter
-  expect_named(result$strata, c("stratum", "N_h", "n_h", "ybar_h", "s2_h", "RSE", "DEFF", "meets_target")) # nolint: object_name_linter
+  expect_named(
+    result$strata,
+    c("stratum", "N_h", "n_h", "ybar_h", "s2_h", "RSE", "DEFF", "meets_target")
+  ) # nolint: object_name_linter
 })
 
 test_that("Test C: weekday RSE matches FPC-corrected reference value", {
   result <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref) # nolint: object_name_linter
-  expect_equal(result$strata$RSE[result$strata$stratum == "weekday"], RSE_wday, tolerance = 1e-10, ignore_attr = TRUE) # nolint: object_name_linter
+  expect_equal(
+    result$strata$RSE[result$strata$stratum == "weekday"],
+    RSE_wday,
+    tolerance = 1e-10,
+    ignore_attr = TRUE
+  ) # nolint: object_name_linter
 })
 
 test_that("Test D: weekend RSE matches FPC-corrected reference value", {
   result <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref) # nolint: object_name_linter
-  expect_equal(result$strata$RSE[result$strata$stratum == "weekend"], RSE_wend, tolerance = 1e-10, ignore_attr = TRUE) # nolint: object_name_linter
+  expect_equal(
+    result$strata$RSE[result$strata$stratum == "weekend"],
+    RSE_wend,
+    tolerance = 1e-10,
+    ignore_attr = TRUE
+  ) # nolint: object_name_linter
 })
 
 test_that("Test E: $n_total equals sum of n_h", {
@@ -42,13 +55,26 @@ test_that("Test E: $n_total equals sum of n_h", {
 test_that("Test F: meets_target is logical and correct for both strata", {
   result <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref) # nolint: object_name_linter
   expect_type(result$strata$meets_target, "logical")
-  expect_equal(result$strata$meets_target[result$strata$stratum == "weekday"], RSE_wday <= rse_target_ref, ignore_attr = TRUE) # nolint: object_name_linter
-  expect_equal(result$strata$meets_target[result$strata$stratum == "weekend"], RSE_wend <= rse_target_ref, ignore_attr = TRUE) # nolint: object_name_linter
+  expect_equal(
+    result$strata$meets_target[result$strata$stratum == "weekday"],
+    RSE_wday <= rse_target_ref,
+    ignore_attr = TRUE
+  ) # nolint: object_name_linter
+  expect_equal(
+    result$strata$meets_target[result$strata$stratum == "weekend"],
+    RSE_wend <= rse_target_ref,
+    ignore_attr = TRUE
+  ) # nolint: object_name_linter
 })
 
 test_that("Test G: $rse_target equals supplied value", {
-  result <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref, # nolint: object_name_linter
-                         rse_target = 0.15)
+  result <- audit_strata(
+    N_h_ref,
+    n_h = n_h_ref,
+    ybar_h = ybar_h_ref,
+    s2_h = s2_h_ref, # nolint: object_name_linter
+    rse_target = 0.15
+  )
   expect_equal(result$rse_target, 0.15)
 })
 
@@ -68,15 +94,21 @@ test_that("Test I: mismatched N_h/n_h lengths fires checkmate error", {
 
 local({
   cal <- data.frame(
-    date     = as.Date(c("2024-01-01", "2024-01-02", "2024-01-03",
-                         "2024-01-06", "2024-01-07", "2024-01-08")),
+    date = as.Date(c(
+      "2024-01-01",
+      "2024-01-02",
+      "2024-01-03",
+      "2024-01-06",
+      "2024-01-07",
+      "2024-01-08"
+    )),
     day_type = c("weekday", "weekday", "weekday", "weekend", "weekend", "weekend")
   )
   design_base <- creel_design(cal, date = date, strata = day_type)
   counts <- data.frame(
-    date     = as.Date(c("2024-01-01", "2024-01-02", "2024-01-06", "2024-01-07")),
+    date = as.Date(c("2024-01-01", "2024-01-02", "2024-01-06", "2024-01-07")),
     day_type = c("weekday", "weekday", "weekend", "weekend"),
-    count    = c(48L, 52L, 57L, 63L)
+    count = c(48L, 52L, 57L, 63L)
   )
   design_with_counts <<- add_counts(design_base, counts)
 })
@@ -88,7 +120,10 @@ test_that("Test J: audit_strata dispatches to creel_design method", {
 
 test_that("Test K: creel_design method returns same structure as default method", {
   result <- audit_strata(design_with_counts)
-  expect_named(result$strata, c("stratum", "N_h", "n_h", "ybar_h", "s2_h", "RSE", "DEFF", "meets_target")) # nolint: object_name_linter
+  expect_named(
+    result$strata,
+    c("stratum", "N_h", "n_h", "ybar_h", "s2_h", "RSE", "DEFF", "meets_target")
+  ) # nolint: object_name_linter
   expect_true(is.numeric(result$deff))
   expect_true(is.integer(result$n_total))
 })
@@ -96,11 +131,11 @@ test_that("Test K: creel_design method returns same structure as default method"
 # --- STRAT-02: simulate_strata_collapse ---
 
 # Three-stratum fixture for collapse tests
-N_h_3    <- c(early = 30, mid = 30, late = 20)    # nolint: object_name_linter
-n_h_3    <- c(early = 10, mid = 12, late = 8)     # nolint: object_name_linter
-ybar_h_3 <- c(early = 40, mid = 45, late = 38)    # nolint: object_name_linter
-s2_h_3   <- c(early = 300, mid = 320, late = 280) # nolint: object_name_linter
-audit_3  <- audit_strata(N_h_3, n_h = n_h_3, ybar_h = ybar_h_3, s2_h = s2_h_3) # nolint: object_name_linter
+N_h_3 <- c(early = 30, mid = 30, late = 20) # nolint: object_name_linter
+n_h_3 <- c(early = 10, mid = 12, late = 8) # nolint: object_name_linter
+ybar_h_3 <- c(early = 40, mid = 45, late = 38) # nolint: object_name_linter
+s2_h_3 <- c(early = 300, mid = 320, late = 280) # nolint: object_name_linter
+audit_3 <- audit_strata(N_h_3, n_h = n_h_3, ybar_h = ybar_h_3, s2_h = s2_h_3) # nolint: object_name_linter
 
 test_that("Test L: simulate_strata_collapse returns tibble with state column", {
   result <- simulate_strata_collapse(audit_3, merge_strata = c("early", "mid"))
@@ -110,9 +145,9 @@ test_that("Test L: simulate_strata_collapse returns tibble with state column", {
 })
 
 test_that("Test M: unmerged strata appear identically in before and after", {
-  result      <- simulate_strata_collapse(audit_3, merge_strata = c("early", "mid"))
+  result <- simulate_strata_collapse(audit_3, merge_strata = c("early", "mid"))
   before_late <- result[result$state == "before" & result$stratum == "late", ]
-  after_late  <- result[result$state == "after"  & result$stratum == "late", ]
+  after_late <- result[result$state == "after" & result$stratum == "late", ]
   expect_equal(nrow(before_late), 1L)
   expect_equal(nrow(after_late), 1L)
   expect_equal(before_late$N_h, after_late$N_h) # nolint: object_name_linter
@@ -120,7 +155,7 @@ test_that("Test M: unmerged strata appear identically in before and after", {
 })
 
 test_that("Test N: merged stratum label is paste(merge_strata, collapse = '+')", {
-  result       <- simulate_strata_collapse(audit_3, merge_strata = c("early", "mid"))
+  result <- simulate_strata_collapse(audit_3, merge_strata = c("early", "mid"))
   after_strata <- result$stratum[result$state == "after"]
   expect_true("early+mid" %in% after_strata)
 })
@@ -171,13 +206,13 @@ test_that("Test U: $strata$DEFF column has same length as number of strata", {
 })
 
 test_that("Test V: $deff matches Var_strat / Var_SRS computed from reference values", {
-  result     <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref) # nolint: object_name_linter
-  N          <- sum(N_h_ref)  # nolint: object_name_linter
-  n          <- sum(n_h_ref)
-  s2_overall <- sum(N_h_ref * s2_h_ref) / N  # nolint: object_name_linter
-  Var_SRS    <- (1 - n / N) * s2_overall / n  # nolint: object_name_linter
-  Var_strat  <- sum((N_h_ref / N)^2 * (1 - n_h_ref / N_h_ref) * s2_h_ref / n_h_ref)  # nolint: object_name_linter
-  deff_ref   <- Var_strat / Var_SRS  # nolint: object_name_linter
+  result <- audit_strata(N_h_ref, n_h = n_h_ref, ybar_h = ybar_h_ref, s2_h = s2_h_ref) # nolint: object_name_linter
+  N <- sum(N_h_ref) # nolint: object_name_linter
+  n <- sum(n_h_ref)
+  s2_overall <- sum(N_h_ref * s2_h_ref) / N # nolint: object_name_linter
+  Var_SRS <- (1 - n / N) * s2_overall / n # nolint: object_name_linter
+  Var_strat <- sum((N_h_ref / N)^2 * (1 - n_h_ref / N_h_ref) * s2_h_ref / n_h_ref) # nolint: object_name_linter
+  deff_ref <- Var_strat / Var_SRS # nolint: object_name_linter
   expect_equal(result$deff, deff_ref, tolerance = 1e-10)
 })
 
@@ -187,9 +222,9 @@ test_that("Test W: @examples call runs without error", {
   expect_no_error(
     audit_strata(
       c(weekday = 65, weekend = 28),
-      n_h    = c(weekday = 22, weekend = 14),
+      n_h = c(weekday = 22, weekend = 14),
       ybar_h = c(50, 60),
-      s2_h   = c(400, 500),
+      s2_h = c(400, 500),
       rse_target = 0.20
     )
   )
@@ -199,8 +234,8 @@ test_that("Test X: reallocate_strata @examples runs without error", {
   expect_no_error(
     reallocate_strata(
       n_total = 36,
-      N_h     = c(weekday = 65, weekend = 28),
-      s2_h    = c(400, 500)
+      N_h = c(weekday = 65, weekend = 28),
+      s2_h = c(400, 500)
     )
   )
 })

--- a/tests/testthat/test-summarize-trips.R
+++ b/tests/testthat/test-summarize-trips.R
@@ -6,7 +6,9 @@ create_trip_design <- function() {
   data(example_interviews, package = "tidycreel", envir = environment())
 
   design <- creel_design(example_calendar, date = date, strata = day_type) # nolint: object_usage_linter
-  add_interviews(design, example_interviews, # nolint: object_usage_linter
+  add_interviews(
+    design,
+    example_interviews, # nolint: object_usage_linter
     catch = catch_total, # nolint: object_usage_linter
     effort = hours_fished, # nolint: object_usage_linter
     harvest = catch_kept, # nolint: object_usage_linter
@@ -119,7 +121,9 @@ test_that("error when design has no trip metadata", {
   data(example_interviews, package = "tidycreel")
 
   design <- creel_design(example_calendar, date = date, strata = day_type)
-  design <- add_interviews(design, example_interviews,
+  design <- add_interviews(
+    design,
+    example_interviews,
     catch = catch_total,
     effort = hours_fished,
     harvest = catch_kept,

--- a/tests/testthat/test-summary-creel-estimates.R
+++ b/tests/testthat/test-summary-creel-estimates.R
@@ -7,7 +7,8 @@ make_effort_est <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     design <- add_counts(design, example_counts) # nolint: object_usage_linter
@@ -20,13 +21,16 @@ make_cpue_est <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     design <- add_counts(design, example_counts) # nolint: object_usage_linter
     design <- add_interviews(
-      design, example_interviews, # nolint: object_usage_linter
-      catch = catch_total, effort = hours_fished, # nolint: object_usage_linter
+      design,
+      example_interviews, # nolint: object_usage_linter
+      catch = catch_total,
+      effort = hours_fished, # nolint: object_usage_linter
       trip_status = trip_status # nolint: object_usage_linter
     )
     estimate_catch_rate(design)
@@ -38,7 +42,8 @@ make_grouped_est <- function() {
     cal <- unique(example_counts[, c("date", "day_type")]) # nolint: object_usage_linter
     design <- creel_design(
       cal,
-      date = date, strata = day_type, # nolint: object_usage_linter
+      date = date,
+      strata = day_type, # nolint: object_usage_linter
       survey_type = "instantaneous"
     )
     design <- add_counts(design, example_counts) # nolint: object_usage_linter

--- a/tests/testthat/test-theme-creel.R
+++ b/tests/testthat/test-theme-creel.R
@@ -37,3 +37,13 @@ test_that("theme_creel() respects custom base size", {
   th <- theme_creel(base_size = 14)
   expect_true(ggplot2::is_theme(th))
 })
+
+test_that("PALETTE-RECYCLE-01: creel_palette(n) at palette-length multiples returns no NA", {
+  n_pal <- length(creel_palette())
+  pal <- creel_palette(n_pal)
+  expect_length(pal, n_pal)
+  expect_false(any(is.na(pal)))
+  pal2 <- creel_palette(n_pal * 2L)
+  expect_length(pal2, n_pal * 2L)
+  expect_false(any(is.na(pal2)))
+})

--- a/tests/testthat/test-tidy-creel-estimates.R
+++ b/tests/testthat/test-tidy-creel-estimates.R
@@ -7,8 +7,8 @@
     build_br_design_for_tests(3L, 6L, 8L, seed = 42L)
   ))
   counts <- data.frame(
-    date      = d$calendar$date,
-    day_type  = d$calendar$day_type,
+    date = d$calendar$date,
+    day_type = d$calendar$day_type,
     effort_hours = c(15, 20, 18, 22, 16, 19),
     stringsAsFactors = FALSE
   )
@@ -27,11 +27,12 @@
   d <- suppressWarnings(add_counts(d, example_counts)) # nolint
   d <- suppressWarnings(
     add_interviews(
-      d, example_interviews, # nolint
-      catch         = catch_total,    # nolint
-      effort        = hours_fished,   # nolint
-      trip_status   = trip_status,    # nolint
-      trip_duration = trip_duration   # nolint
+      d,
+      example_interviews, # nolint
+      catch = catch_total, # nolint
+      effort = hours_fished, # nolint
+      trip_status = trip_status, # nolint
+      trip_duration = trip_duration # nolint
     )
   )
   suppressWarnings(estimate_total_catch(d))
@@ -69,12 +70,13 @@ test_that("TIDY-03: tidy(estimate_angler_n) returns flat tibble", {
 
 # ---- TIDY-04: estimate_mr_harvest() -----------------------------------------
 
-test_that("TIDY-04: tidy(estimate_mr_harvest) returns flat tibble", {
+test_that("TIDY-04: tidy(estimate_mr_harvest) returns flat tibble with n = NA", {
   angler_n <- estimate_angler_n(M = 200L, n = 50L, m = 10L)
-  result   <- tidy(estimate_mr_harvest(angler_n = angler_n, harvest_rate = 0.35))
+  result <- tidy(estimate_mr_harvest(angler_n = angler_n, harvest_rate = 0.35))
   expect_s3_class(result, "tbl_df")
   expect_false(any(vapply(result, is.list, logical(1L))))
-  expect_true(all(c("estimate", "se", "ci_lower", "ci_upper") %in% names(result)))
+  expect_true(all(c("estimate", "se", "ci_lower", "ci_upper", "n") %in% names(result)))
+  expect_true(all(is.na(result$n)))
   expect_gt(nrow(result), 0L)
 })
 
@@ -83,11 +85,11 @@ test_that("TIDY-04: tidy(estimate_mr_harvest) returns flat tibble", {
 test_that("TIDY-05: tidy(estimate_exploitation_rate) returns flat tibble", {
   result <- tidy(
     estimate_exploitation_rate(
-      T      = 200L,
-      C      = 450.0,
-      se_C   = 42.0,
-      n      = 180L,
-      m      = 15L
+      T = 200L,
+      C = 450.0,
+      se_C = 42.0,
+      n = 180L,
+      m = 15L
     )
   )
   expect_s3_class(result, "tbl_df")

--- a/tests/testthat/test-tier2-interviews.R
+++ b/tests/testthat/test-tier2-interviews.R
@@ -6,7 +6,9 @@ make_tier2_test_calendar <- function() {
   data.frame(
     date = dates,
     day_type = ifelse(
-      weekdays(dates) %in% c("Saturday", "Sunday"), "weekend", "weekday"
+      weekdays(dates) %in% c("Saturday", "Sunday"),
+      "weekend",
+      "weekday"
     ),
     stringsAsFactors = FALSE
   )
@@ -23,8 +25,14 @@ test_that("no warnings for clean interview data", {
   design <- make_tier2_test_design()
   clean_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04",
-      "2025-07-05", "2025-07-06", "2025-07-07", "2025-07-08"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04",
+      "2025-07-05",
+      "2025-07-06",
+      "2025-07-07",
+      "2025-07-08"
     )),
     hours_fished = c(2.0, 2.5, 3.0, 1.5, 2.0, 2.5, 3.0, 1.5),
     catch_total = c(5, 3, 7, 2, 6, 4, 8, 1),
@@ -37,7 +45,9 @@ test_that("no warnings for clean interview data", {
   # Use suppressWarnings to hide survey package warnings, then check no warnings
   # were produced by warn_tier2_interview_issues
   result <- suppressWarnings({
-    add_interviews(design, clean_interviews,
+    add_interviews(
+      design,
+      clean_interviews,
       catch = catch_total,
       effort = hours_fished,
       trip_status = trip_status,
@@ -52,7 +62,10 @@ test_that("warning for very short trips (effort < 0.1 hours)", {
   design <- make_tier2_test_design()
   short_trip_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04"
     )),
     hours_fished = c(0.05, 2.0, 0.08, 2.5), # Two very short trips
     catch_total = c(1, 5, 1, 3),
@@ -62,9 +75,13 @@ test_that("warning for very short trips (effort < 0.1 hours)", {
   )
 
   expect_warning(
-    add_interviews(design, short_trip_interviews,
+    add_interviews(
+      design,
+      short_trip_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "2 interviews have effort < 0.1 hours"
   )
@@ -74,7 +91,10 @@ test_that("warning for zero catch values", {
   design <- make_tier2_test_design()
   zero_catch_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04"
     )),
     hours_fished = c(2.0, 2.5, 3.0, 1.5),
     catch_total = c(0, 5, 0, 3), # Two zero catch
@@ -84,9 +104,13 @@ test_that("warning for zero catch values", {
   )
 
   expect_warning(
-    add_interviews(design, zero_catch_interviews,
+    add_interviews(
+      design,
+      zero_catch_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "2 interviews have zero catch"
   )
@@ -96,7 +120,10 @@ test_that("warning for negative catch values", {
   design <- make_tier2_test_design()
   negative_catch_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04"
     )),
     hours_fished = c(2.0, 2.5, 3.0, 1.5),
     catch_total = c(-1, 5, 3, 2), # One negative catch
@@ -106,9 +133,13 @@ test_that("warning for negative catch values", {
   )
 
   expect_warning(
-    add_interviews(design, negative_catch_interviews,
+    add_interviews(
+      design,
+      negative_catch_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "1 interview has negative catch"
   )
@@ -118,7 +149,10 @@ test_that("warning for negative effort values", {
   design <- make_tier2_test_design()
   negative_effort_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04"
     )),
     hours_fished = c(-0.5, 2.0, 2.5, 3.0), # One negative effort
     catch_total = c(5, 3, 7, 2),
@@ -128,9 +162,13 @@ test_that("warning for negative effort values", {
   )
 
   expect_warning(
-    add_interviews(design, negative_effort_interviews,
+    add_interviews(
+      design,
+      negative_effort_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "1 interview has negative effort"
   )
@@ -140,7 +178,10 @@ test_that("warning for missing effort values (NA)", {
   design <- make_tier2_test_design()
   missing_effort_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04"
     )),
     hours_fished = c(NA, 2.0, NA, 2.5), # Two missing effort
     catch_total = c(5, 3, 7, 2),
@@ -150,9 +191,13 @@ test_that("warning for missing effort values (NA)", {
   )
 
   expect_warning(
-    add_interviews(design, missing_effort_interviews,
+    add_interviews(
+      design,
+      missing_effort_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "2 interviews have missing effort"
   )
@@ -162,7 +207,8 @@ test_that("warning for sparse strata (< 3 interviews per stratum)", {
   design <- make_tier2_test_design()
   sparse_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", # 2 weekdays
+      "2025-07-01",
+      "2025-07-02", # 2 weekdays
       "2025-07-05" # 1 weekend (sparse)
     )),
     hours_fished = c(2.0, 2.5, 3.0),
@@ -173,9 +219,13 @@ test_that("warning for sparse strata (< 3 interviews per stratum)", {
   )
 
   expect_warning(
-    add_interviews(design, sparse_interviews,
+    add_interviews(
+      design,
+      sparse_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "2 strata have fewer than 3 interviews"
   )
@@ -185,7 +235,9 @@ test_that("multiple warnings issued simultaneously", {
   design <- make_tier2_test_design()
   problematic_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03"
     )),
     hours_fished = c(0.05, -1.0, 2.0),
     catch_total = c(5, 0, -2),
@@ -196,9 +248,13 @@ test_that("multiple warnings issued simultaneously", {
 
   # Should produce multiple warnings
   expect_warning(
-    add_interviews(design, problematic_interviews,
+    add_interviews(
+      design,
+      problematic_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     ),
     "interview" # At least one warning will mention "interview"
   )
@@ -208,7 +264,10 @@ test_that("warnings do NOT prevent add_interviews() from succeeding", {
   design <- make_tier2_test_design()
   problematic_interviews <- data.frame(
     date = as.Date(c(
-      "2025-07-01", "2025-07-02", "2025-07-03", "2025-07-04"
+      "2025-07-01",
+      "2025-07-02",
+      "2025-07-03",
+      "2025-07-04"
     )),
     hours_fished = c(0.05, NA, -1.0, 2.0), # Multiple issues
     catch_total = c(0, -1, 5, 2),
@@ -219,9 +278,13 @@ test_that("warnings do NOT prevent add_interviews() from succeeding", {
 
   # Should return a valid creel_design despite warnings
   suppressWarnings({
-    result <- add_interviews(design, problematic_interviews,
+    result <- add_interviews(
+      design,
+      problematic_interviews,
       catch = catch_total,
-      effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration
+      effort = hours_fished,
+      trip_status = trip_status,
+      trip_duration = trip_duration
     )
   })
 

--- a/tests/testthat/test-validate-creel-data.R
+++ b/tests/testthat/test-validate-creel-data.R
@@ -52,7 +52,7 @@ test_that("VCDV-04: errors on invalid na_threshold", {
 test_that("VCDV-05: errors on invalid date_range", {
   expect_error(
     validate_creel_data(
-      counts     = make_counts(),
+      counts = make_counts(),
       date_range = c("2020-01-01", "2025-01-01")
     ),
     class = "creel_error_design_validation"
@@ -74,7 +74,7 @@ test_that("VCDV-07: result has expected columns", {
 
 test_that("VCDV-08: status values are restricted to pass/warn/fail", {
   res <- validate_creel_data(
-    counts     = make_counts(),
+    counts = make_counts(),
     interviews = make_interviews()
   )
   expect_true(all(res$status %in% c("pass", "warn", "fail")))
@@ -82,7 +82,7 @@ test_that("VCDV-08: status values are restricted to pass/warn/fail", {
 
 test_that("VCDV-09: table column identifies source correctly", {
   res <- validate_creel_data(
-    counts     = make_counts(),
+    counts = make_counts(),
     interviews = make_interviews()
   )
   expect_true("counts" %in% res$table)
@@ -93,7 +93,7 @@ test_that("VCDV-09: table column identifies source correctly", {
 
 test_that("VCDV-10: high NA rate triggers warn status", {
   df <- data.frame(
-    date  = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
     count = c(NA_integer_, NA_integer_, 1L)
   )
   res <- validate_creel_data(counts = df, na_threshold = 0.10)
@@ -111,7 +111,7 @@ test_that("VCDV-11: NA rate below threshold is pass", {
 
 test_that("VCDV-12: out-of-range dates trigger warn", {
   df <- data.frame(
-    date  = as.Date(c("1900-01-01", "2024-06-01")),
+    date = as.Date(c("1900-01-01", "2024-06-01")),
     count = c(5L, 10L)
   )
   res <- validate_creel_data(counts = df)
@@ -127,14 +127,14 @@ test_that("VCDV-13: in-range dates are pass", {
 
 # Negative values check -------------------------------------------------------
 
-test_that("VCDV-14: negative numeric values trigger warn", {
+test_that("VCDV-14: negative numeric values trigger fail", {
   df <- data.frame(
-    date  = as.Date("2024-06-01"),
+    date = as.Date("2024-06-01"),
     count = -5L
   )
   res <- validate_creel_data(counts = df)
   neg_row <- res[res$column == "count" & res$check == "negative_values", ]
-  expect_equal(neg_row$status, "warn")
+  expect_equal(neg_row$status, "fail")
 })
 
 test_that("VCDV-15: non-negative numerics are pass", {
@@ -201,7 +201,7 @@ test_that("VCDV-22: interviews-only call works (no counts)", {
 
 test_that("VCDV-23: single-row data frame is handled without error", {
   df <- data.frame(
-    date  = as.Date("2024-06-01"),
+    date = as.Date("2024-06-01"),
     count = 5L
   )
   expect_no_error(validate_creel_data(counts = df))
@@ -209,7 +209,7 @@ test_that("VCDV-23: single-row data frame is handled without error", {
 
 test_that("VCDV-24: factor column gets empty_strings check", {
   df <- data.frame(
-    date    = as.Date("2024-06-01"),
+    date = as.Date("2024-06-01"),
     species = factor("walleye")
   )
   res <- validate_creel_data(interviews = df)
@@ -218,7 +218,7 @@ test_that("VCDV-24: factor column gets empty_strings check", {
 
 test_that("VCDV-25: all-NA column still produces rows", {
   df <- data.frame(
-    date  = as.Date(c("2024-06-01", "2024-06-02")),
+    date = as.Date(c("2024-06-01", "2024-06-02")),
     count = c(NA_integer_, NA_integer_)
   )
   res <- validate_creel_data(counts = df)

--- a/tests/testthat/test-validate-incomplete-trips.R
+++ b/tests/testthat/test-validate-incomplete-trips.R
@@ -493,3 +493,36 @@ test_that("plot_data passed status matches per-group results for grouped estimat
   expect_equal(sum(plot_data$passed), 1)
   expect_equal(sum(!plot_data$passed), 1)
 })
+
+# TOST-DEGEN: degenerate TOST cases must not crash ---------------------------
+
+test_that("TOST-DEGEN-01: se_diff=0 (identical estimates) returns equivalence_passed TRUE within bounds", {
+  result <- perform_tost(
+    complete_estimate = 1.0, complete_se = 0,
+    incomplete_estimate = 1.0, incomplete_se = 0,
+    threshold = 0.10, n_complete = 5, n_incomplete = 5
+  )
+  expect_true(result$equivalence_passed)
+  expect_equal(result$se_diff, 0)
+})
+
+test_that("TOST-DEGEN-02: se_diff=0 but diff outside bounds returns equivalence_passed FALSE", {
+  result <- perform_tost(
+    complete_estimate = 2.0, complete_se = 0,
+    incomplete_estimate = 1.0, incomplete_se = 0,
+    threshold = 0.10, n_complete = 5, n_incomplete = 5
+  )
+  expect_false(result$equivalence_passed)
+})
+
+test_that("TOST-DEGEN-03: df <= 0 (n=1 group) warns and returns NA equivalence_passed", {
+  expect_warning(
+    result <- perform_tost(
+      complete_estimate = 1.0, complete_se = 0.1,
+      incomplete_estimate = 0.9, incomplete_se = 0.1,
+      threshold = 0.10, n_complete = 1, n_incomplete = 1
+    ),
+    class = "creel_warn_tost_degenerate"
+  )
+  expect_true(is.na(result$equivalence_passed))
+})

--- a/tests/testthat/test-validate-incomplete-trips.R
+++ b/tests/testthat/test-validate-incomplete-trips.R
@@ -6,8 +6,14 @@ make_validation_design <- function(n_complete = 50, n_incomplete = 50, cpue_diff
   # Calendar with sufficient dates
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     stringsAsFactors = FALSE
@@ -32,7 +38,10 @@ make_validation_design <- function(n_complete = 50, n_incomplete = 50, cpue_diff
 
   # Combine complete and incomplete trips
   interviews <- data.frame(
-    date = as.Date(rep(c("2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04"), length.out = n_total)),
+    date = as.Date(rep(
+      c("2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04"),
+      length.out = n_total
+    )),
     catch_total = c(complete_catch, incomplete_catch),
     hours_fished = c(complete_effort, incomplete_effort),
     trip_status = c(rep("complete", n_complete), rep("incomplete", n_incomplete)),
@@ -40,7 +49,14 @@ make_validation_design <- function(n_complete = 50, n_incomplete = 50, cpue_diff
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 #' Create grouped validation design
@@ -48,8 +64,14 @@ make_grouped_validation_design <- function(group_a_diff = 0, group_b_diff = 0) {
   # Calendar with two groups
   cal <- data.frame(
     date = as.Date(c(
-      "2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04",
-      "2024-06-08", "2024-06-09", "2024-06-15", "2024-06-16"
+      "2024-06-01",
+      "2024-06-02",
+      "2024-06-03",
+      "2024-06-04",
+      "2024-06-08",
+      "2024-06-09",
+      "2024-06-15",
+      "2024-06-16"
     )),
     day_type = rep(c("weekday", "weekend"), each = 4),
     location = rep(c("site_a", "site_b"), times = 4),
@@ -81,25 +103,41 @@ make_grouped_validation_design <- function(group_a_diff = 0, group_b_diff = 0) {
 
   # Combine all
   interviews <- data.frame(
-    date = as.Date(rep(c("2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04"), length.out = 120)),
+    date = as.Date(rep(
+      c("2024-06-01", "2024-06-02", "2024-06-03", "2024-06-04"),
+      length.out = 120
+    )),
     location = rep(c("site_a", "site_b"), each = 60),
     catch_total = c(
-      site_a_complete_catch, site_a_incomplete_catch,
-      site_b_complete_catch, site_b_incomplete_catch
+      site_a_complete_catch,
+      site_a_incomplete_catch,
+      site_b_complete_catch,
+      site_b_incomplete_catch
     ),
     hours_fished = c(
-      site_a_complete_effort, site_a_incomplete_effort,
-      site_b_complete_effort, site_b_incomplete_effort
+      site_a_complete_effort,
+      site_a_incomplete_effort,
+      site_b_complete_effort,
+      site_b_incomplete_effort
     ),
     trip_status = rep(c(rep("complete", 30), rep("incomplete", 30)), times = 2),
     trip_duration = c(
-      site_a_complete_effort, site_a_incomplete_effort,
-      site_b_complete_effort, site_b_incomplete_effort
+      site_a_complete_effort,
+      site_a_incomplete_effort,
+      site_b_complete_effort,
+      site_b_incomplete_effort
     ),
     stringsAsFactors = FALSE
   )
 
-  add_interviews(design, interviews, catch = catch_total, effort = hours_fished, trip_status = trip_status, trip_duration = trip_duration) # nolint: object_usage_linter
+  add_interviews(
+    design,
+    interviews,
+    catch = catch_total,
+    effort = hours_fished,
+    trip_status = trip_status,
+    trip_duration = trip_duration
+  ) # nolint: object_usage_linter
 }
 
 # Basic functionality tests ----
@@ -212,7 +250,12 @@ test_that("default equivalence threshold is 0.20", {
 test_that("validate_incomplete_trips handles grouped estimation", {
   design <- make_grouped_validation_design(group_a_diff = 0, group_b_diff = 0)
 
-  result <- validate_incomplete_trips(design, catch = catch_total, effort = hours_fished, by = location)
+  result <- validate_incomplete_trips(
+    design,
+    catch = catch_total,
+    effort = hours_fished,
+    by = location
+  )
 
   # Should have group_tests component
   expect_true("group_tests" %in% names(result))
@@ -230,7 +273,12 @@ test_that("grouped validation requires all groups to pass", {
   # Site B: different (diff = 1.0)
   design <- make_grouped_validation_design(group_a_diff = 0, group_b_diff = 1.0)
 
-  result <- validate_incomplete_trips(design, catch = catch_total, effort = hours_fished, by = location)
+  result <- validate_incomplete_trips(
+    design,
+    catch = catch_total,
+    effort = hours_fished,
+    by = location
+  )
 
   # Overall should fail because site_b fails
   expect_false(result$passed)
@@ -248,7 +296,12 @@ test_that("grouped validation passes when all groups pass", {
   # Both groups identical
   design <- make_grouped_validation_design(group_a_diff = 0, group_b_diff = 0)
 
-  result <- validate_incomplete_trips(design, catch = catch_total, effort = hours_fished, by = location)
+  result <- validate_incomplete_trips(
+    design,
+    catch = catch_total,
+    effort = hours_fished,
+    by = location
+  )
 
   # Overall should pass
   expect_true(result$passed)
@@ -345,10 +398,14 @@ test_that("metadata includes all required fields", {
   result <- validate_incomplete_trips(design, catch = catch_total, effort = hours_fished)
 
   # Complete trip metadata
-  expect_true(all(c("n", "estimate", "se", "ci_lower", "ci_upper") %in% names(result$metadata$complete)))
+  expect_true(all(
+    c("n", "estimate", "se", "ci_lower", "ci_upper") %in% names(result$metadata$complete)
+  ))
 
   # Incomplete trip metadata
-  expect_true(all(c("n", "estimate", "se", "ci_lower", "ci_upper") %in% names(result$metadata$incomplete)))
+  expect_true(all(
+    c("n", "estimate", "se", "ci_lower", "ci_upper") %in% names(result$metadata$incomplete)
+  ))
 
   # Sample sizes should be correct
   expect_equal(result$metadata$complete$n, 50)
@@ -415,7 +472,8 @@ test_that("plot_data has correct structure for ungrouped estimation", {
 
 test_that("plot_data has correct structure for grouped estimation", {
   design <- make_grouped_validation_design(group_a_diff = 0, group_b_diff = 0)
-  result <- validate_incomplete_trips(design,
+  result <- validate_incomplete_trips(
+    design,
     catch = catch_total,
     effort = hours_fished,
     by = location
@@ -481,7 +539,8 @@ test_that("plot_data includes passed status for annotation", {
 test_that("plot_data passed status matches per-group results for grouped estimation", {
   # Mixed results: group A passes, group B fails
   design <- make_grouped_validation_design(group_a_diff = 0, group_b_diff = 1.0)
-  result <- validate_incomplete_trips(design,
+  result <- validate_incomplete_trips(
+    design,
     catch = catch_total,
     effort = hours_fished,
     by = location
@@ -498,9 +557,13 @@ test_that("plot_data passed status matches per-group results for grouped estimat
 
 test_that("TOST-DEGEN-01: se_diff=0 (identical estimates) returns equivalence_passed TRUE within bounds", {
   result <- perform_tost(
-    complete_estimate = 1.0, complete_se = 0,
-    incomplete_estimate = 1.0, incomplete_se = 0,
-    threshold = 0.10, n_complete = 5, n_incomplete = 5
+    complete_estimate = 1.0,
+    complete_se = 0,
+    incomplete_estimate = 1.0,
+    incomplete_se = 0,
+    threshold = 0.10,
+    n_complete = 5,
+    n_incomplete = 5
   )
   expect_true(result$equivalence_passed)
   expect_equal(result$se_diff, 0)
@@ -508,9 +571,13 @@ test_that("TOST-DEGEN-01: se_diff=0 (identical estimates) returns equivalence_pa
 
 test_that("TOST-DEGEN-02: se_diff=0 but diff outside bounds returns equivalence_passed FALSE", {
   result <- perform_tost(
-    complete_estimate = 2.0, complete_se = 0,
-    incomplete_estimate = 1.0, incomplete_se = 0,
-    threshold = 0.10, n_complete = 5, n_incomplete = 5
+    complete_estimate = 2.0,
+    complete_se = 0,
+    incomplete_estimate = 1.0,
+    incomplete_se = 0,
+    threshold = 0.10,
+    n_complete = 5,
+    n_incomplete = 5
   )
   expect_false(result$equivalence_passed)
 })
@@ -518,9 +585,13 @@ test_that("TOST-DEGEN-02: se_diff=0 but diff outside bounds returns equivalence_
 test_that("TOST-DEGEN-03: df <= 0 (n=1 group) warns and returns NA equivalence_passed", {
   expect_warning(
     result <- perform_tost(
-      complete_estimate = 1.0, complete_se = 0.1,
-      incomplete_estimate = 0.9, incomplete_se = 0.1,
-      threshold = 0.10, n_complete = 1, n_incomplete = 1
+      complete_estimate = 1.0,
+      complete_se = 0.1,
+      incomplete_estimate = 0.9,
+      incomplete_se = 0.1,
+      threshold = 0.10,
+      n_complete = 1,
+      n_incomplete = 1
     ),
     class = "creel_warn_tost_degenerate"
   )

--- a/tests/testthat/test-validation-guard.R
+++ b/tests/testthat/test-validation-guard.R
@@ -6,7 +6,8 @@
 # Resolve the absolute path to the script before any with_dir() changes cwd.
 # system.file() works because tidycreel is loaded during devtools::test().
 script_path <- system.file(
-  "validation", "calamus-2016-validation.R",
+  "validation",
+  "calamus-2016-validation.R",
   package = "tidycreel",
   mustWork = TRUE
 )
@@ -53,7 +54,8 @@ test_that("validation script passes WD guard when run from package root", {
         grepl("DESCRIPTION", conditionMessage(caught)),
         info = paste(
           "DESCRIPTION guard must not fire from package root;",
-          "actual error:", conditionMessage(caught)
+          "actual error:",
+          conditionMessage(caught)
         )
       )
     } else {

--- a/tests/testthat/test-validation-report.R
+++ b/tests/testthat/test-validation-report.R
@@ -1,10 +1,7 @@
 # Tests for validation_report() ----
 # Note: requires validate_creel_data() and standardize_species() from M016 S01/S02.
 # Skip entire file when those functions are not yet available.
-if (!exists("validate_creel_data",
-  mode = "function",
-  where = asNamespace("tidycreel")
-)) {
+if (!exists("validate_creel_data", mode = "function", where = asNamespace("tidycreel"))) {
   skip("validate_creel_data() not available; skipping validation_report tests")
 }
 
@@ -50,7 +47,7 @@ test_that("VRPT-03: result has expected columns", {
 
 test_that("VRPT-04: one row per unique table x check combination", {
   rpt <- validation_report(
-    counts     = make_counts(),
+    counts = make_counts(),
     interviews = make_interviews()
   )
   combos <- paste(rpt$table, rpt$check)
@@ -64,7 +61,7 @@ test_that("VRPT-05: counts-only produces table == 'counts' rows", {
 
 test_that("VRPT-06: both inputs produce rows for both tables", {
   rpt <- validation_report(
-    counts     = make_counts(),
+    counts = make_counts(),
     interviews = make_interviews()
   )
   expect_true("counts" %in% rpt$table)
@@ -81,7 +78,7 @@ test_that("VRPT-07: n_pass + n_warn + n_fail > 0 for every row", {
 
 test_that("VRPT-08: species_col adds a species table row", {
   rpt <- validation_report(
-    interviews  = make_interviews(),
+    interviews = make_interviews(),
     species_col = "species"
   )
   expect_true("species" %in% rpt$table)
@@ -89,7 +86,7 @@ test_that("VRPT-08: species_col adds a species table row", {
 
 test_that("VRPT-09: species coverage detail contains percentage", {
   rpt <- validation_report(
-    interviews  = make_interviews(),
+    interviews = make_interviews(),
     species_col = "species"
   )
   sp_row <- rpt[rpt$table == "species", ]
@@ -99,7 +96,7 @@ test_that("VRPT-09: species coverage detail contains percentage", {
 test_that("VRPT-10: missing species_col warns and skips species row", {
   expect_warning(
     rpt <- validation_report(
-      interviews  = make_interviews(),
+      interviews = make_interviews(),
       species_col = "nonexistent"
     )
   )
@@ -108,7 +105,7 @@ test_that("VRPT-10: missing species_col warns and skips species row", {
 
 test_that("VRPT-11: species_col ignored when interviews is NULL", {
   rpt <- validation_report(
-    counts      = make_counts(),
+    counts = make_counts(),
     species_col = "species"
   )
   expect_false("species" %in% rpt$table)
@@ -118,7 +115,7 @@ test_that("VRPT-11: species_col ignored when interviews is NULL", {
 
 test_that("VRPT-12: high NA rate shows in n_warn", {
   df <- data.frame(
-    date  = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
     count = c(NA_integer_, NA_integer_, 1L)
   )
   rpt <- validation_report(counts = df, na_threshold = 0.10)
@@ -128,7 +125,7 @@ test_that("VRPT-12: high NA rate shows in n_warn", {
 
 test_that("VRPT-13: flagged columns named in detail field", {
   df <- data.frame(
-    date  = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
+    date = as.Date(c("2024-06-01", "2024-06-02", "2024-06-03")),
     count = c(NA_integer_, NA_integer_, 1L)
   )
   rpt <- validation_report(counts = df, na_threshold = 0.10)

--- a/tests/testthat/test-write-estimates.R
+++ b/tests/testthat/test-write-estimates.R
@@ -11,7 +11,8 @@
   d <- suppressWarnings(add_counts(d, example_counts)) # nolint: object_usage_linter
   d <- suppressWarnings(
     add_interviews(
-      d, example_interviews, # nolint: object_usage_linter
+      d,
+      example_interviews, # nolint: object_usage_linter
       catch = catch_total, # nolint: object_usage_linter
       effort = hours_fished, # nolint: object_usage_linter
       trip_status = trip_status # nolint: object_usage_linter


### PR DESCRIPTION
## Summary

Consolidates all post-v2.3.0 work into the v2.4.0 "Bowfin" release.

### New features
- `est_age_distribution()` and `est_mean_age()` — age structure estimation from interview data
- `example_ages` dataset
- `estimate_harvest_rate()` gains species-level dispatch
- `creel_design()` gains `open_start` param for GLMM aerial designs
- Quarto Creel Report starter template (`inst/quarto/templates/creel-report/`)

### Bug fixes (15 total across 3 review tiers)

**Tier 1 — statistical correctness**
- `estimate_total_catch/harvest/release`: inner-join silently dropped strata with effort but no interviews
- `estimate_angler_trips`: `sd()` on single-interview stratum produced silent NA in SE/CI
- `compare_variance`: SEs paired by row position not stratum key
- `adjust_nonresponse`: `"calibrate"` accepted but silently ignored; svyrep path used wrong scaling
- `estimate_effort`: FPC not applied to expanded effort svydesign

**Tier 2 — validation and scheduling**
- `new_creel_validation()`: empty results silently reported `passed = TRUE`
- `design-validator`: stratum vectors consumed positionally vs named
- `validate_incomplete_trips`: crash on degenerate `se_diff == 0` or `df <= 0`
- `schedule_generators`: `inclusion_prob` could silently exceed 1
- `validation_report`, `standardize_species`, `hybrid_design`: second cli string silently dropped

**Tier 3 — reporting helpers**
- `creel_palette`: 0-based modular recycling produced NA at palette-length multiples
- `coerce_schedule_columns`: character `period_id` coerced to all-NA

**Additional**
- `est_age_distribution`/`est_length_distribution`: per-group n was global count; `left_join` inside per-group loop
- `estimate_angler_trips`: singleton SE threshold duplicated with divergent syntax
- `compare_variance`: group-column detection via hardcoded exclusion list replaced with `x$by_vars`
- `optimal_n`: named `cost_ratio` applied positionally; zero-variance/zero-total silent NaN

### R CMD check
- Status: OK (0 errors, 0 warnings, 0 notes beyond expected INFO)
- 3197 tests pass, 10 skip