### PR TITLE
fix(connect): bug-review fixes + bump tidycreel.connect to 0.2.0

### DIFF
--- a/tidycreel.connect/DESCRIPTION
+++ b/tidycreel.connect/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycreel.connect
 Title: Database and File Connections for Tidycreel
-Version: 0.1.0
+Version: 0.2.0
 Authors@R:
     person("Christopher", "Chizinski", role = c("aut", "cre"),
            email = "cchizinski2@unl.edu")

--- a/tidycreel.connect/NEWS.md
+++ b/tidycreel.connect/NEWS.md
@@ -1,3 +1,33 @@
+# tidycreel.connect 0.2.0
+
+## Bug fixes and robustness improvements
+
+* `creel_connect_from_yaml()`: guards against NULL/non-list config block after
+  `config::get()`; catches missing credential keys (not just empty strings);
+  validates `survey_type` against known enum before calling `creel_schema()`;
+  wraps `DBI::dbConnect()` in `tryCatch()` to prevent password leaking into
+  error tracebacks.
+* `creel_connect()`: `creel_connect_csv()` now validates all 5 required path
+  keys (`interviews`, `counts`, `catch`, `harvest_lengths`, `release_lengths`)
+  before checking file existence, giving a clear error on missing keys.
+* `.api_fetch()`: guards against NULL endpoint key with a clear error; wraps
+  `as.data.frame()` for non-tabular API JSON responses; `.parse_api_date()`
+  now strips ISO 8601 timezone suffixes (`Z`, `+HH:MM`, `-HH:MM`) before
+  parsing, preventing silent NA on timezone-aware timestamps.
+* `fetch_interviews()`, `fetch_counts()`, `fetch_catch()`,
+  `fetch_harvest_lengths()`, `fetch_release_lengths()`: all `as.numeric()` and
+  `as.Date()` coercions on data columns now warn when values cannot be parsed
+  rather than silently producing `NA` (via new `.coerce_numeric()` and
+  `.coerce_date()` internal helpers).
+* `list_creels()`: missing NGPC API fields now trigger a warning and are filled
+  with typed `NA` rather than silently producing a short-column data frame;
+  return type unified to tibble across empty and non-empty responses.
+* Validation (`fetch-validators`): `switch()` default now `stop()`s on unknown
+  `expected_type` values rather than silently returning `TRUE`; UID columns
+  (`interview_uid`, `catch_uid`, `length_uid`) use new `"uid"` type that
+  accepts numeric or character (covers both synthesized row-index UIDs and UUID
+  strings), replacing the unchecked `"any"` type.
+
 # tidycreel.connect 0.1.0
 
 ## Initial release

--- a/tidycreel.connect/R/creel-connect-yaml.R
+++ b/tidycreel.connect/R/creel-connect-yaml.R
@@ -39,6 +39,12 @@ creel_connect_from_yaml <- function(path, config = "default") {
   }
   # Load all keys at once -- use_parent=FALSE prevents searching parent directories
   cfg <- config::get(value = NULL, config = config, file = path, use_parent = FALSE)
+  if (is.null(cfg) || !is.list(cfg)) {
+    cli::cli_abort(c(
+      "Config block {.val {config}} not found or empty in {.file {path}}.",
+      "i" = "Check that the YAML file has a {.code {config}:} top-level block."
+    ))
+  }
   # Pre-validate all required keys and types before any connection attempt
   .validate_yaml_config(cfg, path)
   # Build connection from validated config
@@ -112,11 +118,11 @@ creel_connect_from_yaml <- function(path, config = "default") {
         )
       ))
     }
-    # Validate credentials are non-empty (Pitfall 2: !expr returns "" for unset env vars)
+    # Validate credentials exist and are non-empty (!expr returns "" for unset env vars)
     cred_fields <- c("username", "password")
     empty_creds <- cred_fields[vapply(cred_fields, function(k) {
       val <- cfg[[k]]
-      !is.null(val) && !nzchar(val)
+      is.null(val) || !nzchar(val)
     }, logical(1))]
     if (length(empty_creds) > 0L) {
       cli::cli_abort(c(
@@ -140,6 +146,13 @@ creel_connect_from_yaml <- function(path, config = "default") {
 
   # Build a minimal creel_schema from the YAML schema block
   # Column mappings are not in YAML -- this schema holds table names only
+  valid_survey_types <- c("instantaneous", "bus_route", "ice", "camera", "aerial")
+  if (!survey_type %in% valid_survey_types) {
+    cli::cli_abort(c(
+      "{.field schema.survey_type} must be one of {.val {valid_survey_types}}, not {.val {survey_type}}.",
+      "i" = "Check the {.code survey_type} value under {.code schema:} in your YAML config."
+    ))
+  }
   schema_args <- list(survey_type = survey_type)
   table_keys <- c(
     "interviews_table", "counts_table", "catch_table",
@@ -162,13 +175,22 @@ creel_connect_from_yaml <- function(path, config = "default") {
     }
     # WARNING: cfg$username and cfg$password must come from Sys.getenv() via YAML !expr tags.
     # Do NOT log or print cfg$password -- credentials are validated non-empty above.
-    dbi_con <- DBI::dbConnect(
-      odbc::odbc(),
-      Driver   = "ODBC Driver 17 for SQL Server",
-      Server   = cfg$server,
-      Database = cfg$database,
-      UID      = cfg$username,
-      PWD      = cfg$password
+    dbi_con <- tryCatch(
+      DBI::dbConnect(
+        odbc::odbc(),
+        Driver   = "ODBC Driver 17 for SQL Server",
+        Server   = cfg$server,
+        Database = cfg$database,
+        UID      = cfg$username,
+        PWD      = cfg$password
+      ),
+      error = function(e) {
+        cli::cli_abort(c(
+          "Failed to connect to SQL Server {.val {cfg$database}} on {.val {cfg$server}}.",
+          "i" = "Check that the server is reachable and credentials are correct.",
+          "x" = conditionMessage(e)
+        ))
+      }
     )
     .creel_connect_dbi(dbi_con, schema) # nolint: object_usage_linter
   }

--- a/tidycreel.connect/R/creel-connection-api.R
+++ b/tidycreel.connect/R/creel-connection-api.R
@@ -256,6 +256,9 @@ creel_connect_api <- function(
 #' @noRd
 .api_fetch <- function(con_info, endpoint_key, no_uid_filter = FALSE) {
   endpoint <- con_info$endpoints[[endpoint_key]]
+  if (is.null(endpoint)) {
+    cli::cli_abort("Unknown API endpoint key {.val {endpoint_key}}.")
+  }
   url      <- paste0(con_info$base_url, endpoint)
 
   req <- httr2::request(url)
@@ -316,18 +319,30 @@ creel_connect_api <- function(
   if (is.null(result) || (is.list(result) && length(result) == 0L)) {
     return(data.frame())
   }
-  df <- as.data.frame(result)
+  df <- tryCatch(
+    as.data.frame(result),
+    error = function(e) {
+      cli::cli_abort(c(
+        "API returned non-tabular JSON for endpoint {.val {endpoint_key}}.",
+        "i" = "Expected a JSON array of flat objects.",
+        "x" = conditionMessage(e)
+      ))
+    }
+  )
   names(df) <- trimws(names(df))
   df
 }
 
-# Parse a date column that may arrive as "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS"
+# Parse a date column that may arrive as "YYYY-MM-DD", "YYYY-MM-DDTHH:MM:SS",
+# or ISO 8601 with timezone suffix ("...Z" or "...+HH:MM" / "...-HH:MM").
 #' @noRd
 .parse_api_date <- function(x) {
-  result  <- suppressWarnings(as.Date(x, tryFormats = c("%Y-%m-%d", "%m/%d/%Y")))
-  na_mask <- is.na(result) & !is.na(x)
+  # Strip trailing timezone suffix from datetime strings before parsing
+  x_clean <- sub("T(\\d{2}:\\d{2}:\\d{2})([Zz]|[+-]\\d{2}:\\d{2})$", "T\\1", x)
+  result  <- suppressWarnings(as.Date(x_clean, tryFormats = c("%Y-%m-%d", "%m/%d/%Y")))
+  na_mask <- is.na(result) & !is.na(x_clean)
   if (any(na_mask)) {
-    result[na_mask] <- as.Date(strptime(x[na_mask], "%Y-%m-%dT%H:%M:%S"))
+    result[na_mask] <- as.Date(strptime(x_clean[na_mask], "%Y-%m-%dT%H:%M:%S"))
   }
   result
 }

--- a/tidycreel.connect/R/creel-connection.R
+++ b/tidycreel.connect/R/creel-connection.R
@@ -82,6 +82,14 @@ creel_connect <- function(con, schema) {
 
 #' @noRd
 .creel_connect_csv <- function(paths, schema) {
+  required_keys <- c("interviews", "counts", "catch", "harvest_lengths", "release_lengths")
+  missing_keys  <- setdiff(required_keys, names(paths))
+  if (length(missing_keys) > 0L) {
+    cli::cli_abort(c(
+      "CSV path list is missing required key{?s}: {.val {missing_keys}}",
+      "i" = "Required keys: {.val {required_keys}}"
+    ))
+  }
   missing_files <- names(paths)[!vapply(paths, file.exists, logical(1L))]
   if (length(missing_files) > 0L) {
     bullets <- stats::setNames(

--- a/tidycreel.connect/R/creel-discovery.R
+++ b/tidycreel.connect/R/creel-discovery.R
@@ -53,7 +53,23 @@ list_creels.creel_connection_api <- function(conn, ...) {
   if ("data_complete" %in% names(df)) df$data_complete <- as.logical(df$data_complete)
   if ("comments"      %in% names(df)) df$comments      <- as.character(df$comments)
 
-  df
+  # Ensure all documented columns are present; warn and fill missing ones with typed NA
+  expected_cols <- list(
+    creel_uid     = NA_character_,
+    title         = NA_character_,
+    description   = NA_character_,
+    active        = NA,
+    data_complete = NA,
+    comments      = NA_character_
+  )
+  for (col in names(expected_cols)) {
+    if (!col %in% names(df)) {
+      cli::cli_warn("API response missing expected field {.field {col}}; filling with NA.")
+      df[[col]] <- expected_cols[[col]]
+    }
+  }
+
+  tibble::as_tibble(df)
 }
 
 

--- a/tidycreel.connect/R/fetch-loaders.R
+++ b/tidycreel.connect/R/fetch-loaders.R
@@ -6,6 +6,28 @@
   readr::read_csv(path, show_col_types = FALSE, progress = FALSE)
 }
 
+# Internal: as.numeric() that warns when coercion introduces NAs
+.coerce_numeric <- function(x, col_name) {
+  result <- suppressWarnings(as.numeric(x))
+  na_new <- is.na(result) & !is.na(x)
+  if (any(na_new)) {
+    cli::cli_warn("Coercion introduced {sum(na_new)} NA{?s} in column {.field {col_name}}.")
+  }
+  result
+}
+
+# Internal: as.Date() that warns when parsing introduces NAs
+.coerce_date <- function(x, col_name, formats = c("%Y-%m-%d", "%m/%d/%Y")) {
+  result <- suppressWarnings(as.Date(x, tryFormats = formats))
+  na_new <- is.na(result) & !is.na(x)
+  if (any(na_new)) {
+    cli::cli_warn(
+      "Could not parse {sum(na_new)} date value{?s} in column {.field {col_name}}; coerced to NA."
+    )
+  }
+  result
+}
+
 # Internal: rename raw NGPC API columns to canonical names using a hardcoded map.
 # api_rename_map: named character vector where names = canonical names,
 #   values = raw NGPC JSON field names (e.g., c(interview_uid = "ii_UID", date = "cd_Date")).
@@ -71,11 +93,9 @@ fetch_interviews.creel_connection_csv <- function(conn, ...) {
     trip_status   = "trip_status_col"
   )
   df <- .rename_to_canonical(df, conn$schema, rename_map)
-  if ("date" %in% names(df)) {
-    df$date <- as.Date(df$date, tryFormats = c("%Y-%m-%d", "%m/%d/%Y"))
-  }
-  if ("catch_count" %in% names(df)) df$catch_count <- as.numeric(df$catch_count)
-  if ("effort" %in% names(df)) df$effort <- as.numeric(df$effort)
+  if ("date"        %in% names(df)) df$date        <- .coerce_date(df$date, "date")
+  if ("catch_count" %in% names(df)) df$catch_count <- .coerce_numeric(df$catch_count, "catch_count")
+  if ("effort"      %in% names(df)) df$effort      <- .coerce_numeric(df$effort, "effort")
   if ("trip_status" %in% names(df)) df$trip_status <- as.character(df$trip_status)
   validate_fetch_interviews(df) # nolint: object_usage_linter
   df
@@ -116,14 +136,14 @@ fetch_interviews.creel_connection_api <- function(conn, ...) {
   hours_col   <- fm$effort_hours
   minutes_col <- fm$effort_minutes
   if (!is.null(hours_col) && nzchar(hours_col) && hours_col %in% names(raw_df)) {
-    df$effort <- as.numeric(raw_df[[hours_col]])
+    df$effort <- .coerce_numeric(raw_df[[hours_col]], hours_col)
     if (!is.null(minutes_col) && nzchar(minutes_col) && minutes_col %in% names(raw_df)) {
-      df$effort <- df$effort + as.numeric(raw_df[[minutes_col]]) / 60
+      df$effort <- df$effort + .coerce_numeric(raw_df[[minutes_col]], minutes_col) / 60
     }
   }
 
-  if ("date" %in% names(df))        df$date        <- .parse_api_date(df$date)
-  if ("catch_count" %in% names(df)) df$catch_count <- as.numeric(df$catch_count)
+  if ("date"        %in% names(df)) df$date        <- .parse_api_date(df$date)
+  if ("catch_count" %in% names(df)) df$catch_count <- .coerce_numeric(df$catch_count, "catch_count")
   if ("trip_status" %in% names(df)) df$trip_status <- as.character(df$trip_status)
 
   validate_fetch_interviews(df) # nolint: object_usage_linter
@@ -157,12 +177,10 @@ fetch_counts.creel_connection_csv <- function(conn, ...) {
     non_ang_boats = "non_ang_boats_col"
   )
   df <- .rename_to_canonical(df, conn$schema, rename_map)
-  if ("date" %in% names(df)) {
-    df$date <- as.Date(df$date, tryFormats = c("%Y-%m-%d", "%m/%d/%Y"))
-  }
-  if ("bank_anglers"  %in% names(df)) df$bank_anglers  <- as.numeric(df$bank_anglers)
-  if ("angler_boats"  %in% names(df)) df$angler_boats  <- as.numeric(df$angler_boats)
-  if ("non_ang_boats" %in% names(df)) df$non_ang_boats <- as.numeric(df$non_ang_boats)
+  if ("date"          %in% names(df)) df$date          <- .coerce_date(df$date, "date")
+  if ("bank_anglers"  %in% names(df)) df$bank_anglers  <- .coerce_numeric(df$bank_anglers, "bank_anglers")
+  if ("angler_boats"  %in% names(df)) df$angler_boats  <- .coerce_numeric(df$angler_boats, "angler_boats")
+  if ("non_ang_boats" %in% names(df)) df$non_ang_boats <- .coerce_numeric(df$non_ang_boats, "non_ang_boats")
   validate_fetch_counts(df) # nolint: object_usage_linter
   df
 }
@@ -200,9 +218,9 @@ fetch_counts.creel_connection_api <- function(conn, ...) {
   df <- .rename_api_to_canonical(raw_df, api_rename_map)
 
   if ("date"          %in% names(df)) df$date          <- .parse_api_date(df$date)
-  if ("bank_anglers"  %in% names(df)) df$bank_anglers  <- as.numeric(df$bank_anglers)
-  if ("angler_boats"  %in% names(df)) df$angler_boats  <- as.numeric(df$angler_boats)
-  if ("non_ang_boats" %in% names(df)) df$non_ang_boats <- as.numeric(df$non_ang_boats)
+  if ("bank_anglers"  %in% names(df)) df$bank_anglers  <- .coerce_numeric(df$bank_anglers, "bank_anglers")
+  if ("angler_boats"  %in% names(df)) df$angler_boats  <- .coerce_numeric(df$angler_boats, "angler_boats")
+  if ("non_ang_boats" %in% names(df)) df$non_ang_boats <- .coerce_numeric(df$non_ang_boats, "non_ang_boats")
 
   validate_fetch_counts(df) # nolint: object_usage_linter
   df
@@ -237,9 +255,9 @@ fetch_catch.creel_connection_csv <- function(conn, ...) {
   )
   df <- .rename_to_canonical(df, conn$schema, rename_map)
   # Coerce species to character BEFORE validation (NGPC integer codes)
-  if ("species" %in% names(df)) df$species <- as.character(df$species)
-  if ("catch_count" %in% names(df)) df$catch_count <- as.numeric(df$catch_count)
-  if ("catch_type" %in% names(df)) df$catch_type <- as.character(df$catch_type)
+  if ("species"     %in% names(df)) df$species     <- as.character(df$species)
+  if ("catch_count" %in% names(df)) df$catch_count <- .coerce_numeric(df$catch_count, "catch_count")
+  if ("catch_type"  %in% names(df)) df$catch_type  <- as.character(df$catch_type)
   validate_fetch_catch(df) # nolint: object_usage_linter
   df
 }
@@ -280,9 +298,9 @@ fetch_catch.creel_connection_api <- function(conn, ...) {
     df$catch_uid <- seq_len(nrow(df))
   }
 
-  if ("species" %in% names(df))     df$species     <- as.character(df$species)
-  if ("catch_count" %in% names(df)) df$catch_count <- as.numeric(df$catch_count)
-  if ("catch_type" %in% names(df))  df$catch_type  <- as.character(df$catch_type)
+  if ("species"     %in% names(df)) df$species     <- as.character(df$species)
+  if ("catch_count" %in% names(df)) df$catch_count <- .coerce_numeric(df$catch_count, "catch_count")
+  if ("catch_type"  %in% names(df)) df$catch_type  <- as.character(df$catch_type)
 
   validate_fetch_catch(df) # nolint: object_usage_linter
   df
@@ -316,8 +334,8 @@ fetch_harvest_lengths.creel_connection_csv <- function(conn, ...) {
     length_type   = "length_type_col"
   )
   df <- .rename_to_canonical(df, conn$schema, rename_map)
-  if ("species" %in% names(df)) df$species <- as.character(df$species)
-  if ("length_mm" %in% names(df)) df$length_mm <- as.numeric(df$length_mm)
+  if ("species"     %in% names(df)) df$species     <- as.character(df$species)
+  if ("length_mm"   %in% names(df)) df$length_mm   <- .coerce_numeric(df$length_mm, "length_mm")
   if ("length_type" %in% names(df)) df$length_type <- as.character(df$length_type)
   validate_fetch_harvest_lengths(df) # nolint: object_usage_linter
   df
@@ -362,8 +380,8 @@ fetch_harvest_lengths.creel_connection_api <- function(conn, ...) {
   # Constant injection: API returns no length_type flag for harvest endpoint (CONTEXT.md D-07)
   df$length_type <- "harvest"
 
-  if ("species" %in% names(df))   df$species   <- as.character(df$species)
-  if ("length_mm" %in% names(df)) df$length_mm <- as.numeric(df$length_mm)
+  if ("species"   %in% names(df)) df$species   <- as.character(df$species)
+  if ("length_mm" %in% names(df)) df$length_mm <- .coerce_numeric(df$length_mm, "length_mm")
 
   validate_fetch_harvest_lengths(df) # nolint: object_usage_linter
   df
@@ -397,8 +415,8 @@ fetch_release_lengths.creel_connection_csv <- function(conn, ...) {
     length_type   = "length_type_col"
   )
   df <- .rename_to_canonical(df, conn$schema, rename_map)
-  if ("species" %in% names(df)) df$species <- as.character(df$species)
-  if ("length_mm" %in% names(df)) df$length_mm <- as.numeric(df$length_mm)
+  if ("species"     %in% names(df)) df$species     <- as.character(df$species)
+  if ("length_mm"   %in% names(df)) df$length_mm   <- .coerce_numeric(df$length_mm, "length_mm")
   if ("length_type" %in% names(df)) df$length_type <- as.character(df$length_type)
   validate_fetch_release_lengths(df) # nolint: object_usage_linter
   df
@@ -444,8 +462,8 @@ fetch_release_lengths.creel_connection_api <- function(conn, ...) {
   # Constant injection: API returns no length_type flag for release endpoint (CONTEXT.md D-07)
   df$length_type <- "release"
 
-  if ("species" %in% names(df))   df$species   <- as.character(df$species)
-  if ("length_mm" %in% names(df)) df$length_mm <- as.numeric(df$length_mm)
+  if ("species"   %in% names(df)) df$species   <- as.character(df$species)
+  if ("length_mm" %in% names(df)) df$length_mm <- .coerce_numeric(df$length_mm, "length_mm")
 
   validate_fetch_release_lengths(df) # nolint: object_usage_linter
   df

--- a/tidycreel.connect/R/fetch-validators.R
+++ b/tidycreel.connect/R/fetch-validators.R
@@ -19,7 +19,8 @@
     "Date"      = inherits(df[[col]], "Date"),
     "numeric"   = is.numeric(df[[col]]),
     "character" = is.character(df[[col]]),
-    TRUE
+    "uid"       = is.numeric(df[[col]]) || is.character(df[[col]]),
+    stop(paste0("Unknown expected_type '", expected_type, "' for column '", col, "'"))
   )
   if (!ok) {
     actual <- paste(class(df[[col]]), collapse = "/")
@@ -51,7 +52,7 @@
 #' @keywords internal
 validate_fetch_interviews <- function(df) {
   spec <- list(
-    interview_uid = "any",
+    interview_uid = "uid",
     date          = "Date",
     catch_count   = "numeric",
     effort        = "numeric",
@@ -78,8 +79,8 @@ validate_fetch_counts <- function(df) {
 #' @keywords internal
 validate_fetch_catch <- function(df) {
   spec <- list(
-    catch_uid     = "any",
-    interview_uid = "any",
+    catch_uid     = "uid",
+    interview_uid = "uid",
     species       = "character",
     catch_count   = "numeric",
     catch_type    = "character"
@@ -92,8 +93,8 @@ validate_fetch_catch <- function(df) {
 #' @keywords internal
 validate_fetch_harvest_lengths <- function(df) {
   spec <- list(
-    length_uid    = "any",
-    interview_uid = "any",
+    length_uid    = "uid",
+    interview_uid = "uid",
     species       = "character",
     length_mm     = "numeric",
     length_type   = "character"
@@ -106,8 +107,8 @@ validate_fetch_harvest_lengths <- function(df) {
 #' @keywords internal
 validate_fetch_release_lengths <- function(df) {
   spec <- list(
-    length_uid    = "any",
-    interview_uid = "any",
+    length_uid    = "uid",
+    interview_uid = "uid",
     species       = "character",
     length_mm     = "numeric",
     length_type   = "character"


### PR DESCRIPTION
## Summary

- Fix 2 red bugs and 26 yellow risks identified by parallel cavecrew-reviewer pass on all `tidycreel.connect/R/` files
- Bump `tidycreel.connect` from 0.1.0 → 0.2.0

## Key fixes

**Security**
- `creel_connect_from_yaml()`: wrap `DBI::dbConnect()` in `tryCatch()` — failed connection no longer leaks `cfg$password` in traceback

**Silent failure → loud failure**
- `fetch-validators`: `switch()` default now `stop()`s on unknown `expected_type` (was silently returning `TRUE`)
- All `as.numeric()`/`as.Date()` coercions on data columns replaced with `.coerce_numeric()`/`.coerce_date()` helpers that warn when NAs are introduced
- `list_creels()`: missing NGPC API fields warn + fill typed NA instead of silently returning a short-column data frame

**Input validation**
- `creel_connect_from_yaml()`: guard NULL/non-list config block; catch missing credential keys; validate `survey_type` enum before `creel_schema()` call
- `.creel_connect_csv()`: validate all 5 required path keys before file existence check
- `.api_fetch()`: guard NULL endpoint key; wrap `as.data.frame()` for non-tabular JSON

**Type correctness**
- `.parse_api_date()`: strip ISO 8601 timezone suffixes (`Z`, `±HH:MM`) before parsing
- UID columns use new `"uid"` type (numeric|character) instead of unchecked `"any"`
- `list_creels()`: unified return type to tibble across empty and non-empty responses

## Test plan

- [ ] CI passes (187 tests, 0 fail, 7 skip)
- [ ] R CMD check clean on tidycreel.connect