### PR TITLE
docs: pkgdown v2.4.0 updates — badge, README, age vignette, .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -122,3 +122,4 @@
 ^\.contextatlas$
 ^\.gsd\.archive.*$
 ^air\.toml$
+^\.codegraph$

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ output: github_document
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![Codecov test coverage](https://codecov.io/gh/chrischizinski/tidycreel/graph/badge.svg)](https://app.codecov.io/gh/chrischizinski/tidycreel)
-[![Release](https://img.shields.io/badge/release-v2.2.0%20%22Goldeye%22-4CAF50)](https://github.com/chrischizinski/tidycreel/releases)
+[![Release](https://img.shields.io/badge/release-v2.4.0%20%22Bowfin%22-4CAF50)](https://github.com/chrischizinski/tidycreel/releases)
 <!-- badges: end -->
 
 **Tidy Interface for Creel Survey Design, Estimation, and Reporting**
@@ -140,13 +140,13 @@ estimate_catch_rate(design)
 
 ### Survey Design
 - **`creel_design()`** — single entry point; dispatches on `survey_type`.
-- **`add_counts()`**, **`add_interviews()`**, **`add_catch()`**, **`add_lengths()`**, **`add_sections()`** — attach observation data.
+- **`add_counts()`**, **`add_interviews()`**, **`add_catch()`**, **`add_lengths()`**, **`add_ages()`**, **`add_sections()`** — attach observation data.
 
 ### Estimation
 - **`estimate_effort()`** — total effort with Taylor linearization, bootstrap, or jackknife variance.
 - **`estimate_catch_rate()`**, **`estimate_harvest_rate()`**, **`estimate_release_rate()`** — ratio-based interview estimators.
 - **`estimate_total_catch()`**, **`estimate_total_harvest()`**, **`estimate_total_release()`** — totals via delta-method propagation.
-- **`est_effort_camera()`**, **`est_length_distribution()`** — camera effort indexing and weighted size-structure estimation.
+- **`est_effort_camera()`**, **`est_length_distribution()`**, **`est_mean_length()`**, **`est_age_distribution()`**, **`est_mean_age()`** — camera effort indexing and weighted size- and age-structure estimation.
 - **`estimate_exploitation_rate()`** — exploitation rate from tag returns (Pollock et al.; simple and T-weighted stratified paths).
 - **`estimate_angler_n()`** — Petersen and Schnabel mark-recapture population size estimators.
 - **`estimate_mr_harvest()`** — population-scale total harvest from mark-recapture data.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ output: github_document
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![Codecov test coverage](https://codecov.io/gh/chrischizinski/tidycreel/graph/badge.svg)](https://app.codecov.io/gh/chrischizinski/tidycreel)
-[![Release](https://img.shields.io/badge/release-v2.2.0%20%22Goldeye%22-4CAF50)](https://github.com/chrischizinski/tidycreel/releases)
+[![Release](https://img.shields.io/badge/release-v2.4.0%20%22Bowfin%22-4CAF50)](https://github.com/chrischizinski/tidycreel/releases)
 <!-- badges: end -->
 
 **Tidy Interface for Creel Survey Design, Estimation, and Reporting**
@@ -140,13 +140,13 @@ estimate_catch_rate(design)
 
 ### Survey Design
 - **`creel_design()`** — single entry point; dispatches on `survey_type`.
-- **`add_counts()`**, **`add_interviews()`**, **`add_catch()`**, **`add_lengths()`**, **`add_sections()`** — attach observation data.
+- **`add_counts()`**, **`add_interviews()`**, **`add_catch()`**, **`add_lengths()`**, **`add_ages()`**, **`add_sections()`** — attach observation data.
 
 ### Estimation
 - **`estimate_effort()`** — total effort with Taylor linearization, bootstrap, or jackknife variance.
 - **`estimate_catch_rate()`**, **`estimate_harvest_rate()`**, **`estimate_release_rate()`** — ratio-based interview estimators.
 - **`estimate_total_catch()`**, **`estimate_total_harvest()`**, **`estimate_total_release()`** — totals via delta-method propagation.
-- **`est_effort_camera()`**, **`est_length_distribution()`** — camera effort indexing and weighted size-structure estimation.
+- **`est_effort_camera()`**, **`est_length_distribution()`**, **`est_mean_length()`**, **`est_age_distribution()`**, **`est_mean_age()`** — camera effort indexing and weighted size- and age-structure estimation.
 - **`estimate_exploitation_rate()`** — exploitation rate from tag returns (Pollock et al.; simple and T-weighted stratified paths).
 - **`estimate_angler_n()`** — Petersen and Schnabel mark-recapture population size estimators.
 - **`estimate_mr_harvest()`** — population-scale total harvest from mark-recapture data.

--- a/vignettes/interview-estimation.Rmd
+++ b/vignettes/interview-estimation.Rmd
@@ -153,6 +153,48 @@ All three methods produce similar results for these data. Use bootstrap or jackk
 - **Bootstrap**: Use when working with non-smooth statistics or when you want to verify Taylor linearization assumptions. More computationally intensive.
 - **Jackknife**: Alternative resampling method that is deterministic (unlike bootstrap). Useful for verification or when bootstrap is too slow.
 
+## Age Structure Estimation
+
+Age data collected during interviews can be used to estimate a pressure-weighted
+age distribution and design-weighted mean age for the catch or harvest. Attach
+age records with `add_ages()`, then call `est_age_distribution()` followed by
+`est_mean_age()`.
+
+```{r ages}
+data(example_ages)
+head(example_ages)
+
+# Attach age data — one row per aged fish
+design <- add_ages(
+  design,
+  example_ages,
+  age_uid      = interview_id,
+  interview_uid = interview_id,
+  species      = species,
+  age          = age,
+  age_type     = age_type
+)
+
+# Estimate weighted age frequency by species
+ad <- est_age_distribution(design, by = species)
+print(ad)
+```
+
+Each row is one integer age class. The `estimate` column is the
+survey-design-weighted count of fish at that age, `percent` is the within-species
+proportion, and `cumulative_percent` accumulates from the youngest age class up.
+The same `variance`, `type`, and `conf_level` arguments available in
+`est_length_distribution()` are accepted here.
+
+```{r mean_age}
+# Compute weighted mean age from the distribution object
+est_mean_age(ad)
+```
+
+`est_mean_age()` applies the ratio estimator
+(Σ a N̂_a / N̂) to the weighted age counts returned by `est_age_distribution()`
+and propagates variance via the delta method.
+
 ## Complete Workflow Example
 
 Here's the full pipeline in a single workflow:
@@ -218,6 +260,10 @@ For more details on interview-based estimation functions, see:
 - `?estimate_harvest_rate` - Estimate harvest per unit effort
 - `?estimate_total_catch` - Estimate total catch
 - `?estimate_total_harvest` - Estimate total harvest
+- `?add_ages` - Attach age data to a design
+- `?est_age_distribution` - Estimate weighted age frequency
+- `?est_mean_age` - Compute design-weighted mean age
 - `?example_interviews` - Example interview dataset
+- `?example_ages` - Example age dataset
 
 For the effort estimation workflow, see the "Getting Started with tidycreel" vignette.


### PR DESCRIPTION
## Summary

- Update release badge from v2.2.0 "Goldeye" to v2.4.0 "Bowfin" in README.Rmd and README.md
- Add `add_ages()`, `est_age_distribution()`, and `est_mean_age()` to README function list (omitted at v2.4.0 ship)
- Add "Age Structure Estimation" section to `interview-estimation` vignette — walks through `add_ages → est_age_distribution → est_mean_age` with `example_ages` data
- Add `^\.codegraph$` to `.Rbuildignore` to clear R CMD check NOTE about hidden directories

## Test plan

- [ ] R CMD check passes (0 errors, 0 warnings, 0 notes — pre-push hook verified locally)
- [ ] pkgdown CI rebuilds site with corrected badge and new vignette section
- [ ] Vignette renders clean (verified locally with `rmarkdown::render`)
