### PR TITLE
fix(connect): remove catch_count from NGPC interviews field map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ data/ngpc_creel_params.rda
 data-raw/ngpc_creel_params.rda
 data-raw/ngpc_creel_inventory.R
 data-raw/fish_release_names.txt
+.codegraph/

--- a/R/creel-estimates-age.R
+++ b/R/creel-estimates-age.R
@@ -345,7 +345,9 @@ est_age_distribution <- function(
 #'
 #' @return A `data.frame` with class `c("creel_mean_age", "data.frame")` and
 #'   columns: grouping columns (if any), `mean_age`, `mean_age_se`,
-#'   `mean_age_ci_lower`, `mean_age_ci_upper`.
+#'   `mean_age_ci_lower`, `mean_age_ci_upper`. Rows where the total estimated
+#'   fish is zero or negative return `NA` for all numeric columns with a
+#'   warning.
 #'
 #' @examples
 #' data(example_calendar)
@@ -401,6 +403,16 @@ est_mean_age <- function(ad, conf_level = NULL) {
   compute_mean_age <- function(rows) {
     a <- as.numeric(rows$age)
     n_total <- sum(rows$estimate)
+    if (n_total <= 0) {
+      cli::cli_warn("Total estimated fish is zero or negative; mean age cannot be computed.")
+      return(data.frame(
+        mean_age = NA_real_,
+        mean_age_se = NA_real_,
+        mean_age_ci_lower = NA_real_,
+        mean_age_ci_upper = NA_real_,
+        stringsAsFactors = FALSE
+      ))
+    }
     mean_a <- sum(a * rows$estimate) / n_total
     se_a <- sqrt(sum((a - mean_a)^2 * rows$se^2)) / n_total
     data.frame(

--- a/R/creel-estimates-camera.R
+++ b/R/creel-estimates-camera.R
@@ -182,8 +182,7 @@ estimate_effort_camera <- function(
     # ---- Raw count expansion fallback ----------------------------------------
     if (is.null(h_open) || !is.numeric(h_open) || h_open <= 0) {
       cli::cli_abort(
-        "{.arg h_open} must be a positive number when no interview data ",
-        "are provided for camera effort estimation."
+        "{.arg h_open} must be a positive number when no interview data are provided for camera effort estimation."
       )
     }
 

--- a/R/creel-estimates-length.R
+++ b/R/creel-estimates-length.R
@@ -573,7 +573,9 @@ est_biomass <- function(ld, a, b, conf_level = NULL) {
 #'
 #' @return A `data.frame` with class `c("creel_mean_length", "data.frame")` and
 #'   columns: grouping columns (if any), `mean_length`, `mean_length_se`,
-#'   `mean_length_ci_lower`, `mean_length_ci_upper`.
+#'   `mean_length_ci_lower`, `mean_length_ci_upper`. Rows where the total
+#'   estimated fish is zero or negative return `NA` for all numeric columns
+#'   with a warning.
 #'
 #' @examples
 #' data(example_calendar)
@@ -631,6 +633,16 @@ est_mean_length <- function(ld, conf_level = NULL) {
   compute_mean_length <- function(rows) {
     l_mid <- (rows$bin_lower + rows$bin_upper) / 2
     n_total <- sum(rows$estimate)
+    if (n_total <= 0) {
+      cli::cli_warn("Total estimated fish is zero or negative; mean length cannot be computed.")
+      return(data.frame(
+        mean_length = NA_real_,
+        mean_length_se = NA_real_,
+        mean_length_ci_lower = NA_real_,
+        mean_length_ci_upper = NA_real_,
+        stringsAsFactors = FALSE
+      ))
+    }
     mean_l <- sum(l_mid * rows$estimate) / n_total
     se_l <- sqrt(sum((l_mid - mean_l)^2 * rows$se^2)) / n_total
     data.frame(
@@ -697,7 +709,9 @@ est_mean_length <- function(ld, conf_level = NULL) {
 #' @return A `data.frame` with class `c("creel_compliance", "data.frame")` and
 #'   columns: grouping columns (if any), `min_length`, `n_legal_est`,
 #'   `n_total_est`, `compliance_prop`, `compliance_se`,
-#'   `compliance_ci_lower`, `compliance_ci_upper`.
+#'   `compliance_ci_lower`, `compliance_ci_upper`. Rows where the total
+#'   estimated fish is zero or negative return `NA` for all numeric columns
+#'   with a warning.
 #'
 #' @examples
 #' data(example_calendar)
@@ -763,6 +777,19 @@ est_compliance <- function(ld, min_length, conf_level = NULL) {
     legal <- rows$bin_lower >= min_length
     n_legal <- sum(rows$estimate[legal])
     n_total <- sum(rows$estimate)
+    if (n_total <= 0) {
+      cli::cli_warn("Total estimated fish is zero or negative; compliance proportion cannot be computed.")
+      return(data.frame(
+        min_length = min_length,
+        n_legal_est = NA_real_,
+        n_total_est = NA_real_,
+        compliance_prop = NA_real_,
+        compliance_se = NA_real_,
+        compliance_ci_lower = NA_real_,
+        compliance_ci_upper = NA_real_,
+        stringsAsFactors = FALSE
+      ))
+    }
     p <- n_legal / n_total
     se_p <- sqrt(sum((as.numeric(legal) - p)^2 * rows$se^2)) / n_total
     data.frame(

--- a/R/est-effort-camera.R
+++ b/R/est-effort-camera.R
@@ -90,8 +90,7 @@ est_effort_camera <- function(
     !identical(design$design_type, "camera")
   if (bad_type) {
     cli::cli_warn(
-      "{.arg design} has {.field design_type} = {.val {design$design_type}}, ",
-      "not {.val camera}. Proceeding anyway."
+      "{.arg design} has {.field design_type} = {.val {design$design_type}}, not {.val camera}. Proceeding anyway."
     )
   }
   if (!is.numeric(conf_level) || conf_level <= 0 || conf_level >= 1) {

--- a/tests/testthat/test-creel-estimates-age.R
+++ b/tests/testthat/test-creel-estimates-age.R
@@ -371,3 +371,42 @@ test_that("AGD-40 est_mean_age() defaults conf_level from distribution attr", {
   result <- est_mean_age(ad)
   expect_equal(attr(result, "conf_level"), 0.90)
 })
+
+# Zero-total guard ----
+
+test_that("AGD-41 est_mean_age() warns and returns NA when all estimates are zero", {
+  fake_ad <- data.frame(
+    age = c(1L, 2L, 3L),
+    estimate = c(0, 0, 0),
+    se = c(0, 0, 0),
+    stringsAsFactors = FALSE
+  )
+  class(fake_ad) <- c("creel_age_distribution", "data.frame")
+  attr(fake_ad, "by_vars") <- NULL
+  attr(fake_ad, "conf_level") <- 0.95
+
+  expect_warning(result <- est_mean_age(fake_ad), "zero")
+  expect_true(is.na(result$mean_age))
+  expect_true(is.na(result$mean_age_se))
+  expect_true(is.na(result$mean_age_ci_lower))
+  expect_true(is.na(result$mean_age_ci_upper))
+})
+
+test_that("AGD-42 est_mean_age() warns NA only for zero-total group in grouped call", {
+  fake_ad <- data.frame(
+    species = c("walleye", "walleye", "perch", "perch"),
+    age = c(1L, 2L, 1L, 2L),
+    estimate = c(10, 20, 0, 0),
+    se = c(1, 2, 0, 0),
+    stringsAsFactors = FALSE
+  )
+  class(fake_ad) <- c("creel_age_distribution", "data.frame")
+  attr(fake_ad, "by_vars") <- "species"
+  attr(fake_ad, "conf_level") <- 0.95
+
+  expect_warning(result <- est_mean_age(fake_ad), "zero")
+  walleye_row <- result[result$species == "walleye", ]
+  perch_row <- result[result$species == "perch", ]
+  expect_false(is.na(walleye_row$mean_age))
+  expect_true(is.na(perch_row$mean_age))
+})

--- a/tests/testthat/test-est-mean-length.R
+++ b/tests/testthat/test-est-mean-length.R
@@ -188,3 +188,55 @@ test_that("est_mean_length() uses supplied conf_level over ld attribute", {
   ci_half <- (result$mean_length_ci_upper - result$mean_length_ci_lower) / 2
   expect_equal(ci_half, z_90 * result$mean_length_se, tolerance = 1e-9)
 })
+
+# Zero-total guard ----
+
+make_zero_ld <- function() {
+  ld <- data.frame(
+    bin_lower = c(200, 225, 250),
+    bin_upper = c(225, 250, 275),
+    estimate = c(0, 0, 0),
+    se = c(0, 0, 0),
+    stringsAsFactors = FALSE
+  )
+  class(ld) <- c("creel_length_distribution", "data.frame")
+  attr(ld, "by_vars") <- NULL
+  attr(ld, "conf_level") <- 0.95
+  ld
+}
+
+test_that("EML-ZT-01 est_mean_length() warns and returns NA when all estimates are zero", {
+  ld <- make_zero_ld()
+  expect_warning(result <- est_mean_length(ld), "zero")
+  expect_true(is.na(result$mean_length))
+  expect_true(is.na(result$mean_length_se))
+})
+
+test_that("EML-ZT-02 est_compliance() warns and returns NA when all estimates are zero", {
+  ld <- make_zero_ld()
+  expect_warning(result <- est_compliance(ld, min_length = 230), "zero")
+  expect_true(is.na(result$compliance_prop))
+  expect_true(is.na(result$compliance_se))
+  expect_true(is.na(result$n_legal_est))
+  expect_true(is.na(result$n_total_est))
+})
+
+test_that("EML-ZT-03 est_mean_length() warns NA only for zero-total group in grouped call", {
+  ld <- data.frame(
+    species = c("walleye", "walleye", "perch", "perch"),
+    bin_lower = c(200, 225, 200, 225),
+    bin_upper = c(225, 250, 225, 250),
+    estimate = c(10, 20, 0, 0),
+    se = c(1, 2, 0, 0),
+    stringsAsFactors = FALSE
+  )
+  class(ld) <- c("creel_length_distribution", "data.frame")
+  attr(ld, "by_vars") <- "species"
+  attr(ld, "conf_level") <- 0.95
+
+  expect_warning(result <- est_mean_length(ld), "zero")
+  walleye_row <- result[result$species == "walleye", ]
+  perch_row <- result[result$species == "perch", ]
+  expect_false(is.na(walleye_row$mean_length))
+  expect_true(is.na(perch_row$mean_length))
+})

--- a/tidycreel.connect/R/creel-connection-api.R
+++ b/tidycreel.connect/R/creel-connection-api.R
@@ -175,7 +175,6 @@ creel_connect_api <- function(
     interviews = list(
       interview_uid  = "ii_UID",
       date           = "cd_Date",
-      catch_count    = "Num",
       trip_status    = "ii_TripType",
       effort_hours   = "ii_TimeFishedHours",
       effort_minutes = "ii_TimeFishedMinutes"

--- a/tidycreel.connect/R/fetch-loaders.R
+++ b/tidycreel.connect/R/fetch-loaders.R
@@ -115,7 +115,6 @@ fetch_interviews.creel_connection_api <- function(conn, ...) {
     return(data.frame(
       interview_uid    = character(0),
       date             = as.Date(character(0)),
-      catch_count      = numeric(0),
       effort           = numeric(0),
       trip_status      = character(0),
       stringsAsFactors = FALSE
@@ -123,6 +122,9 @@ fetch_interviews.creel_connection_api <- function(conn, ...) {
   }
 
   fm <- conn$con$api_field_map$interviews
+  # catch_count: NULL in NGPC defaults (Num lives in GetCatchData, not GetInterviewData);
+  # non-NULL when caller supplies a custom api_field_map for a non-NGPC API.
+  # c() drops NULL entries silently, so the field is simply absent for NGPC connections.
   api_rename_map <- c(
     interview_uid = fm$interview_uid,
     date          = fm$date,
@@ -146,7 +148,7 @@ fetch_interviews.creel_connection_api <- function(conn, ...) {
   if ("catch_count" %in% names(df)) df$catch_count <- .coerce_numeric(df$catch_count, "catch_count")
   if ("trip_status" %in% names(df)) df$trip_status <- as.character(df$trip_status)
 
-  validate_fetch_interviews(df) # nolint: object_usage_linter
+  validate_fetch_interviews_api(df) # nolint: object_usage_linter
   df
 }
 

--- a/tidycreel.connect/R/fetch-validators.R
+++ b/tidycreel.connect/R/fetch-validators.R
@@ -61,6 +61,20 @@ validate_fetch_interviews <- function(df) {
   .validate_fetch(df, spec, "fetch_interviews")
 }
 
+# API variant: catch_count is absent from the NGPC interviews endpoint (Num is in
+# GetCatchData, not GetInterviewData). Users aggregate from fetch_catch() instead.
+#' @noRd
+#' @keywords internal
+validate_fetch_interviews_api <- function(df) {
+  spec <- list(
+    interview_uid = "uid",
+    date          = "Date",
+    effort        = "numeric",
+    trip_status   = "character"
+  )
+  .validate_fetch(df, spec, "fetch_interviews")
+}
+
 
 #' @noRd
 #' @keywords internal

--- a/tidycreel.connect/tests/testthat/test-fetch-interviews.R
+++ b/tidycreel.connect/tests/testthat/test-fetch-interviews.R
@@ -64,11 +64,13 @@ test_that("fetch_interviews() aborts with clear error when column has wrong type
 # --- creel_connection_api tests (API-01) ---
 
 test_that("fetch_interviews.creel_connection_api() returns canonical columns (API-01)", {
+  # NGPC GetInterviewData does not include per-trip catch totals (Num is in GetCatchData).
+  # catch_count is intentionally absent from API interview results.
   httr2::local_mocked_responses(function(req) {
     httr2::response(
       200,
       headers = "Content-Type: application/json",
-      body    = charToRaw('[{"ii_UID":"A1","cd_Date":"2016-03-28","Num":2,"ii_TripType":"complete","ii_TimeFishedHours":2,"ii_TimeFishedMinutes":30}]')
+      body    = charToRaw('[{"ii_UID":"A1","cd_Date":"2016-03-28","ii_TripType":"complete","ii_TimeFishedHours":2,"ii_TimeFishedMinutes":30}]')
     )
   })
   conn   <- make_api_conn()
@@ -76,13 +78,12 @@ test_that("fetch_interviews.creel_connection_api() returns canonical columns (AP
   expect_true(is.data.frame(result))
   expect_equal(
     sort(names(result)),
-    sort(c("interview_uid", "date", "catch_count", "effort", "trip_status"))
+    sort(c("interview_uid", "date", "effort", "trip_status"))
   )
   expect_equal(result$interview_uid, "A1")
   expect_true(inherits(result$date, "Date"))
   expect_true(is.numeric(result$effort))
   expect_equal(result$effort, 2 + 30 / 60)
-  expect_true(is.numeric(result$catch_count))
   expect_true(is.character(result$trip_status))
 })
 


### PR DESCRIPTION
## Summary

- `Num` (per-trip catch count) lives in `GetCatchData`, not `GetInterviewData` — the stale mapping in `.default_api_field_map()$interviews` caused `fetch_interviews()` to fail validation on live API connections
- Added `validate_fetch_interviews_api()` without `catch_count` requirement
- Custom `api_field_map` callers can still supply `catch_count` for non-NGPC APIs (NULL drops silently from `c()`)
- Updated mock response and column assertions in `test-fetch-interviews.R`

For NGPC connections, aggregate `fetch_catch()` by `interview_uid` to get per-trip catch totals before calling `add_interviews()`.

## Test plan

- [ ] 186 tidycreel.connect tests pass
- [ ] 3216 main package tests pass
- [ ] R CMD check: 0 errors, 0 warnings, 1 note (expected CRAN "New submission")
- [ ] Live smoke test verified: all 5 fetch functions + `list_creels()` against Calamus 2016 UID