### PR TITLE
docs(vignettes): add generate_progressive_start() to progressive and scheduling articles

### DIFF
--- a/vignettes/progressive-count-surveys.Rmd
+++ b/vignettes/progressive-count-surveys.Rmd
@@ -95,6 +95,35 @@ design <- creel_design(calendar, date = date, strata = day_type)
 design
 ```
 
+### Scheduling Circuit Start Times
+
+Before field work begins, randomise the circuit start time for each survey day
+using `generate_progressive_start()`. This ensures the count is unbiased with
+respect to time-of-day effort patterns. Two strategies are available:
+
+- `"discrete"` (default): start drawn from the \eqn{k = T / \tau} valid
+  τ-aligned offsets — avoids mid-day over-representation caused by the common
+  \eqn{U[0, T - \tau]} error.
+- `"wraparound"`: start drawn from \eqn{U[0, T)}; circuit may wrap past the
+  end of the survey day.
+
+```{r prog-start, message = FALSE}
+starts <- generate_progressive_start(
+  open_start    = "06:00",
+  open_end      = "16:00",
+  circuit_time  = 2,          # τ = 2 h; T = 10 h → k = 5 valid starts
+  strategy      = "discrete",
+  n             = nrow(calendar),
+  seed          = 42
+)
+starts
+```
+
+The returned `creel_schedule` records `circuit_start`, `circuit_end`,
+`is_wrapped`, and `direction` (`"forward"` / `"reverse"`) for each survey day.
+Record the scheduled start and direction in your field protocol — both are
+required for unbiased estimation.
+
 ### Count Data
 
 Each row is one circuit traversal per sampled day. The `shift_hours` column records

--- a/vignettes/survey-scheduling.Rmd
+++ b/vignettes/survey-scheduling.Rmd
@@ -411,6 +411,27 @@ ct_fixed <- generate_count_times(strategy = "fixed", fixed_windows = fw)
 ct_fixed
 ```
 
+### Progressive Count Strategy
+
+Progressive surveys require a randomised circuit start time in addition to a
+day-level schedule. Use `generate_progressive_start()` to draw start times that
+avoid the \eqn{U[0, T - \tau]} mid-day bias common in hand-crafted schedules.
+
+```{r count-times-progressive, message = FALSE}
+prog_starts <- generate_progressive_start(
+  open_start   = "06:00",
+  open_end     = "16:00",   # T = 10 h
+  circuit_time = 2,          # τ = 2 h → k = 5 discrete start offsets
+  strategy     = "discrete",
+  n            = 10,
+  seed         = 99
+)
+prog_starts
+```
+
+Use `strategy = "wraparound"` when τ does not divide T evenly. The `direction`
+column (`"forward"` / `"reverse"`) must be recorded in the field protocol.
+
 ### Exporting Count Time Schedules
 
 `generate_count_times()` returns a `creel_schedule` object, the same class returned by


### PR DESCRIPTION
## Summary

- Adds `generate_progressive_start()` demonstration to `progressive-count-surveys.Rmd` (new "Scheduling Circuit Start Times" section, inserted between Survey Setup and Count Data)
- Adds `### Progressive Count Strategy` subsection to `survey-scheduling.Rmd` (within the Within-Day Count Time Scheduling section)
- Both vignettes now show discrete and wraparound strategies per Hoenig et al. (1993)

Closes staleness gap introduced by v2.5.0 "Creek Chub" release. Also adds a `## Vignettes & pkgdown articles` section to `AGENTS.md` (gitignored) with a function→vignette mapping and protocol for keeping articles in sync with future releases.

## Test plan

- [ ] Both vignettes render without errors (`rmarkdown::render` with `devtools::load_all()`)
- [ ] `just check` passes (0 errors, 0 warnings)
- [ ] `just site` builds pkgdown without errors