### PR TITLE
docs(pkgdown): redesign survey card grid and typography

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -37,39 +37,44 @@ devtools::install_github("chrischizinski/tidycreel")
 ## Survey Types
 
 <div class="row mt-4 mb-4">
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Instantaneous Count</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Instantaneous Count</h3>
 <p class="small">Stratified effort estimation from periodic angler counts.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/tidycreel.html">Getting Started →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/tidycreel.html">Getting Started <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Bus-Route</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Bus-Route</h3>
 <p class="small">PPS site selection with Horvitz-Thompson estimators and enumeration expansion.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html">Bus-Route vignette →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html">Bus-Route vignette <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Ice Fishing</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Ice Fishing</h3>
 <p class="small">Degenerate bus-route design with certainty site sampling.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html">Ice Fishing vignette →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html">Ice Fishing vignette <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Camera-Monitored</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Camera-Monitored</h3>
 <p class="small">Counter and ingress-egress preprocessing, NB GLMM count imputation, and camera effort indexing.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html">Camera Survey vignette →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html">Camera Survey vignette <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Aerial Survey</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Aerial Survey</h3>
 <p class="small">Single-overflight effort estimation with calibrated open-hours scaling.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/aerial-surveys.html">Aerial vignette →</a> | <a href="https://chrischizinski.github.io/tidycreel/articles/aerial-glmm.html">GLMM variant →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/aerial-surveys.html">Aerial vignette <span aria-hidden="true">→</span></a> | <a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/aerial-glmm.html">GLMM variant <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
 </div>

--- a/README.md
+++ b/README.md
@@ -37,39 +37,44 @@ devtools::install_github("chrischizinski/tidycreel")
 ## Survey Types
 
 <div class="row mt-4 mb-4">
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Instantaneous Count</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Instantaneous Count</h3>
 <p class="small">Stratified effort estimation from periodic angler counts.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/tidycreel.html">Getting Started →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/tidycreel.html">Getting Started <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Bus-Route</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Bus-Route</h3>
 <p class="small">PPS site selection with Horvitz-Thompson estimators and enumeration expansion.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html">Bus-Route vignette →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/bus-route-surveys.html">Bus-Route vignette <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Ice Fishing</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Ice Fishing</h3>
 <p class="small">Degenerate bus-route design with certainty site sampling.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html">Ice Fishing vignette →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/ice-fishing.html">Ice Fishing vignette <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Camera-Monitored</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Camera-Monitored</h3>
 <p class="small">Counter and ingress-egress preprocessing, NB GLMM count imputation, and camera effort indexing.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html">Camera Survey vignette →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/camera-surveys.html">Camera Survey vignette <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
-<div class="col-md-4 mb-3">
-<div class="card h-100 border-0 bg-light p-3">
-<h5 class="text-primary">Aerial Survey</h5>
+<div class="col-sm-6 col-lg-4 mb-3">
+<div class="tc-survey-card h-100">
+<div class="tc-card-type" aria-hidden="true">Survey Type</div>
+<h3>Aerial Survey</h3>
 <p class="small">Single-overflight effort estimation with calibrated open-hours scaling.</p>
-<p class="small"><a href="https://chrischizinski.github.io/tidycreel/articles/aerial-surveys.html">Aerial vignette →</a> | <a href="https://chrischizinski.github.io/tidycreel/articles/aerial-glmm.html">GLMM variant →</a></p>
+<p class="mb-0"><a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/aerial-surveys.html">Aerial vignette <span aria-hidden="true">→</span></a> | <a class="tc-card-link" href="https://chrischizinski.github.io/tidycreel/articles/aerial-glmm.html">GLMM variant <span aria-hidden="true">→</span></a></p>
 </div>
 </div>
 </div>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,10 +9,12 @@ template:
     link-color: "#f47d65"
     headings-color: "#1f5e80"
     font-size-base: "1rem"
+    line-height-base: "1.65"
+    body-color: "#1c2e3d"
     border-radius: "0.375rem"
-    base_font: {google: "Inter"}
+    base_font: {google: "DM Sans"}
     heading_font: {google: "Outfit"}
-    code_font: {google: "Fira Code"}
+    code_font: {google: "JetBrains Mono"}
 
 home:
   title: "tidycreel"

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -21,7 +21,7 @@
 }
 
 a:hover {
-  color: #f47d65 !important;
+  color: #f47d65;
   text-decoration: underline;
   transition: color 0.3s ease-in-out;
 }
@@ -79,31 +79,71 @@ h1, h2, h3, h4, h5, h6 {
   color: #1f5e80;
 }
 
+h1, h2 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
 /* =============================================================
-   PHASE 54 ADDITIONS BELOW THIS LINE
-   (hero section spacing, badge styling)
+   REDESIGN ADDITIONS
    ============================================================= */
 
-/* ============================================================= */
-/*   PHASE 54: Hero section & badge styling                      */
-/* ============================================================= */
-
-/* ---- Feature Grid Cards ---- */
-/* Bootstrap 5 card grid for the Survey Types section on the home page */
-.card.border-0.bg-light {
+/* ---- Survey Type Cards ---- */
+.tc-survey-card {
+  border-top: 3px solid #f47d65;
+  background: transparent;
   border-radius: 0.375rem;
-  box-shadow: 0 1px 4px rgba(27, 79, 114, 0.12);
-  transition: box-shadow 0.2s ease;
+  padding: 1.25rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.card.border-0.bg-light:hover {
-  box-shadow: 0 4px 12px rgba(27, 79, 114, 0.22);
+.tc-survey-card:hover {
+  box-shadow: 0 4px 16px rgba(11, 59, 94, 0.18);
+  transform: translateY(-2px);
 }
 
-.card.border-0.bg-light h5.text-primary {
-  color: #0b3b5e !important;
-  font-size: 1rem;
-  margin-bottom: 0.4rem;
+@media (prefers-reduced-motion: reduce) {
+  .tc-survey-card {
+    transition: none;
+  }
+  .tc-survey-card:hover {
+    transform: none;
+  }
+}
+
+.tc-card-type {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5a6268;
+  margin-bottom: 0.35rem;
+}
+
+.tc-card-link {
+  color: #b83d29;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.tc-card-link:hover,
+.tc-card-link:focus {
+  color: #8c2d1e;
+  text-decoration: underline;
+}
+
+/* ---- Focus ring ---- */
+:focus-visible {
+  outline: 2px solid #f47d65;
+  outline-offset: 3px;
+}
+
+/* ---- Smooth scroll (reduced-motion safe) ---- */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 
 /* ---- Badge Block ---- */


### PR DESCRIPTION
## Summary

- Swap fonts: Inter → DM Sans (body), Fira Code → JetBrains Mono (code)
- Add `body-color: #1c2e3d` and `line-height-base: 1.65` to bslib vars
- Replace generic `.bg-light` cards with `.tc-survey-card` (top-border accent, transparent bg, hover lift with `prefers-reduced-motion` guard)
- Fix heading hierarchy: card titles `h5` → `h3` (was H2 → H5 skip — WCAG SC 1.3.1)
- Fix card hover contrast: removed `!important` from global `a:hover` that was overriding `.tc-card-link:hover` (would have rendered 2.63:1, fails SC 1.4.3 AA)
- Card link text `#b83d29` (5.62:1 on white, WCAG AA)
- Responsive grid `col-md-4` → `col-sm-6 col-lg-4`
- `aria-hidden` on decorative "Survey Type" labels and arrow glyphs
- Add h1/h2 weight + tracking, focus ring (`:focus-visible`), smooth scroll (motion-safe)

## Test plan

- [x] `just site` builds clean (exit 0, no warnings)
- [x] R CMD check passes (pre-push hook)
- [ ] Visual review on pkgdown site after CI deploys