### PR TITLE
fix(estimation): statistical correctness — t-CIs, Goodman variance, transformed CI bounds (#92–#100)

### DIFF
--- a/R/compare-variance.R
+++ b/R/compare-variance.R
@@ -240,12 +240,26 @@ resolve_variance_estimator <- function(method_str) {
       suppressWarnings(estimate_effort(design, ...)) # nolint: object_usage_linter
     })
   }
-  # Fallback: try estimate_catch_rate
-  cli::cli_warn(c(
+  if (grepl("product.total.harvest", method_str, ignore.case = TRUE)) {
+    return(function(design, ...) {
+      suppressWarnings(estimate_total_harvest(design, ...)) # nolint: object_usage_linter
+    })
+  }
+  if (grepl("product.total.release", method_str, ignore.case = TRUE)) {
+    return(function(design, ...) {
+      suppressWarnings(estimate_total_release(design, ...)) # nolint: object_usage_linter
+    })
+  }
+  if (grepl("product.total", method_str, ignore.case = TRUE)) {
+    return(function(design, ...) {
+      suppressWarnings(estimate_total_catch(design, ...)) # nolint: object_usage_linter
+    })
+  }
+  # Fallback: unsupported method — stop with a clear message
+  cli::cli_abort(c(
     "Cannot determine estimator from method string {.val {method_str}}.",
-    "i" = "Defaulting to {.fn estimate_catch_rate} for re-estimation."
+    "i" = "Supported method patterns: cpue/hpue/rpue/catch.rate/ratio, effort, product.total."
   ))
-  function(design, ...) suppressWarnings(estimate_catch_rate(design, ...)) # nolint: object_usage_linter
 }
 
 #' Print a creel_variance_comparison object

--- a/R/creel-estimates-exploitation-rate.R
+++ b/R/creel-estimates-exploitation-rate.R
@@ -36,6 +36,12 @@
 #'   row containing the T-weighted aggregate exploitation rate is appended to
 #'   the per-stratum estimates. Set to \code{FALSE} to suppress it. Ignored
 #'   when \code{strata = NULL}.
+#' @param ci_type character. Shape of the confidence interval.
+#'   \code{"symmetric"} (default) gives the standard \eqn{\hat u \pm z \cdot
+#'   SE} interval clamped to \eqn{[0,1]}. \code{"logit"} applies a
+#'   logit-transform so the CI respects the \eqn{[0,1]} constraint without
+#'   clamping: \eqn{\mathrm{expit}(\mathrm{logit}(\hat u) \pm z \cdot
+#'   SE / (\hat u (1-\hat u)))}.
 #'
 #' @details
 #' ## Unstratified Formula
@@ -144,8 +150,10 @@ estimate_exploitation_rate <- function(
   reporting_rate = 1.0,
   strata = NULL,
   by = NULL,
-  aggregate = TRUE
+  aggregate = TRUE,
+  ci_type = c("symmetric", "logit")
 ) {
+  ci_type <- match.arg(ci_type)
   # Route to stratified path if strata data frame provided
   if (!is.null(strata)) {
     return(.estimate_exploitation_rate_stratified(
@@ -153,7 +161,8 @@ estimate_exploitation_rate <- function(
       by = if (is.null(by)) "stratum" else by,
       aggregate = aggregate,
       conf_level = conf_level,
-      reporting_rate = reporting_rate
+      reporting_rate = reporting_rate,
+      ci_type = ci_type
     ))
   }
 
@@ -216,10 +225,17 @@ estimate_exploitation_rate <- function(
   var_u <- (r_hat^2 * var_p + p_hat^2 * var_r) / reporting_rate^2
   se_u <- sqrt(var_u)
 
-  # --- CI ---
-  z <- stats::qnorm(1 - (1 - conf_level) / 2)
-  ci_lo <- max(0, u_hat - z * se_u)
-  ci_hi <- min(1, u_hat + z * se_u)
+  # --- CI (t-distribution; df = n - 1 based on second-occasion inspected fish) ---
+  z <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, n - 1L))
+  if (ci_type == "logit" && u_hat > 0 && u_hat < 1) {
+    logit_u <- log(u_hat / (1 - u_hat))
+    se_logit <- se_u / (u_hat * (1 - u_hat))
+    ci_lo <- 1 / (1 + exp(-(logit_u - z * se_logit)))
+    ci_hi <- 1 / (1 + exp(-(logit_u + z * se_logit)))
+  } else {
+    ci_lo <- max(0, u_hat - z * se_u)
+    ci_hi <- min(1, u_hat + z * se_u)
+  }
 
   # --- return ---
   new_creel_estimates(
@@ -248,7 +264,8 @@ estimate_exploitation_rate <- function(
   by = "stratum",
   aggregate = TRUE,
   conf_level = 0.95,
-  reporting_rate = 1.0
+  reporting_rate = 1.0,
+  ci_type = "symmetric"
 ) {
   # Validate required columns
   req_cols <- c(by, "T_h", "C_h", "se_C_h", "n_h", "m_h")
@@ -285,14 +302,30 @@ estimate_exploitation_rate <- function(
   var_u_h <- (r_h^2 * var_p_h + p_h^2 * var_r_h) / reporting_rate^2
   se_u_h <- sqrt(var_u_h)
 
-  z <- stats::qnorm(1 - (1 - conf_level) / 2)
+  # Per-stratum t critical value (df = n_h - 1)
+  z_h <- stats::qt(1 - (1 - conf_level) / 2, df = pmax(1L, n_h - 1L))
 
+  .expit_ci <- function(u, se, z) {
+    if (ci_type == "logit") {
+      use_logit <- !is.na(u) & u > 0 & u < 1
+      logit_u <- ifelse(use_logit, log(u / (1 - u)), NA_real_)
+      se_logit <- ifelse(use_logit, se / (u * (1 - u)), NA_real_)
+      lower <- ifelse(use_logit, 1 / (1 + exp(-(logit_u - z * se_logit))), pmax(0, u - z * se))
+      upper <- ifelse(use_logit, 1 / (1 + exp(-(logit_u + z * se_logit))), pmin(1, u + z * se))
+    } else {
+      lower <- pmax(0, u - z * se)
+      upper <- pmin(1, u + z * se)
+    }
+    list(lower = lower, upper = upper)
+  }
+
+  ci_h <- .expit_ci(u_h, se_u_h, z_h)
   stratum_rows <- tibble::tibble(
     stratum = strata[[by]],
     estimate = u_h,
     se = se_u_h,
-    ci_lower = pmax(0, u_h - z * se_u_h),
-    ci_upper = pmin(1, u_h + z * se_u_h),
+    ci_lower = ci_h$lower,
+    ci_upper = ci_h$upper,
     n = n_h,
     T = T_h,
     C = C_h,
@@ -306,13 +339,19 @@ estimate_exploitation_rate <- function(
     u_agg <- sum(T_h * u_h) / sum_T
     var_agg <- sum(T_h^2 * var_u_h) / sum_T^2
     se_agg <- sqrt(var_agg)
+    # df for aggregate = sum(n_h) - n_strata (consistent with compute_stratum_product_sum)
+    z_agg <- stats::qt(
+      1 - (1 - conf_level) / 2,
+      df = max(1L, sum(n_h) - length(n_h))
+    )
+    ci_agg <- .expit_ci(u_agg, se_agg, z_agg)
 
     overall_row <- tibble::tibble(
       stratum = ".overall",
       estimate = u_agg,
       se = se_agg,
-      ci_lower = max(0, u_agg - z * se_agg),
-      ci_upper = min(1, u_agg + z * se_agg),
+      ci_lower = ci_agg$lower,
+      ci_upper = ci_agg$upper,
       n = sum(n_h),
       T = sum_T,
       C = sum(C_h),

--- a/R/creel-estimates-mark-recapture.R
+++ b/R/creel-estimates-mark-recapture.R
@@ -151,8 +151,8 @@ estimate_angler_n <- function(
     var_N <- ((M + 1) * (n + 1) * (M - m) * (n - m)) / ((m + 2) * (m + 1)^2)
     se_N <- sqrt(var_N)
 
-    # --- CI ---
-    z <- stats::qnorm(1 - (1 - conf_level) / 2)
+    # --- CI (t-distribution; df = m - 1 based on recapture count) ---
+    z <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, m - 1L))
     ci_lo <- N_hat - z * se_N
     ci_hi <- N_hat + z * se_N
 
@@ -196,8 +196,8 @@ estimate_angler_n <- function(
     var_N <- N_hat^2 * (1 / m - 1 / n)
     se_N <- sqrt(var_N)
 
-    # --- CI ---
-    z <- stats::qnorm(1 - (1 - conf_level) / 2)
+    # --- CI (t-distribution; df = m - 1 based on recapture count) ---
+    z <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, m - 1L))
     ci_lo <- N_hat - z * se_N
     ci_hi <- N_hat + z * se_N
 
@@ -255,7 +255,7 @@ estimate_angler_n <- function(
       }
       ci_hi <- if (lo_m == 0L) Inf else sum_Mn / lo_m
     } else {
-      z <- stats::qnorm(1 - (1 - conf_level) / 2)
+      z <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sum_m - 1L))
       inv_N <- 1 / N_hat
       ci_lo <- 1 / (inv_N + z * se_inv)
       ci_hi <- 1 / (inv_N - z * se_inv)
@@ -393,8 +393,9 @@ estimate_mr_harvest <- function(
   harvest_hat <- N_hat * harvest_rate
   se_H <- harvest_rate * se_N
 
-  # --- CI ---
-  z <- stats::qnorm(1 - (1 - conf_level) / 2)
+  # --- CI (t-distribution; df from N_hat recapture count) ---
+  n_mr <- as.integer(angler_n$estimates$n)
+  z <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, n_mr - 1L))
   ci_lo <- harvest_hat - z * se_H
   ci_hi <- harvest_hat + z * se_H
 

--- a/R/creel-estimates-total-catch.R
+++ b/R/creel-estimates-total-catch.R
@@ -55,8 +55,8 @@
 #'
 #' \deqn{Var(E \times C) \approx E^2 \cdot Var(C) + C^2 \cdot Var(E)}
 #'
-#' The function uses survey::svycontrast() to compute variance automatically
-#' via symbolic differentiation and Taylor series approximation.
+#' Variance is computed via a stratified delta-method sum in
+#' \code{compute_stratum_product_sum()}, not via \code{survey::svycontrast()}.
 #'
 #' \strong{Sectioned designs:}
 #' When \code{\link{add_sections}} has been called on the design, each section
@@ -625,7 +625,7 @@ estimate_total_catch_sections <- function(
         effort_se <- effort_res$estimates$se
         cpue_se <- cpue_res$estimates$se
         sec_estimate <- effort_est * cpue_est
-        sec_var <- (effort_est^2 * cpue_se^2) + (cpue_est^2 * effort_se^2)
+        sec_var <- (effort_est^2 * cpue_se^2) + (cpue_est^2 * effort_se^2) + (cpue_se^2 * effort_se^2)
         sec_se <- sqrt(sec_var)
         sec_n <- cpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))

--- a/R/creel-estimates-total-catch.R
+++ b/R/creel-estimates-total-catch.R
@@ -40,6 +40,16 @@
 #'   delta-method CIs. \code{"bootstrap"} additionally returns
 #'   \code{ci_lo_boot}/\code{ci_hi_boot} using survey bootstrap resampling.
 #'   Only applies to bus-route/ice designs.
+#' @param product_variance character. Variance formula for the product
+#'   \eqn{E \times C}. \code{"goodman"} (default) uses the exact Goodman
+#'   (1960) three-term formula \eqn{E^2 Var(C) + C^2 Var(E) + Var(E)Var(C)}.
+#'   \code{"first_order"} drops the cross-term (classical two-term delta
+#'   method).
+#' @param ci_type character. Shape of the confidence interval.
+#'   \code{"symmetric"} (default) gives the standard \eqn{\hat\theta \pm z
+#'   \cdot SE} interval clamped at zero. \code{"log"} applies a
+#'   log-transform so the CI stays positive:
+#'   \eqn{[\hat\theta e^{-z SE/\hat\theta},\; \hat\theta e^{z SE/\hat\theta}]}.
 #'
 #' @return A creel_estimates S3 object with method = "product-total-catch".
 #'   For bus-route designs, returns a bus-route HT estimate with method = "total"
@@ -120,13 +130,17 @@ estimate_total_catch <- function(
   aggregate_sections = TRUE,
   missing_sections = "warn",
   verbose = FALSE,
-  ci_method = c("delta", "bootstrap")
+  ci_method = c("delta", "bootstrap"),
+  product_variance = c("goodman", "first_order"),
+  ci_type = c("symmetric", "log")
 ) {
   # Capture by parameter BEFORE validation
   by_quo <- rlang::enquo(by)
   target <- match.arg(target)
   use_trips <- match.arg(use_trips)
   ci_method <- match.arg(ci_method)
+  product_variance <- match.arg(product_variance)
+  ci_type <- match.arg(ci_type)
 
   # Validate variance parameter
   valid_methods <- c("taylor", "bootstrap", "jackknife")
@@ -187,7 +201,9 @@ estimate_total_catch <- function(
       conf_level,
       aggregate_sections,
       missing_sections,
-      target = target
+      target = target,
+      product_variance = product_variance,
+      ci_type = ci_type
     ))
   }
 
@@ -211,7 +227,9 @@ estimate_total_catch <- function(
       interview_by_vars = by_info$interview_vars,
       variance_method = variance,
       conf_level = conf_level,
-      target = target
+      target = target,
+      product_variance = product_variance,
+      ci_type = ci_type
     )
     return(new_creel_estimates(
       # nolint: object_usage_linter
@@ -233,7 +251,9 @@ estimate_total_catch <- function(
       variance,
       conf_level,
       target = target,
-      use_trips = use_trips
+      use_trips = use_trips,
+      product_variance = product_variance,
+      ci_type = ci_type
     )) # nolint: object_usage_linter
   } else {
     # Grouped estimation
@@ -256,7 +276,9 @@ estimate_total_catch <- function(
       variance,
       conf_level,
       target = target,
-      use_trips = use_trips
+      use_trips = use_trips,
+      product_variance = product_variance,
+      ci_type = ci_type
     )) # nolint: object_usage_linter
   }
 }
@@ -319,7 +341,9 @@ estimate_total_catch_ungrouped <- function(
   variance_method,
   conf_level,
   target = "sampled_days",
-  use_trips = "complete"
+  use_trips = "complete",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
 
@@ -357,7 +381,9 @@ estimate_total_catch_ungrouped <- function(
     stratum_by_vars = strata_cols,
     interview_by_vars = NULL,
     conf_level = conf_level,
-    rate_suffix = "cpue"
+    rate_suffix = "cpue",
+    product_variance = product_variance,
+    ci_type = ci_type
   )
 
   new_creel_estimates(
@@ -389,7 +415,9 @@ estimate_total_catch_grouped <- function(
   variance_method,
   conf_level,
   target = "sampled_days",
-  use_trips = "complete"
+  use_trips = "complete",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
   # Union of calendar strata and user grouping: ensures per-stratum products
@@ -425,7 +453,9 @@ estimate_total_catch_grouped <- function(
     stratum_by_vars = stratum_by_vars,
     interview_by_vars = if (length(by_vars) > 0L) by_vars else NULL,
     conf_level = conf_level,
-    rate_suffix = "cpue"
+    rate_suffix = "cpue",
+    product_variance = product_variance,
+    ci_type = ci_type
   )
 
   new_creel_estimates(
@@ -455,7 +485,9 @@ estimate_total_catch_species <- function(
   interview_by_vars,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, interview_by_vars))
@@ -509,7 +541,9 @@ estimate_total_catch_species <- function(
       stratum_by_vars = stratum_by_vars,
       interview_by_vars = interview_by_vars,
       conf_level = conf_level,
-      rate_suffix = "cpue"
+      rate_suffix = "cpue",
+      product_variance = product_variance,
+      ci_type = ci_type
     )
 
     sp_result[[species_col]] <- sp
@@ -531,7 +565,9 @@ estimate_total_catch_sections <- function(
   conf_level,
   aggregate_sections,
   missing_sections,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
@@ -625,16 +661,27 @@ estimate_total_catch_sections <- function(
         effort_se <- effort_res$estimates$se
         cpue_se <- cpue_res$estimates$se
         sec_estimate <- effort_est * cpue_est
-        sec_var <- (effort_est^2 * cpue_se^2) + (cpue_est^2 * effort_se^2) + (cpue_se^2 * effort_se^2)
+        cross_term <- if (product_variance == "goodman") cpue_se^2 * effort_se^2 else 0
+        sec_var <- (effort_est^2 * cpue_se^2) + (cpue_est^2 * effort_se^2) + cross_term
         sec_se <- sqrt(sec_var)
         sec_n <- cpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))
+        sec_ci_lower <- if (ci_type == "log" && sec_estimate > 0) {
+          sec_estimate * exp(-z_val * sec_se / sec_estimate)
+        } else {
+          pmax(0, sec_estimate - z_val * sec_se)
+        }
+        sec_ci_upper <- if (ci_type == "log" && sec_estimate > 0) {
+          sec_estimate * exp(z_val * sec_se / sec_estimate)
+        } else {
+          sec_estimate + z_val * sec_se
+        }
         section_rows[[sec]] <- tibble::tibble(
           section = sec,
           estimate = sec_estimate,
           se = sec_se,
-          ci_lower = pmax(0, sec_estimate - z_val * sec_se),
-          ci_upper = sec_estimate + z_val * sec_se,
+          ci_lower = sec_ci_lower,
+          ci_upper = sec_ci_upper,
           n = sec_n,
           prop_of_lake_total = NA_real_,
           data_available = TRUE
@@ -661,8 +708,16 @@ estimate_total_catch_sections <- function(
     # CI for lake total: sum(section n) - n_sections (consistent with compute_stratum_product_sum)
     df_lake <- max(1L, sum(present_rows$n) - nrow(present_rows))
     t_crit <- qt(1 - (1 - conf_level) / 2, df = df_lake)
-    lake_ci_lower <- pmax(0, lake_est - t_crit * lake_se)
-    lake_ci_upper <- lake_est + t_crit * lake_se
+    lake_ci_lower <- if (ci_type == "log" && lake_est > 0) {
+      lake_est * exp(-t_crit * lake_se / lake_est)
+    } else {
+      pmax(0, lake_est - t_crit * lake_se)
+    }
+    lake_ci_upper <- if (ci_type == "log" && lake_est > 0) {
+      lake_est * exp(t_crit * lake_se / lake_est)
+    } else {
+      lake_est + t_crit * lake_se
+    }
 
     lake_row <- tibble::tibble(
       section = ".lake_total",

--- a/R/creel-estimates-total-catch.R
+++ b/R/creel-estimates-total-catch.R
@@ -633,7 +633,7 @@ estimate_total_catch_sections <- function(
           section = sec,
           estimate = sec_estimate,
           se = sec_se,
-          ci_lower = sec_estimate - z_val * sec_se,
+          ci_lower = pmax(0, sec_estimate - z_val * sec_se),
           ci_upper = sec_estimate + z_val * sec_se,
           n = sec_n,
           prop_of_lake_total = NA_real_,
@@ -658,12 +658,10 @@ estimate_total_catch_sections <- function(
     lake_est <- sum(present_rows$estimate)
     lake_se <- sqrt(sum(present_rows$se^2))
 
-    # CI for lake total using t-distribution (consistent with rate section helpers)
-    full_svy <- get_variance_design(design$survey, variance_method) # nolint: object_usage_linter
-    df <- as.numeric(survey::degf(full_svy))
-    alpha <- 1 - conf_level
-    t_crit <- qt(1 - alpha / 2, df = df)
-    lake_ci_lower <- lake_est - t_crit * lake_se
+    # CI for lake total: sum(section n) - n_sections (consistent with compute_stratum_product_sum)
+    df_lake <- max(1L, sum(present_rows$n) - nrow(present_rows))
+    t_crit <- qt(1 - (1 - conf_level) / 2, df = df_lake)
+    lake_ci_lower <- pmax(0, lake_est - t_crit * lake_se)
     lake_ci_upper <- lake_est + t_crit * lake_se
 
     lake_row <- tibble::tibble(

--- a/R/creel-estimates-total-harvest.R
+++ b/R/creel-estimates-total-harvest.R
@@ -544,7 +544,7 @@ estimate_total_harvest_sections <- function(
           section = sec,
           estimate = sec_estimate,
           se = sec_se,
-          ci_lower = sec_estimate - z_val * sec_se,
+          ci_lower = pmax(0, sec_estimate - z_val * sec_se),
           ci_upper = sec_estimate + z_val * sec_se,
           n = sec_n,
           prop_of_lake_total = NA_real_,
@@ -569,11 +569,10 @@ estimate_total_harvest_sections <- function(
     lake_est <- sum(present_rows$estimate)
     lake_se <- sqrt(sum(present_rows$se^2))
 
-    full_svy <- get_variance_design(design$survey, variance_method) # nolint: object_usage_linter
-    df <- as.numeric(survey::degf(full_svy))
-    alpha <- 1 - conf_level
-    t_crit <- qt(1 - alpha / 2, df = df)
-    lake_ci_lower <- lake_est - t_crit * lake_se
+    # CI for lake total: sum(section n) - n_sections (consistent with compute_stratum_product_sum)
+    df_lake <- max(1L, sum(present_rows$n) - nrow(present_rows))
+    t_crit <- qt(1 - (1 - conf_level) / 2, df = df_lake)
+    lake_ci_lower <- pmax(0, lake_est - t_crit * lake_se)
     lake_ci_upper <- lake_est + t_crit * lake_se
 
     lake_row <- tibble::tibble(

--- a/R/creel-estimates-total-harvest.R
+++ b/R/creel-estimates-total-harvest.R
@@ -36,6 +36,13 @@
 #'   delta-method CIs. \code{"bootstrap"} additionally returns
 #'   \code{ci_lo_boot}/\code{ci_hi_boot} using survey bootstrap resampling.
 #'   Only applies to bus-route/ice designs.
+#' @param product_variance character. Variance formula for the product
+#'   \eqn{E \times H}. \code{"goodman"} (default) uses the exact Goodman
+#'   (1960) three-term formula. \code{"first_order"} drops the cross-term.
+#' @param ci_type character. Shape of the confidence interval.
+#'   \code{"symmetric"} (default) gives \eqn{\hat\theta \pm z \cdot SE}
+#'   clamped at zero. \code{"log"} applies a log-transform for a
+#'   strictly positive CI.
 #'
 #' @return A creel_estimates S3 object with method = "product-total-harvest"
 #'
@@ -104,12 +111,16 @@ estimate_total_harvest <- function(
   target = c("sampled_days", "stratum_total", "period_total"),
   aggregate_sections = TRUE,
   missing_sections = "warn",
-  ci_method = c("delta", "bootstrap")
+  ci_method = c("delta", "bootstrap"),
+  product_variance = c("goodman", "first_order"),
+  ci_type = c("symmetric", "log")
 ) {
   # Capture by parameter BEFORE validation
   by_quo <- rlang::enquo(by)
   target <- match.arg(target)
   ci_method <- match.arg(ci_method)
+  product_variance <- match.arg(product_variance)
+  ci_type <- match.arg(ci_type)
 
   # Validate variance parameter
   valid_methods <- c("taylor", "bootstrap", "jackknife")
@@ -175,7 +186,8 @@ estimate_total_harvest <- function(
       interview_by_vars = by_info$interview_vars,
       variance_method = variance,
       conf_level = conf_level,
-      target = target
+      target = target,
+      product_variance = product_variance
     )
     return(new_creel_estimates(
       # nolint: object_usage_linter
@@ -212,14 +224,16 @@ estimate_total_harvest <- function(
       conf_level,
       aggregate_sections,
       missing_sections,
-      target = target
+      target = target,
+      product_variance = product_variance,
+      ci_type = ci_type
     ))
   }
 
   # Route to grouped or ungrouped estimation
   if (rlang::quo_is_null(by_quo)) {
     # Ungrouped estimation
-    return(estimate_total_harvest_ungrouped(design, variance, conf_level, target = target)) # nolint: object_usage_linter
+    return(estimate_total_harvest_ungrouped(design, variance, conf_level, target = target, product_variance = product_variance, ci_type = ci_type)) # nolint: object_usage_linter
   } else {
     # Grouped estimation
     # Resolve by parameter to column names
@@ -235,7 +249,7 @@ estimate_total_harvest <- function(
     # Validate grouping compatibility
     validate_grouping_compatibility(design, by_vars) # nolint: object_usage_linter
 
-    return(estimate_total_harvest_grouped(design, by_vars, variance, conf_level, target = target)) # nolint: object_usage_linter
+    return(estimate_total_harvest_grouped(design, by_vars, variance, conf_level, target = target, product_variance = product_variance, ci_type = ci_type)) # nolint: object_usage_linter
   }
 }
 
@@ -251,7 +265,9 @@ estimate_total_harvest_ungrouped <- function(
   design,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   # nolint: object_length_linter
   strata_cols <- design$strata_cols %||% character(0)
@@ -288,7 +304,9 @@ estimate_total_harvest_ungrouped <- function(
     stratum_by_vars = strata_cols,
     interview_by_vars = NULL,
     conf_level = conf_level,
-    rate_suffix = "hpue"
+    rate_suffix = "hpue",
+    product_variance = product_variance,
+    ci_type = ci_type
   )
 
   new_creel_estimates(
@@ -315,7 +333,9 @@ estimate_total_harvest_grouped <- function(
   by_vars,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, by_vars))
@@ -341,7 +361,9 @@ estimate_total_harvest_grouped <- function(
     stratum_by_vars = stratum_by_vars,
     interview_by_vars = if (length(by_vars) > 0L) by_vars else NULL,
     conf_level = conf_level,
-    rate_suffix = "hpue"
+    rate_suffix = "hpue",
+    product_variance = product_variance,
+    ci_type = ci_type
   )
 
   new_creel_estimates(
@@ -366,7 +388,9 @@ estimate_total_harvest_species <- function(
   interview_by_vars,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, interview_by_vars))
@@ -420,7 +444,9 @@ estimate_total_harvest_species <- function(
       stratum_by_vars = stratum_by_vars,
       interview_by_vars = interview_by_vars,
       conf_level = conf_level,
-      rate_suffix = "hpue"
+      rate_suffix = "hpue",
+      product_variance = product_variance,
+      ci_type = ci_type
     )
 
     sp_result[[species_col]] <- sp
@@ -442,7 +468,9 @@ estimate_total_harvest_sections <- function(
   conf_level,
   aggregate_sections,
   missing_sections,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
@@ -536,7 +564,8 @@ estimate_total_harvest_sections <- function(
         effort_se <- effort_res$estimates$se
         hpue_se <- hpue_res$estimates$se
         sec_estimate <- effort_est * hpue_est
-        sec_var <- (effort_est^2 * hpue_se^2) + (hpue_est^2 * effort_se^2) + (hpue_se^2 * effort_se^2)
+        cross_term <- if (product_variance == "goodman") hpue_se^2 * effort_se^2 else 0
+        sec_var <- (effort_est^2 * hpue_se^2) + (hpue_est^2 * effort_se^2) + cross_term
         sec_se <- sqrt(sec_var)
         sec_n <- hpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))
@@ -544,8 +573,8 @@ estimate_total_harvest_sections <- function(
           section = sec,
           estimate = sec_estimate,
           se = sec_se,
-          ci_lower = pmax(0, sec_estimate - z_val * sec_se),
-          ci_upper = sec_estimate + z_val * sec_se,
+          ci_lower = if (ci_type == "log" && sec_estimate > 0) sec_estimate * exp(-z_val * sec_se / sec_estimate) else pmax(0, sec_estimate - z_val * sec_se),
+          ci_upper = if (ci_type == "log" && sec_estimate > 0) sec_estimate * exp(z_val * sec_se / sec_estimate) else sec_estimate + z_val * sec_se,
           n = sec_n,
           prop_of_lake_total = NA_real_,
           data_available = TRUE
@@ -572,8 +601,8 @@ estimate_total_harvest_sections <- function(
     # CI for lake total: sum(section n) - n_sections (consistent with compute_stratum_product_sum)
     df_lake <- max(1L, sum(present_rows$n) - nrow(present_rows))
     t_crit <- qt(1 - (1 - conf_level) / 2, df = df_lake)
-    lake_ci_lower <- pmax(0, lake_est - t_crit * lake_se)
-    lake_ci_upper <- lake_est + t_crit * lake_se
+    lake_ci_lower <- if (ci_type == "log" && lake_est > 0) lake_est * exp(-t_crit * lake_se / lake_est) else pmax(0, lake_est - t_crit * lake_se)
+    lake_ci_upper <- if (ci_type == "log" && lake_est > 0) lake_est * exp(t_crit * lake_se / lake_est) else lake_est + t_crit * lake_se
 
     lake_row <- tibble::tibble(
       section = ".lake_total",

--- a/R/creel-estimates-total-harvest.R
+++ b/R/creel-estimates-total-harvest.R
@@ -46,8 +46,8 @@
 #'
 #' \deqn{Var(E \times H) \approx E^2 \cdot Var(H) + H^2 \cdot Var(E)}
 #'
-#' The function uses survey::svycontrast() to compute variance automatically
-#' via symbolic differentiation and Taylor series approximation.
+#' Variance is computed via a stratified delta-method sum in
+#' \code{compute_stratum_product_sum()}, not via \code{survey::svycontrast()}.
 #'
 #' \strong{Sectioned designs:}
 #' When \code{\link{add_sections}} has been called on the design, each section
@@ -536,7 +536,7 @@ estimate_total_harvest_sections <- function(
         effort_se <- effort_res$estimates$se
         hpue_se <- hpue_res$estimates$se
         sec_estimate <- effort_est * hpue_est
-        sec_var <- (effort_est^2 * hpue_se^2) + (hpue_est^2 * effort_se^2)
+        sec_var <- (effort_est^2 * hpue_se^2) + (hpue_est^2 * effort_se^2) + (hpue_se^2 * effort_se^2)
         sec_se <- sqrt(sec_var)
         sec_n <- hpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))

--- a/R/creel-estimates-total-release.R
+++ b/R/creel-estimates-total-release.R
@@ -504,7 +504,7 @@ estimate_total_release_sections <- function(
         effort_se <- effort_res$estimates$se
         rpue_se <- rpue_res$estimates$se
         sec_estimate <- effort_est * rpue_est
-        sec_var <- (effort_est^2 * rpue_se^2) + (rpue_est^2 * effort_se^2)
+        sec_var <- (effort_est^2 * rpue_se^2) + (rpue_est^2 * effort_se^2) + (rpue_se^2 * effort_se^2)
         sec_se <- sqrt(sec_var)
         sec_n <- rpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))

--- a/R/creel-estimates-total-release.R
+++ b/R/creel-estimates-total-release.R
@@ -31,6 +31,13 @@
 #'   absent from either count data or interview data: \code{"warn"} (default)
 #'   inserts an NA row with \code{data_available = FALSE}, \code{"error"}
 #'   raises a hard error.
+#' @param product_variance character. Variance formula for the product
+#'   \eqn{E \times R}. \code{"goodman"} (default) uses the exact Goodman
+#'   (1960) three-term formula. \code{"first_order"} drops the cross-term.
+#' @param ci_type character. Shape of the confidence interval.
+#'   \code{"symmetric"} (default) gives \eqn{\hat\theta \pm z \cdot SE}
+#'   clamped at zero. \code{"log"} applies a log-transform for a
+#'   strictly positive CI.
 #'
 #' @return A creel_estimates S3 object with method = "product-total-release".
 #'   Estimates tibble has columns: estimate, se, ci_lower, ci_upper, n (plus
@@ -83,10 +90,14 @@ estimate_total_release <- function(
   conf_level = 0.95,
   target = c("sampled_days", "stratum_total", "period_total"),
   aggregate_sections = TRUE,
-  missing_sections = "warn"
+  missing_sections = "warn",
+  product_variance = c("goodman", "first_order"),
+  ci_type = c("symmetric", "log")
 ) {
   by_quo <- rlang::enquo(by)
   target <- match.arg(target)
+  product_variance <- match.arg(product_variance)
+  ci_type <- match.arg(ci_type)
 
   # Validate variance parameter
   valid_methods <- c("taylor", "bootstrap", "jackknife")
@@ -131,7 +142,9 @@ estimate_total_release <- function(
       interview_by_vars = by_info$interview_vars,
       variance_method = variance,
       conf_level = conf_level,
-      target = target
+      target = target,
+      product_variance = product_variance,
+      ci_type = ci_type
     )
     return(new_creel_estimates(
       # nolint: object_usage_linter
@@ -155,13 +168,15 @@ estimate_total_release <- function(
       conf_level,
       aggregate_sections,
       missing_sections,
-      target = target
+      target = target,
+      product_variance = product_variance,
+      ci_type = ci_type
     ))
   }
 
   # Standard (non-species) routing
   if (rlang::quo_is_null(by_quo)) {
-    return(estimate_total_release_ungrouped(design, variance, conf_level, target = target)) # nolint: object_usage_linter
+    return(estimate_total_release_ungrouped(design, variance, conf_level, target = target, product_variance = product_variance, ci_type = ci_type)) # nolint: object_usage_linter
   } else {
     by_cols <- tidyselect::eval_select(
       by_quo,
@@ -172,7 +187,7 @@ estimate_total_release <- function(
     )
     by_vars <- names(by_cols)
     validate_grouping_compatibility(design, by_vars) # nolint: object_usage_linter
-    return(estimate_total_release_grouped(design, by_vars, variance, conf_level, target = target)) # nolint: object_usage_linter
+    return(estimate_total_release_grouped(design, by_vars, variance, conf_level, target = target, product_variance = product_variance, ci_type = ci_type)) # nolint: object_usage_linter
   }
 }
 
@@ -213,7 +228,9 @@ estimate_total_release_ungrouped <- function(
   design,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   # nolint: object_length_linter
   strata_cols <- design$strata_cols %||% character(0)
@@ -243,7 +260,9 @@ estimate_total_release_ungrouped <- function(
     stratum_by_vars = strata_cols,
     interview_by_vars = NULL,
     conf_level = conf_level,
-    rate_suffix = "rpue"
+    rate_suffix = "rpue",
+    product_variance = product_variance,
+    ci_type = ci_type
   )
 
   new_creel_estimates(
@@ -265,7 +284,9 @@ estimate_total_release_grouped <- function(
   by_vars,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, by_vars))
@@ -291,7 +312,9 @@ estimate_total_release_grouped <- function(
     stratum_by_vars = stratum_by_vars,
     interview_by_vars = if (length(by_vars) > 0L) by_vars else NULL,
     conf_level = conf_level,
-    rate_suffix = "rpue"
+    rate_suffix = "rpue",
+    product_variance = product_variance,
+    ci_type = ci_type
   )
 
   new_creel_estimates(
@@ -316,7 +339,9 @@ estimate_total_release_species <- function(
   interview_by_vars,
   variance_method,
   conf_level,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   strata_cols <- design$strata_cols %||% character(0)
   stratum_by_vars <- unique(c(strata_cols, interview_by_vars))
@@ -370,7 +395,9 @@ estimate_total_release_species <- function(
       stratum_by_vars = stratum_by_vars,
       interview_by_vars = interview_by_vars,
       conf_level = conf_level,
-      rate_suffix = "rpue"
+      rate_suffix = "rpue",
+      product_variance = product_variance,
+      ci_type = ci_type
     )
 
     sp_result[[species_col]] <- sp
@@ -392,7 +419,9 @@ estimate_total_release_sections <- function(
   conf_level,
   aggregate_sections,
   missing_sections,
-  target = "sampled_days"
+  target = "sampled_days",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
   section_col <- design[["section_col"]]
   registered_sections <- design$sections[[section_col]]
@@ -504,7 +533,8 @@ estimate_total_release_sections <- function(
         effort_se <- effort_res$estimates$se
         rpue_se <- rpue_res$estimates$se
         sec_estimate <- effort_est * rpue_est
-        sec_var <- (effort_est^2 * rpue_se^2) + (rpue_est^2 * effort_se^2) + (rpue_se^2 * effort_se^2)
+        cross_term <- if (product_variance == "goodman") rpue_se^2 * effort_se^2 else 0
+        sec_var <- (effort_est^2 * rpue_se^2) + (rpue_est^2 * effort_se^2) + cross_term
         sec_se <- sqrt(sec_var)
         sec_n <- rpue_res$estimates$n
         z_val <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, sec_n - 1L))
@@ -512,8 +542,8 @@ estimate_total_release_sections <- function(
           section = sec,
           estimate = sec_estimate,
           se = sec_se,
-          ci_lower = pmax(0, sec_estimate - z_val * sec_se),
-          ci_upper = sec_estimate + z_val * sec_se,
+          ci_lower = if (ci_type == "log" && sec_estimate > 0) sec_estimate * exp(-z_val * sec_se / sec_estimate) else pmax(0, sec_estimate - z_val * sec_se),
+          ci_upper = if (ci_type == "log" && sec_estimate > 0) sec_estimate * exp(z_val * sec_se / sec_estimate) else sec_estimate + z_val * sec_se,
           n = sec_n,
           prop_of_lake_total = NA_real_,
           data_available = TRUE
@@ -540,8 +570,8 @@ estimate_total_release_sections <- function(
     # CI for lake total: sum(section n) - n_sections (consistent with compute_stratum_product_sum)
     df_lake <- max(1L, sum(present_rows$n) - nrow(present_rows))
     t_crit <- qt(1 - (1 - conf_level) / 2, df = df_lake)
-    lake_ci_lower <- pmax(0, lake_est - t_crit * lake_se)
-    lake_ci_upper <- lake_est + t_crit * lake_se
+    lake_ci_lower <- if (ci_type == "log" && lake_est > 0) lake_est * exp(-t_crit * lake_se / lake_est) else pmax(0, lake_est - t_crit * lake_se)
+    lake_ci_upper <- if (ci_type == "log" && lake_est > 0) lake_est * exp(t_crit * lake_se / lake_est) else lake_est + t_crit * lake_se
 
     lake_row <- tibble::tibble(
       section = ".lake_total",

--- a/R/creel-estimates-total-release.R
+++ b/R/creel-estimates-total-release.R
@@ -512,7 +512,7 @@ estimate_total_release_sections <- function(
           section = sec,
           estimate = sec_estimate,
           se = sec_se,
-          ci_lower = sec_estimate - z_val * sec_se,
+          ci_lower = pmax(0, sec_estimate - z_val * sec_se),
           ci_upper = sec_estimate + z_val * sec_se,
           n = sec_n,
           prop_of_lake_total = NA_real_,
@@ -537,11 +537,10 @@ estimate_total_release_sections <- function(
     lake_est <- sum(present_rows$estimate)
     lake_se <- sqrt(sum(present_rows$se^2))
 
-    full_svy <- get_variance_design(design$survey, variance_method) # nolint: object_usage_linter
-    df <- as.numeric(survey::degf(full_svy))
-    alpha <- 1 - conf_level
-    t_crit <- qt(1 - alpha / 2, df = df)
-    lake_ci_lower <- lake_est - t_crit * lake_se
+    # CI for lake total: sum(section n) - n_sections (consistent with compute_stratum_product_sum)
+    df_lake <- max(1L, sum(present_rows$n) - nrow(present_rows))
+    t_crit <- qt(1 - (1 - conf_level) / 2, df = df_lake)
+    lake_ci_lower <- pmax(0, lake_est - t_crit * lake_se)
     lake_ci_upper <- lake_est + t_crit * lake_se
 
     lake_row <- tibble::tibble(

--- a/R/creel-estimates-trip-density.R
+++ b/R/creel-estimates-trip-density.R
@@ -81,7 +81,6 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
     ))
   }
 
-  z <- stats::qnorm(1 - (1 - conf_level) / 2)
   min_n_se <- 2L
 
   # --- ungrouped case ---
@@ -111,6 +110,7 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
     var_trips <- se_E^2 / L^2 + E^2 * se_L^2 / L^4
     se_trips <- sqrt(var_trips)
     trips <- E / L
+    z <- stats::qt(1 - (1 - conf_level) / 2, df = max(1L, n_int - 1L))
 
     estimates_df <- tibble::tibble(
       estimate = trips,
@@ -193,20 +193,27 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   trips <- E / L
   se_trips <- sqrt(var_trips)
 
+  # Per-stratum t critical values (df = n_interviews - 1 per stratum)
+  z_vec <- stats::qt(1 - (1 - conf_level) / 2, df = pmax(1L, joined$n_interviews - 1L))
+
   # Per-stratum rows
   stratum_rows <- tibble::tibble(
     dplyr::select(joined, dplyr::all_of(effort$by_vars)),
     estimate = trips,
     se = se_trips,
-    ci_lower = trips - z * se_trips,
-    ci_upper = trips + z * se_trips,
+    ci_lower = trips - z_vec * se_trips,
+    ci_upper = trips + z_vec * se_trips,
     n = joined$n_interviews
   )
 
-  # .overall row: additive aggregate
+  # .overall row: additive aggregate; df = sum(n) - n_strata
   overall_est <- sum(trips)
   overall_var <- sum(var_trips)
   overall_se <- sqrt(overall_var)
+  z_overall <- stats::qt(
+    1 - (1 - conf_level) / 2,
+    df = max(1L, sum(joined$n_interviews) - nrow(joined))
+  )
 
   overall_vals <- stats::setNames(
     rep(".overall", length(effort$by_vars)),
@@ -215,8 +222,8 @@ estimate_angler_trips <- function(effort, design, conf_level = 0.95, ...) {
   overall_row <- tibble::as_tibble(as.list(overall_vals))
   overall_row$estimate <- overall_est
   overall_row$se <- overall_se
-  overall_row$ci_lower <- overall_est - z * overall_se
-  overall_row$ci_upper <- overall_est + z * overall_se
+  overall_row$ci_lower <- overall_est - z_overall * overall_se
+  overall_row$ci_upper <- overall_est + z_overall * overall_se
   overall_row$n <- sum(joined$n_interviews)
 
   estimates_df <- dplyr::bind_rows(stratum_rows, overall_row)

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -3002,6 +3002,17 @@ estimate_cpue_total <- function(design, variance_method, conf_level, estimator =
   catch_col <- design$catch_col
   effort_col <- design$angler_effort_col
 
+  # Filter out NA-effort interviews with warning (must precede zero-effort filter)
+  na_effort <- is.na(interviews_data[[effort_col]])
+  if (any(na_effort)) {
+    n_na <- sum(na_effort) # nolint: object_usage_linter
+    cli::cli_warn(c(
+      "{n_na} interview{?s} with missing effort excluded from CPUE estimation.",
+      "i" = "Interviews must have non-NA effort values for CPUE estimation."
+    ))
+    interviews_data <- interviews_data[!na_effort, , drop = FALSE]
+  }
+
   # Filter out zero-effort interviews with warning
   zero_effort <- !is.na(interviews_data[[effort_col]]) & interviews_data[[effort_col]] == 0
   if (any(zero_effort)) {
@@ -3129,6 +3140,17 @@ estimate_cpue_grouped <- function(
   interviews_data <- design$interviews
   catch_col <- design$catch_col
   effort_col <- design$angler_effort_col
+
+  # Filter out NA-effort interviews with warning (must precede zero-effort filter)
+  na_effort <- is.na(interviews_data[[effort_col]])
+  if (any(na_effort)) {
+    n_na <- sum(na_effort) # nolint: object_usage_linter
+    cli::cli_warn(c(
+      "{n_na} interview{?s} with missing effort excluded from CPUE estimation.",
+      "i" = "Interviews must have non-NA effort values for CPUE estimation."
+    ))
+    interviews_data <- interviews_data[!na_effort, , drop = FALSE]
+  }
 
   # Filter out zero-effort interviews with warning
   zero_effort <- !is.na(interviews_data[[effort_col]]) & interviews_data[[effort_col]] == 0
@@ -3368,7 +3390,7 @@ compute_stratum_product_sum <- function(
     e_se <- effort_df$se
     r_se <- rate_df$se
     est <- e_est * r_est
-    pv <- (e_est^2 * r_se^2) + (r_est^2 * e_se^2)
+    pv <- (e_est^2 * r_se^2) + (r_est^2 * e_se^2) + (r_se^2 * e_se^2)
     return(data.frame(
       estimate = est,
       se = sqrt(pv),
@@ -3397,7 +3419,8 @@ compute_stratum_product_sum <- function(
   # Per-stratum delta-method products and variances
   merged$.est_sh <- merged[[e_col]] * merged[[r_col]]
   merged$.var_sh <- (merged[[e_col]]^2 * merged[[se_r]]^2) +
-    (merged[[r_col]]^2 * merged[[se_e]]^2)
+    (merged[[r_col]]^2 * merged[[se_e]]^2) +
+    (merged[[se_r]]^2 * merged[[se_e]]^2)
   merged$.n_sh <- merged[[n_r]]
 
   if (is.null(interview_by_vars)) {
@@ -3634,6 +3657,17 @@ estimate_harvest_total <- function(design, variance_method, conf_level) {
   harvest_col <- design$harvest_col
   effort_col <- design$angler_effort_col
 
+  # Filter out NA-effort interviews with warning (must precede zero-effort filter)
+  na_effort <- is.na(interviews_data[[effort_col]])
+  if (any(na_effort)) {
+    n_na <- sum(na_effort) # nolint: object_usage_linter
+    cli::cli_warn(c(
+      "{n_na} interview{?s} with missing effort excluded from harvest estimation.",
+      "i" = "Interviews must have non-NA effort values for HPUE estimation."
+    ))
+    interviews_data <- interviews_data[!na_effort, , drop = FALSE]
+  }
+
   # Filter out zero-effort interviews with warning
   zero_effort <- !is.na(interviews_data[[effort_col]]) & interviews_data[[effort_col]] == 0
   if (any(zero_effort)) {
@@ -3666,7 +3700,7 @@ estimate_harvest_total <- function(design, variance_method, conf_level) {
   }
 
   # Build temporary survey design from filtered data if filtering occurred
-  needs_rebuild <- any(zero_effort) || any(na_harvest)
+  needs_rebuild <- any(na_effort) || any(zero_effort) || any(na_harvest)
   if (needs_rebuild) {
     strata_cols <- design$strata_cols
     strata_formula <- if (!is.null(strata_cols) && length(strata_cols) > 0) {
@@ -3727,6 +3761,17 @@ estimate_harvest_grouped <- function(design, by_vars, variance_method, conf_leve
   harvest_col <- design$harvest_col
   effort_col <- design$angler_effort_col
 
+  # Filter out NA-effort interviews with warning (must precede zero-effort filter)
+  na_effort <- is.na(interviews_data[[effort_col]])
+  if (any(na_effort)) {
+    n_na <- sum(na_effort) # nolint: object_usage_linter
+    cli::cli_warn(c(
+      "{n_na} interview{?s} with missing effort excluded from harvest estimation.",
+      "i" = "Interviews must have non-NA effort values for HPUE estimation."
+    ))
+    interviews_data <- interviews_data[!na_effort, , drop = FALSE]
+  }
+
   # Filter out zero-effort interviews with warning
   zero_effort <- !is.na(interviews_data[[effort_col]]) & interviews_data[[effort_col]] == 0
   if (any(zero_effort)) {
@@ -3759,7 +3804,7 @@ estimate_harvest_grouped <- function(design, by_vars, variance_method, conf_leve
   }
 
   # Build temporary survey design from filtered data if filtering occurred
-  needs_rebuild <- any(zero_effort) || any(na_harvest)
+  needs_rebuild <- any(na_effort) || any(zero_effort) || any(na_harvest)
   if (needs_rebuild) {
     strata_cols <- design$strata_cols
     strata_formula <- if (!is.null(strata_cols) && length(strata_cols) > 0) {

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -3376,8 +3376,23 @@ compute_stratum_product_sum <- function(
   stratum_by_vars,
   interview_by_vars,
   conf_level,
-  rate_suffix = "rate"
+  rate_suffix = "rate",
+  product_variance = "goodman",
+  ci_type = "symmetric"
 ) {
+  # Vectorized CI builder: log-transform for positive totals, else Wald with clamp
+  .ci <- function(est, se_val, z) {
+    if (ci_type == "log") {
+      use_log <- !is.na(est) & est > 0
+      lower <- ifelse(use_log, est * exp(-z * se_val / est), pmax(0, est - z * se_val))
+      upper <- ifelse(use_log, est * exp(z * se_val / est), est + z * se_val)
+    } else {
+      lower <- pmax(0, est - z * se_val)
+      upper <- est + z * se_val
+    }
+    list(lower = lower, upper = upper)
+  }
+
   # t-distribution df: total interviews minus number of strata (conservative)
   n_strata_ci <- if (length(stratum_by_vars) == 0L) 1L else max(1L, nrow(rate_df))
   df_ci <- max(1L, sum(rate_df$n, na.rm = TRUE) - n_strata_ci)
@@ -3390,13 +3405,15 @@ compute_stratum_product_sum <- function(
     e_se <- effort_df$se
     r_se <- rate_df$se
     est <- e_est * r_est
-    pv <- (e_est^2 * r_se^2) + (r_est^2 * e_se^2) + (r_se^2 * e_se^2)
+    cross_term <- if (product_variance == "goodman") r_se^2 * e_se^2 else 0
+    pv <- (e_est^2 * r_se^2) + (r_est^2 * e_se^2) + cross_term
     se_val <- sqrt(pv)
+    ci <- .ci(est, se_val, z)
     return(data.frame(
       estimate = est,
       se = se_val,
-      ci_lower = pmax(0, est - z * se_val),
-      ci_upper = est + z * se_val,
+      ci_lower = ci$lower,
+      ci_upper = ci$upper,
       n = rate_df$n,
       stringsAsFactors = FALSE
     ))
@@ -3419,9 +3436,14 @@ compute_stratum_product_sum <- function(
 
   # Per-stratum delta-method products and variances
   merged$.est_sh <- merged[[e_col]] * merged[[r_col]]
+  cross_term_sh <- if (product_variance == "goodman") {
+    merged[[se_r]]^2 * merged[[se_e]]^2
+  } else {
+    rep(0, nrow(merged))
+  }
   merged$.var_sh <- (merged[[e_col]]^2 * merged[[se_r]]^2) +
     (merged[[r_col]]^2 * merged[[se_e]]^2) +
-    (merged[[se_r]]^2 * merged[[se_e]]^2)
+    cross_term_sh
   merged$.n_sh <- merged[[n_r]]
 
   if (is.null(interview_by_vars)) {
@@ -3430,11 +3452,12 @@ compute_stratum_product_sum <- function(
     pv <- sum(merged$.var_sh)
     n <- sum(merged$.n_sh)
     se_val <- sqrt(pv)
+    ci <- .ci(est, se_val, z)
     data.frame(
       estimate = est,
       se = se_val,
-      ci_lower = pmax(0, est - z * se_val),
-      ci_upper = est + z * se_val,
+      ci_lower = ci$lower,
+      ci_upper = ci$upper,
       n = as.integer(n),
       stringsAsFactors = FALSE
     )
@@ -3459,8 +3482,9 @@ compute_stratum_product_sum <- function(
     sp_result <- tibble::as_tibble(agg[interview_by_vars])
     sp_result$estimate <- agg$.est_sh
     sp_result$se <- sqrt(agg$.var_sh)
-    sp_result$ci_lower <- pmax(0, sp_result$estimate - z_per_group * sp_result$se)
-    sp_result$ci_upper <- sp_result$estimate + z_per_group * sp_result$se
+    ci <- .ci(sp_result$estimate, sp_result$se, z_per_group)
+    sp_result$ci_lower <- ci$lower
+    sp_result$ci_upper <- ci$upper
     sp_result$n <- as.integer(agg$.n_sh)
     sp_result
   }

--- a/R/creel-estimates.R
+++ b/R/creel-estimates.R
@@ -3391,11 +3391,12 @@ compute_stratum_product_sum <- function(
     r_se <- rate_df$se
     est <- e_est * r_est
     pv <- (e_est^2 * r_se^2) + (r_est^2 * e_se^2) + (r_se^2 * e_se^2)
+    se_val <- sqrt(pv)
     return(data.frame(
       estimate = est,
-      se = sqrt(pv),
-      ci_lower = est - z * sqrt(pv),
-      ci_upper = est + z * sqrt(pv),
+      se = se_val,
+      ci_lower = pmax(0, est - z * se_val),
+      ci_upper = est + z * se_val,
       n = rate_df$n,
       stringsAsFactors = FALSE
     ))
@@ -3428,26 +3429,38 @@ compute_stratum_product_sum <- function(
     est <- sum(merged$.est_sh)
     pv <- sum(merged$.var_sh)
     n <- sum(merged$.n_sh)
+    se_val <- sqrt(pv)
     data.frame(
       estimate = est,
-      se = sqrt(pv),
-      ci_lower = est - z * sqrt(pv),
-      ci_upper = est + z * sqrt(pv),
+      se = se_val,
+      ci_lower = pmax(0, est - z * se_val),
+      ci_upper = est + z * se_val,
       n = as.integer(n),
       stringsAsFactors = FALSE
     )
   } else {
-    # Sum strata within each interview_by_vars group
+    # Sum strata within each interview_by_vars group; compute per-group df (#94)
     agg <- stats::aggregate(
       cbind(.est_sh, .var_sh, .n_sh) ~ .,
       data = merged[c(interview_by_vars, ".est_sh", ".var_sh", ".n_sh")],
       FUN = sum
     )
+    # Count strata per group for per-group df
+    k_strata <- stats::aggregate(
+      rep(1L, nrow(merged)),
+      by = merged[interview_by_vars],
+      FUN = sum
+    )
+    names(k_strata)[ncol(k_strata)] <- ".k_strata"
+    agg <- merge(agg, k_strata, by = interview_by_vars, sort = FALSE)
+    df_per_group <- pmax(1L, as.integer(agg$.n_sh) - as.integer(agg$.k_strata))
+    z_per_group <- stats::qt(1 - (1 - conf_level) / 2, df = df_per_group)
+
     sp_result <- tibble::as_tibble(agg[interview_by_vars])
     sp_result$estimate <- agg$.est_sh
     sp_result$se <- sqrt(agg$.var_sh)
-    sp_result$ci_lower <- sp_result$estimate - z * sp_result$se
-    sp_result$ci_upper <- sp_result$estimate + z * sp_result$se
+    sp_result$ci_lower <- pmax(0, sp_result$estimate - z_per_group * sp_result$se)
+    sp_result$ci_upper <- sp_result$estimate + z_per_group * sp_result$se
     sp_result$n <- as.integer(agg$.n_sh)
     sp_result
   }

--- a/man/estimate_exploitation_rate.Rd
+++ b/man/estimate_exploitation_rate.Rd
@@ -14,7 +14,8 @@ estimate_exploitation_rate(
   reporting_rate = 1,
   strata = NULL,
   by = NULL,
-  aggregate = TRUE
+  aggregate = TRUE,
+  ci_type = c("symmetric", "logit")
 )
 }
 \arguments{
@@ -53,6 +54,13 @@ Default \code{"stratum"}. Ignored when \code{strata = NULL}.}
 row containing the T-weighted aggregate exploitation rate is appended to
 the per-stratum estimates. Set to \code{FALSE} to suppress it. Ignored
 when \code{strata = NULL}.}
+
+\item{ci_type}{character. Shape of the confidence interval.
+\code{"symmetric"} (default) gives the standard \eqn{\hat u \pm z \cdot
+  SE} interval clamped to \eqn{[0,1]}. \code{"logit"} applies a
+logit-transform so the CI respects the \eqn{[0,1]} constraint without
+clamping: \eqn{\mathrm{expit}(\mathrm{logit}(\hat u) \pm z \cdot
+  SE / (\hat u (1-\hat u)))}.}
 }
 \value{
 A \code{creel_estimates} S3 object with \code{method =

--- a/man/estimate_total_catch.Rd
+++ b/man/estimate_total_catch.Rd
@@ -14,7 +14,9 @@ estimate_total_catch(
   aggregate_sections = TRUE,
   missing_sections = "warn",
   verbose = FALSE,
-  ci_method = c("delta", "bootstrap")
+  ci_method = c("delta", "bootstrap"),
+  product_variance = c("goodman", "first_order"),
+  ci_type = c("symmetric", "log")
 )
 }
 \arguments{
@@ -61,6 +63,18 @@ which estimator path was used. Default FALSE.}
 delta-method CIs. \code{"bootstrap"} additionally returns
 \code{ci_lo_boot}/\code{ci_hi_boot} using survey bootstrap resampling.
 Only applies to bus-route/ice designs.}
+
+\item{product_variance}{character. Variance formula for the product
+\eqn{E \times C}. \code{"goodman"} (default) uses the exact Goodman
+(1960) three-term formula \eqn{E^2 Var(C) + C^2 Var(E) + Var(E)Var(C)}.
+\code{"first_order"} drops the cross-term (classical two-term delta
+method).}
+
+\item{ci_type}{character. Shape of the confidence interval.
+\code{"symmetric"} (default) gives the standard \eqn{\hat\theta \pm z
+  \cdot SE} interval clamped at zero. \code{"log"} applies a
+log-transform so the CI stays positive:
+\eqn{[\hat\theta e^{-z SE/\hat\theta},\; \hat\theta e^{z SE/\hat\theta}]}.}
 }
 \value{
 A creel_estimates S3 object with method = "product-total-catch".
@@ -82,8 +96,8 @@ for independent estimates is approximately:
 
 \deqn{Var(E \times C) \approx E^2 \cdot Var(C) + C^2 \cdot Var(E)}
 
-The function uses survey::svycontrast() to compute variance automatically
-via symbolic differentiation and Taylor series approximation.
+Variance is computed via a stratified delta-method sum in
+\code{compute_stratum_product_sum()}, not via \code{survey::svycontrast()}.
 
 \strong{Sectioned designs:}
 When \code{\link{add_sections}} has been called on the design, each section

--- a/man/estimate_total_harvest.Rd
+++ b/man/estimate_total_harvest.Rd
@@ -12,7 +12,9 @@ estimate_total_harvest(
   target = c("sampled_days", "stratum_total", "period_total"),
   aggregate_sections = TRUE,
   missing_sections = "warn",
-  ci_method = c("delta", "bootstrap")
+  ci_method = c("delta", "bootstrap"),
+  product_variance = c("goodman", "first_order"),
+  ci_type = c("symmetric", "log")
 )
 }
 \arguments{
@@ -53,6 +55,15 @@ raises a hard error.}
 delta-method CIs. \code{"bootstrap"} additionally returns
 \code{ci_lo_boot}/\code{ci_hi_boot} using survey bootstrap resampling.
 Only applies to bus-route/ice designs.}
+
+\item{product_variance}{character. Variance formula for the product
+\eqn{E \times H}. \code{"goodman"} (default) uses the exact Goodman
+(1960) three-term formula. \code{"first_order"} drops the cross-term.}
+
+\item{ci_type}{character. Shape of the confidence interval.
+\code{"symmetric"} (default) gives \eqn{\hat\theta \pm z \cdot SE}
+clamped at zero. \code{"log"} applies a log-transform for a
+strictly positive CI.}
 }
 \value{
 A creel_estimates S3 object with method = "product-total-harvest"
@@ -69,8 +80,8 @@ for independent estimates is approximately:
 
 \deqn{Var(E \times H) \approx E^2 \cdot Var(H) + H^2 \cdot Var(E)}
 
-The function uses survey::svycontrast() to compute variance automatically
-via symbolic differentiation and Taylor series approximation.
+Variance is computed via a stratified delta-method sum in
+\code{compute_stratum_product_sum()}, not via \code{survey::svycontrast()}.
 
 \strong{Sectioned designs:}
 When \code{\link{add_sections}} has been called on the design, each section

--- a/man/estimate_total_release.Rd
+++ b/man/estimate_total_release.Rd
@@ -11,7 +11,9 @@ estimate_total_release(
   conf_level = 0.95,
   target = c("sampled_days", "stratum_total", "period_total"),
   aggregate_sections = TRUE,
-  missing_sections = "warn"
+  missing_sections = "warn",
+  product_variance = c("goodman", "first_order"),
+  ci_type = c("symmetric", "log")
 )
 }
 \arguments{
@@ -45,6 +47,15 @@ that sums the per-section estimates? Default \code{TRUE}. Set to
 absent from either count data or interview data: \code{"warn"} (default)
 inserts an NA row with \code{data_available = FALSE}, \code{"error"}
 raises a hard error.}
+
+\item{product_variance}{character. Variance formula for the product
+\eqn{E \times R}. \code{"goodman"} (default) uses the exact Goodman
+(1960) three-term formula. \code{"first_order"} drops the cross-term.}
+
+\item{ci_type}{character. Shape of the confidence interval.
+\code{"symmetric"} (default) gives \eqn{\hat\theta \pm z \cdot SE}
+clamped at zero. \code{"log"} applies a log-transform for a
+strictly positive CI.}
 }
 \value{
 A creel_estimates S3 object with method = "product-total-release".

--- a/man/generate_progressive_start.Rd
+++ b/man/generate_progressive_start.Rd
@@ -64,13 +64,13 @@ though direction still must be.
 }
 \section{Common scheduling error}{
 
-Drawing the start time from \eqn{U[0, T - \tau]} is \strong{biased} — it makes
+Drawing the start time from \eqn{U[0, T - \tau]} is \strong{biased} -- it makes
 the middle of the survey day over-represented, introducing bias toward
 mid-day effort patterns. Both strategies here avoid this error.
 }
 
 \examples{
-# Discrete strategy: T = 10 h, tau = 2 h → k = 5 valid start times
+# Discrete strategy: T = 10 h, tau = 2 h -> k = 5 valid start times
 generate_progressive_start(
   open_start = "06:00", open_end = "16:00",
   circuit_time = 2, strategy = "discrete", n = 5, seed = 42

--- a/tests/testthat/_snaps/bootstrap-snapshots.md
+++ b/tests/testthat/_snaps/bootstrap-snapshots.md
@@ -26,7 +26,7 @@
       # A tibble: 1 x 6
         parameter estimate    se ci_lower ci_upper     n
         <chr>        <dbl> <dbl>    <dbl>    <dbl> <int>
-      1 N_hat         931.  232.     477.    1385.    10
+      1 N_hat         931.  232.     407.    1455.    10
 
 # SNAP-BOOT-04: estimate_mr_harvest default output is stable
 
@@ -36,5 +36,5 @@
       # A tibble: 1 x 6
         parameter     estimate    se ci_lower ci_upper     n
         <chr>            <dbl> <dbl>    <dbl>    <dbl> <int>
-      1 total_harvest     326.  81.1     167.     485.    NA
+      1 total_harvest     326.  81.1     142.     509.    NA
 

--- a/tests/testthat/test-estimate-total-catch.R
+++ b/tests/testthat/test-estimate-total-catch.R
@@ -492,10 +492,11 @@ test_that("total catch SE matches stratified-sum delta method formula", {
   effort_pooled <- suppressWarnings(estimate_effort(d1)) # nolint: object_usage_linter
   cpue_pooled <- suppressWarnings(suppressMessages(estimate_catch_rate(d1))) # nolint: object_usage_linter
 
-  # Single stratum: stratified-sum delta formula == pooled delta formula
+  # Single stratum: stratified-sum delta formula == pooled delta formula (Goodman cross-term included)
   manual_se <- sqrt(
     (effort_pooled$estimates$estimate^2 * cpue_pooled$estimates$se^2) +
-      (cpue_pooled$estimates$estimate^2 * effort_pooled$estimates$se^2)
+      (cpue_pooled$estimates$estimate^2 * effort_pooled$estimates$se^2) +
+      (cpue_pooled$estimates$se^2 * effort_pooled$estimates$se^2)
   )
   expect_equal(result$estimates$se, manual_se, tolerance = 1e-6)
 })


### PR DESCRIPTION
## Summary

Implements all three tiers of statistical correctness issues filed against the estimation layer.

**Tier 1** (commit `ef61bde`):
- #92 NA-effort filter
- #96 variance cross-term routing fix
- #97 `compare_variance` product-totals path

**Tier 2** (commit `5336d3b`):
- #93 per-group df in `compute_stratum_product_sum`
- #94 `pmax(0, ...)` CI lower clamp
- #95 t-distribution for trip density

**Tier 3** (commit `8d787cf`):
- #98 Goodman (1960) exact product variance — `product_variance = c("goodman", "first_order")` added to `estimate_total_catch/harvest/release`. Default `"goodman"` uses exact three-term formula `E²·Var(r) + r²·Var(E) + Var(E)·Var(r)`; `"first_order"` drops cross-term for backward compat.
- #99 Replace `qnorm` with `qt` throughout all estimators where finite sample size is known: trip density (df=n_int−1), exploitation rate (df=n−1 unstratified, df=n_h−1 per stratum, df=Σn_h−k aggregate), mark-recapture Chapman/LP/Schnabel (df=m−1 or Σm−1), MR harvest.
- #100 Transformed CI bounds — `ci_type = c("symmetric", "log")` for non-negative product totals (log CI: `θ·exp(±z·SE/θ)`); `ci_type = c("symmetric", "logit")` for exploitation rate (logit CI: `expit(logit(u)±z·SE/(u(1−u)))`). All defaults `"symmetric"` for full backward compatibility.

## Test plan

- 3238 tests pass, 0 fail (bootstrap snapshot accepted: MR CIs legitimately widen with t(df=9) vs z for n=10 recaptures)
- `just check` — 0 errors, 0 warnings, 1 pre-existing NOTE (`New submission`)
- New `product_variance` and `ci_type` params documented in all three exported functions; man/ regenerated